### PR TITLE
Show user display name instead of user id

### DIFF
--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -7,6 +7,7 @@ class Spot {
   final GeoPoint location;
   final List<String>? imageUrls;
   final String? createdBy;
+  final String? createdByName;
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final double? rating;
@@ -21,6 +22,7 @@ class Spot {
     required this.location,
     this.imageUrls,
     this.createdBy,
+    this.createdByName,
     this.createdAt,
     this.updatedAt,
     this.rating,
@@ -40,6 +42,7 @@ class Spot {
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl']] : null),
       createdBy: data['createdBy'],
+      createdByName: data['createdByName'],
       createdAt: data['createdAt']?.toDate(),
       updatedAt: data['updatedAt']?.toDate(),
       rating: data['rating']?.toDouble(),
@@ -56,6 +59,7 @@ class Spot {
       'location': location,
       'imageUrls': imageUrls,
       'createdBy': createdBy,
+      'createdByName': createdByName,
       'createdAt': createdAt,
       'updatedAt': updatedAt,
       'rating': rating,
@@ -72,6 +76,7 @@ class Spot {
     GeoPoint? location,
     List<String>? imageUrls,
     String? createdBy,
+    String? createdByName,
     DateTime? createdAt,
     DateTime? updatedAt,
     double? rating,
@@ -86,6 +91,7 @@ class Spot {
       location: location ?? this.location,
       imageUrls: imageUrls ?? this.imageUrls,
       createdBy: createdBy ?? this.createdBy,
+      createdByName: createdByName ?? this.createdByName,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       rating: rating ?? this.rating,

--- a/lib/screens/spots/add_spot_screen.dart
+++ b/lib/screens/spots/add_spot_screen.dart
@@ -373,6 +373,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> {
           : GeoPoint(_currentPosition!.latitude, _currentPosition!.longitude),
         tags: tags.isNotEmpty ? tags : null,
         createdBy: authService.currentUser?.uid,
+        createdByName: authService.userProfile?.displayName ?? authService.currentUser?.email ?? authService.currentUser?.uid,
       );
 
       final success = await spotService.createSpot(

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -479,7 +479,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                     ],
                     
                     // Additional Info
-                    if (widget.spot.createdBy != null || widget.spot.createdAt != null) ...[
+                    if (widget.spot.createdBy != null || widget.spot.createdByName != null || widget.spot.createdAt != null) ...[
                       Text(
                         'Additional Information',
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
@@ -487,11 +487,11 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                         ),
                       ),
                       const SizedBox(height: 8),
-                      if (widget.spot.createdBy != null) ...[
+                      if (widget.spot.createdBy != null || widget.spot.createdByName != null) ...[
                         ListTile(
                           leading: const Icon(Icons.person),
                           title: const Text('Added by'),
-                          subtitle: Text(widget.spot.createdBy!),
+                          subtitle: Text(widget.spot.createdByName ?? widget.spot.createdBy ?? ''),
                           contentPadding: EdgeInsets.zero,
                         ),
                       ],

--- a/lib/widgets/spot_card.dart
+++ b/lib/widgets/spot_card.dart
@@ -161,7 +161,7 @@ class SpotCard extends StatelessWidget {
                   ),
                   
                   // Created by and date
-                  if (spot.createdBy != null) ...[
+                  if (spot.createdBy != null || spot.createdByName != null) ...[
                     const SizedBox(height: 8),
                     Row(
                       children: [
@@ -172,7 +172,7 @@ class SpotCard extends StatelessWidget {
                         ),
                         const SizedBox(width: 4),
                         Text(
-                          'Added by ${spot.createdBy}',
+                          'Added by ${spot.createdByName ?? spot.createdBy}',
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
                           ),


### PR DESCRIPTION
Display the creator's display name instead of their user ID for spots.

This change denormalizes the creator's display name onto the `Spot` model to avoid client-side profile lookups, which are restricted by Firestore rules. Existing spots will continue to show the user ID until updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a5d6977-a6c2-43dc-83e7-9e46bdbcce3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a5d6977-a6c2-43dc-83e7-9e46bdbcce3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

