### PR TITLE
Improve spot card layout on larger screens

### DIFF
--- a/lib/screens/spots/spots_list_screen.dart
+++ b/lib/screens/spots/spots_list_screen.dart
@@ -166,29 +166,57 @@ class _SpotsListScreenState extends State<SpotsListScreen> {
                   );
                 }
 
+                final screenWidth = MediaQuery.of(context).size.width;
+                final useGrid = screenWidth >= 600;
+
                 return RefreshIndicator(
                   onRefresh: () => spotService.fetchSpots(),
-                  child: ListView.builder(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    itemCount: spots.length,
-                    itemBuilder: (context, index) {
-                      final spot = spots[index];
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 12),
-                        child: SpotCard(
-                          spot: spot,
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => SpotDetailScreen(spot: spot),
+                  child: useGrid
+                      ? GridView.builder(
+                          padding: const EdgeInsets.all(16),
+                          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                            maxCrossAxisExtent: 480,
+                            mainAxisExtent: 320,
+                            crossAxisSpacing: 12,
+                            mainAxisSpacing: 12,
+                          ),
+                          itemCount: spots.length,
+                          itemBuilder: (context, index) {
+                            final spot = spots[index];
+                            return SpotCard(
+                              spot: spot,
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => SpotDetailScreen(spot: spot),
+                                  ),
+                                );
+                              },
+                            );
+                          },
+                        )
+                      : ListView.builder(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          itemCount: spots.length,
+                          itemBuilder: (context, index) {
+                            final spot = spots[index];
+                            return Padding(
+                              padding: const EdgeInsets.only(bottom: 12),
+                              child: SpotCard(
+                                spot: spot,
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => SpotDetailScreen(spot: spot),
+                                    ),
+                                  );
+                                },
                               ),
                             );
                           },
                         ),
-                      );
-                    },
-                  ),
                 );
               },
             ),


### PR DESCRIPTION
Reorganize spot cards into a responsive grid on wider screens to prevent them from becoming excessively large.

---
<a href="https://cursor.com/background-agent?bcId=bc-c93c0ac1-9b68-4105-b170-fcb67915ce15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c93c0ac1-9b68-4105-b170-fcb67915ce15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

