### PR TITLE
Disable map interaction when modal is open

### DIFF
--- a/lib/screens/spots/map_screen.dart
+++ b/lib/screens/spots/map_screen.dart
@@ -21,7 +21,8 @@ class _MapScreenState extends State<MapScreen> {
   Position? _currentPosition;
   bool _isGettingLocation = false;
   bool _isSatelliteView = false;
-
+  bool _isSpotSheetOpen = false;
+  
   @override
   void initState() {
     super.initState();
@@ -87,12 +88,21 @@ class _MapScreenState extends State<MapScreen> {
   }
 
   void _showSpotBottomSheet(Spot spot) {
+    setState(() {
+      _isSpotSheetOpen = true;
+    });
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) => _SpotBottomSheet(spot: spot),
-    );
+    ).whenComplete(() {
+      if (mounted) {
+        setState(() {
+          _isSpotSheetOpen = false;
+        });
+      }
+    });
   }
 
   String _formatDate(DateTime date) {
@@ -226,6 +236,10 @@ class _MapScreenState extends State<MapScreen> {
                 myLocationEnabled: true,
                 myLocationButtonEnabled: true,
                 zoomControlsEnabled: false,
+                zoomGesturesEnabled: !_isSpotSheetOpen,
+                scrollGesturesEnabled: !_isSpotSheetOpen,
+                rotateGesturesEnabled: !_isSpotSheetOpen,
+                tiltGesturesEnabled: !_isSpotSheetOpen,
                 liteModeEnabled: kIsWeb,
                 compassEnabled: false,
                 onMapCreated: (GoogleMapController controller) {


### PR DESCRIPTION
Disable map gestures when the spot details bottom sheet is open to prevent unintended map interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-fda9330e-2696-4bee-ac62-0c7955cd2fdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fda9330e-2696-4bee-ac62-0c7955cd2fdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

