### PR TITLE
Implement client-side location search and map navigation

### DIFF
--- a/lib/utils/geocoding_stub.dart
+++ b/lib/utils/geocoding_stub.dart
@@ -1,0 +1,7 @@
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+/// Non-web stub: geocoding is not available here
+Future<LatLng?> geocodePlace(String query) async {
+  return null;
+}
+

--- a/lib/utils/geocoding_web.dart
+++ b/lib/utils/geocoding_web.dart
@@ -1,0 +1,20 @@
+// Web implementation that calls window.geocodePlace defined in web/index.html
+import 'dart:async';
+import 'dart:js_util' as js_util;
+import 'dart:html' as html;
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+Future<LatLng?> geocodePlace(String query) async {
+  try {
+    final dynamic promise = js_util.callMethod(html.window, 'geocodePlace', [query]);
+    final dynamic result = await js_util.promiseToFuture(promise);
+    if (result == null) return null;
+    final num? lat = js_util.getProperty(result, 'lat');
+    final num? lng = js_util.getProperty(result, 'lng');
+    if (lat == null || lng == null) return null;
+    return LatLng(lat.toDouble(), lng.toDouble());
+  } catch (_) {
+    return null;
+  }
+}
+

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,77 @@
   <!-- Google Maps JavaScript API -->
   <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAAhFK9QYxOlbI3ySWTmoFIJKLAl8CL-qo&loading=async"></script>
 
+  <!-- Client-side geocoding helper accessible from Dart (Flutter web) -->
+  <script>
+    (function() {
+      function waitForGoogleMaps() {
+        return new Promise(function(resolve) {
+          if (window.google && window.google.maps && window.google.maps.Geocoder) {
+            resolve();
+            return;
+          }
+          var checkInterval = setInterval(function() {
+            if (window.google && window.google.maps && window.google.maps.Geocoder) {
+              clearInterval(checkInterval);
+              resolve();
+            }
+          }, 50);
+          // Safety timeout after 10s
+          setTimeout(function() {
+            clearInterval(checkInterval);
+            resolve();
+          }, 10000);
+        });
+      }
+
+      // Promise-returning function: geocode a place name to {lat, lng, viewport, formattedAddress}
+      window.geocodePlace = function(query) {
+        return new Promise(function(resolve, reject) {
+          if (!query || typeof query !== 'string' || !query.trim()) {
+            resolve(null);
+            return;
+          }
+          waitForGoogleMaps().then(function() {
+            if (!(window.google && window.google.maps && window.google.maps.Geocoder)) {
+              resolve(null);
+              return;
+            }
+            try {
+              var geocoder = new window.google.maps.Geocoder();
+              geocoder.geocode({ address: query.trim() }, function(results, status) {
+                if (status === 'OK' && results && results.length > 0) {
+                  var r = results[0];
+                  var loc = r.geometry && r.geometry.location ? r.geometry.location : null;
+                  if (!loc) {
+                    resolve(null);
+                    return;
+                  }
+                  var viewport = r.geometry && r.geometry.viewport ? r.geometry.viewport : null;
+                  var formatted = r.formatted_address || query.trim();
+                  resolve({
+                    lat: loc.lat(),
+                    lng: loc.lng(),
+                    viewport: viewport ? {
+                      south: viewport.getSouthWest().lat(),
+                      west: viewport.getSouthWest().lng(),
+                      north: viewport.getNorthEast().lat(),
+                      east: viewport.getNorthEast().lng()
+                    } : null,
+                    formattedAddress: formatted
+                  });
+                } else {
+                  resolve(null);
+                }
+              });
+            } catch (e) {
+              resolve(null);
+            }
+          });
+        });
+      }
+    })();
+  </script>
+
   <script>
     // The value below is injected by flutter build, do not touch.
     const serviceWorkerVersion = '{{flutter_service_worker_version}}';


### PR DESCRIPTION
Enable searching for place names on the Search tab to pan the map using client-side Google Maps geocoding.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5e215dd-5974-46bd-a75b-55158ba4511f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5e215dd-5974-46bd-a75b-55158ba4511f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

