### PR TITLE
Extract and store country and city for share links

### DIFF
--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -6,6 +6,8 @@ class Spot {
   final String description;
   final GeoPoint location;
   final String? address;
+  final String? city;
+  final String? countryCode;
   final List<String>? imageUrls;
   final String? createdBy;
   final String? createdByName;
@@ -21,6 +23,8 @@ class Spot {
     required this.description,
     required this.location,
     this.address,
+    this.city,
+    this.countryCode,
     this.imageUrls,
     this.createdBy,
     this.createdByName,
@@ -39,6 +43,8 @@ class Spot {
       description: data['description'] ?? '',
       location: data['location'] ?? const GeoPoint(0, 0),
       address: data['address'],
+      city: data['city'],
+      countryCode: data['countryCode'],
       imageUrls: data['imageUrls'] != null
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl']] : null),
@@ -58,6 +64,8 @@ class Spot {
       'description': description,
       'location': location,
       'address': address,
+      'city': city,
+      'countryCode': countryCode,
       'imageUrls': imageUrls,
       'createdBy': createdBy,
       'createdByName': createdByName,
@@ -75,6 +83,8 @@ class Spot {
     String? description,
     GeoPoint? location,
     String? address,
+    String? city,
+    String? countryCode,
     List<String>? imageUrls,
     String? createdBy,
     String? createdByName,
@@ -90,6 +100,8 @@ class Spot {
       description: description ?? this.description,
       location: location ?? this.location,
       address: address ?? this.address,
+      city: city ?? this.city,
+      countryCode: countryCode ?? this.countryCode,
       imageUrls: imageUrls ?? this.imageUrls,
       createdBy: createdBy ?? this.createdBy,
       createdByName: createdByName ?? this.createdByName,

--- a/lib/screens/spots/add_spot_screen.dart
+++ b/lib/screens/spots/add_spot_screen.dart
@@ -34,6 +34,8 @@ class _AddSpotScreenState extends State<AddSpotScreen> {
   Position? _currentPosition;
   LatLng? _pickedLocation;
   String? _currentAddress;
+  String? _currentCity;
+  String? _currentCountryCode;
   bool _isLoading = false;
   bool _isGettingLocation = false;
   bool _isGeocoding = false;
@@ -385,11 +387,13 @@ class _AddSpotScreenState extends State<AddSpotScreen> {
 
     try {
       final geocodingService = Provider.of<GeocodingService>(context, listen: false);
-      final address = await geocodingService.geocodeCoordinatesSilently(latitude, longitude);
+      final details = await geocodingService.geocodeCoordinatesDetailsSilently(latitude, longitude);
       
       if (mounted) {
         setState(() {
-          _currentAddress = address;
+          _currentAddress = details['address'];
+          _currentCity = details['city'];
+          _currentCountryCode = details['countryCode'];
         });
       }
     } catch (e) {
@@ -457,6 +461,8 @@ class _AddSpotScreenState extends State<AddSpotScreen> {
           ? GeoPoint(_pickedLocation!.latitude, _pickedLocation!.longitude)
           : GeoPoint(_currentPosition!.latitude, _currentPosition!.longitude),
         address: _currentAddress,
+        city: _currentCity,
+        countryCode: _currentCountryCode,
         tags: tags.isNotEmpty ? tags : null,
         createdBy: authService.currentUser?.uid,
         createdByName: authService.userProfile?.displayName ?? authService.currentUser?.email ?? authService.currentUser?.uid,

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -156,7 +156,12 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                 setState(() {
                   _isShareModalOpen = false;
                 });
-                UrlService.shareSpot(widget.spot.id!, widget.spot.name);
+                UrlService.shareSpot(
+                  widget.spot.id!,
+                  widget.spot.name,
+                  countryCode: widget.spot.countryCode,
+                  city: widget.spot.city,
+                );
               },
             ),
             ListTile(
@@ -167,7 +172,11 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                 setState(() {
                   _isShareModalOpen = false;
                 });
-                await UrlService.copySpotUrl(widget.spot.id!);
+                await UrlService.copySpotUrl(
+                  widget.spot.id!,
+                  countryCode: widget.spot.countryCode,
+                  city: widget.spot.city,
+                );
                 if (mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(
@@ -186,7 +195,11 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                 setState(() {
                   _isShareModalOpen = false;
                 });
-                UrlService.openSpotInBrowser(widget.spot.id!);
+                UrlService.openSpotInBrowser(
+                  widget.spot.id!,
+                  countryCode: widget.spot.countryCode,
+                  city: widget.spot.city,
+                );
               },
             ),
           ],

--- a/lib/services/geocoding_service.dart
+++ b/lib/services/geocoding_service.dart
@@ -62,6 +62,81 @@ class GeocodingService extends ChangeNotifier {
     }
   }
 
+  /// Geocodes coordinates and returns address details including city and country code
+  /// Notifies listeners during the operation
+  Future<Map<String, String?>> geocodeCoordinatesDetails(double latitude, double longitude) async {
+    try {
+      _isLoading = true;
+      _error = null;
+      notifyListeners();
+
+      final callable = _functions.httpsCallable('geocodeCoordinates');
+      final result = await callable.call({
+        'latitude': latitude,
+        'longitude': longitude,
+      });
+
+      if (result.data['success'] == true) {
+        return {
+          'address': result.data['address'] as String?,
+          'city': result.data['city'] as String?,
+          'countryCode': result.data['countryCode'] as String?,
+        };
+      } else {
+        _error = result.data['error'] ?? 'Failed to geocode coordinates';
+        return {
+          'address': null,
+          'city': null,
+          'countryCode': null,
+        };
+      }
+    } catch (e) {
+      _error = 'Failed to geocode coordinates: $e';
+      debugPrint('Error geocoding coordinates details: $e');
+      return {
+        'address': null,
+        'city': null,
+        'countryCode': null,
+      };
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Geocodes coordinates silently and returns address details including city and country code
+  Future<Map<String, String?>> geocodeCoordinatesDetailsSilently(double latitude, double longitude) async {
+    try {
+      final callable = _functions.httpsCallable('geocodeCoordinates');
+      final result = await callable.call({
+        'latitude': latitude,
+        'longitude': longitude,
+      });
+
+      if (result.data['success'] == true) {
+        return {
+          'address': result.data['address'] as String?,
+          'city': result.data['city'] as String?,
+          'countryCode': result.data['countryCode'] as String?,
+        };
+      } else {
+        debugPrint('Geocoding failed: ${result.data['error']}');
+        return {
+          'address': null,
+          'city': null,
+          'countryCode': null,
+        };
+      }
+    } catch (e) {
+      debugPrint('Error geocoding coordinates silently (details): $e');
+      return {
+        'address': null,
+        'city': null,
+        'countryCode': null,
+      };
+    }
+  }
+
   /// Reverse geocodes an address to coordinates
   /// Returns null if reverse geocoding fails
   Future<Map<String, double>?> reverseGeocodeAddress(String address) async {


### PR DESCRIPTION
Store city and 2-letter country code for spots and use them to generate more descriptive share links.

This allows share links to include location context (e.g., `parkour.spot/nl/amsterdam/<spot-id>`) when available, providing more relevant information to users.

---
<a href="https://cursor.com/background-agent?bcId=bc-17ddd37b-4d2f-49be-92b0-e1ce4b7facbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17ddd37b-4d2f-49be-92b0-e1ce4b7facbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

