### PR TITLE
Add admin role and spot source management

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -7,6 +7,7 @@ class User {
   final DateTime? lastLoginAt;
   final List<String>? favoriteSpots;
   final bool isEmailVerified;
+  final bool isAdmin;
 
   User({
     required this.id,
@@ -17,6 +18,7 @@ class User {
     this.lastLoginAt,
     this.favoriteSpots,
     this.isEmailVerified = false,
+    this.isAdmin = false,
   });
 
   factory User.fromMap(Map<String, dynamic> map) {
@@ -31,6 +33,7 @@ class User {
           ? List<String>.from(map['favoriteSpots']) 
           : null,
       isEmailVerified: map['isEmailVerified'] ?? false,
+      isAdmin: map['isAdmin'] ?? false,
     );
   }
 
@@ -44,6 +47,7 @@ class User {
       'lastLoginAt': lastLoginAt,
       'favoriteSpots': favoriteSpots,
       'isEmailVerified': isEmailVerified,
+      'isAdmin': isAdmin,
     };
   }
 
@@ -56,6 +60,7 @@ class User {
     DateTime? lastLoginAt,
     List<String>? favoriteSpots,
     bool? isEmailVerified,
+    bool? isAdmin,
   }) {
     return User(
       id: id ?? this.id,
@@ -66,6 +71,7 @@ class User {
       lastLoginAt: lastLoginAt ?? this.lastLoginAt,
       favoriteSpots: favoriteSpots ?? this.favoriteSpots,
       isEmailVerified: isEmailVerified ?? this.isEmailVerified,
+      isAdmin: isAdmin ?? this.isAdmin,
     );
   }
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import '../screens/splash_screen.dart';
 import '../screens/home_screen.dart';
+import '../screens/admin/admin_home_screen.dart';
+import '../screens/admin/sync_sources_screen.dart';
 import '../screens/spots/spot_detail_screen.dart';
 import '../screens/auth/login_screen.dart';
 import '../models/spot.dart';
@@ -85,6 +87,15 @@ class AppRouter {
       GoRoute(
         path: '/login',
         builder: (context, state) => const LoginScreen(),
+      ),
+      // Admin routes (screen will self-guard on admin status)
+      GoRoute(
+        path: '/admin',
+        builder: (context, state) => const AdminHomeScreen(),
+      ),
+      GoRoute(
+        path: '/admin/sources',
+        builder: (context, state) => const SyncSourcesScreen(),
       ),
       // Simple spot detail route: /spot/:spotId
       GoRoute(

--- a/lib/screens/admin/admin_home_screen.dart
+++ b/lib/screens/admin/admin_home_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import '../../services/auth_service.dart';
+
+class AdminHomeScreen extends StatelessWidget {
+  const AdminHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = context.select<AuthService, bool>((s) => s.isAdmin);
+    if (!isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Admin')),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.lock_outline, size: 64),
+                const SizedBox(height: 12),
+                const Text('Administrator access required'),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: () => context.go('/home?tab=profile'),
+                  child: const Text('Back to Profile'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Admin Tools')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.sync),
+              title: const Text('Sync Sources'),
+              subtitle: const Text('Add, edit, delete, and sync external sources'),
+              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+              onTap: () => context.go('/admin/sources'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/screens/admin/sync_sources_screen.dart
+++ b/lib/screens/admin/sync_sources_screen.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../services/auth_service.dart';
+import '../../services/sync_source_service.dart';
+
+class SyncSourcesScreen extends StatefulWidget {
+  const SyncSourcesScreen({super.key});
+
+  @override
+  State<SyncSourcesScreen> createState() => _SyncSourcesScreenState();
+}
+
+class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final service = context.read<SyncSourceService>();
+    if (service.sources.isEmpty && !service.isLoading) {
+      service.fetchSyncSources(includeInactive: true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = context.select<AuthService, bool>((s) => s.isAdmin);
+    if (!isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Sync Sources')),
+        body: const Center(child: Text('Administrator access required')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sync Sources'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.sync),
+            tooltip: 'Sync All',
+            onPressed: () async {
+              final ok = await context.read<SyncSourceService>().syncAllSources();
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(ok ? 'Sync started' : 'Failed to start sync')),
+                );
+              }
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add Source',
+            onPressed: () => _openEditDialog(context),
+          ),
+        ],
+      ),
+      body: Consumer<SyncSourceService>(
+        builder: (context, service, _) {
+          if (service.isLoading && service.sources.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (service.error != null && service.sources.isEmpty) {
+            return Center(child: Text(service.error!));
+          }
+          final sources = service.sources;
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: sources.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final s = sources[index];
+              return Card(
+                child: ListTile(
+                  title: Text(s.name),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(s.kmzUrl, maxLines: 1, overflow: TextOverflow.ellipsis),
+                      if (s.description != null && s.description!.isNotEmpty)
+                        Text(s.description!),
+                      Row(
+                        children: [
+                          Chip(label: Text(s.isActive ? 'Active' : 'Inactive')),
+                          const SizedBox(width: 8),
+                          Chip(label: Text(s.isPublic ? 'Public' : 'Private')),
+                          if (s.lastSyncAt != null) ...[
+                            const SizedBox(width: 8),
+                            Chip(label: Text('Last sync: ${s.lastSyncAt}')),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                  isThreeLine: true,
+                  trailing: PopupMenuButton<String>(
+                    onSelected: (v) async {
+                      switch (v) {
+                        case 'edit':
+                          _openEditDialog(context, source: s);
+                          break;
+                        case 'toggleActive':
+                          await context.read<SyncSourceService>().updateSource(
+                            sourceId: s.id,
+                            isActive: !s.isActive,
+                          );
+                          break;
+                        case 'delete':
+                          final confirmed = await showDialog<bool>(
+                            context: context,
+                            builder: (c) => AlertDialog(
+                              title: const Text('Delete Source'),
+                              content: Text('Delete \'${s.name}\'?'),
+                              actions: [
+                                TextButton(onPressed: () => Navigator.pop(c, false), child: const Text('Cancel')),
+                                TextButton(onPressed: () => Navigator.pop(c, true), child: const Text('Delete')),
+                              ],
+                            ),
+                          );
+                          if (confirmed == true) {
+                            await context.read<SyncSourceService>().deleteSource(s.id);
+                          }
+                          break;
+                      }
+                    },
+                    itemBuilder: (c) => [
+                      const PopupMenuItem(value: 'edit', child: Text('Edit')),
+                      PopupMenuItem(value: 'toggleActive', child: Text(s.isActive ? 'Deactivate' : 'Activate')),
+                      const PopupMenuItem(value: 'delete', child: Text('Delete')),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openEditDialog(BuildContext context, {SyncSource? source}) async {
+    final formKey = GlobalKey<FormState>();
+    final nameCtrl = TextEditingController(text: source?.name ?? '');
+    final urlCtrl = TextEditingController(text: source?.kmzUrl ?? '');
+    final descCtrl = TextEditingController(text: source?.description ?? '');
+    bool isPublic = source?.isPublic ?? true;
+    bool isActive = source?.isActive ?? true;
+
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (c) => AlertDialog(
+        title: Text(source == null ? 'Add Source' : 'Edit Source'),
+        content: SingleChildScrollView(
+          child: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: nameCtrl,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                  validator: (v) => (v == null || v.trim().isEmpty) ? 'Required' : null,
+                ),
+                TextFormField(
+                  controller: urlCtrl,
+                  decoration: const InputDecoration(labelText: 'KMZ URL'),
+                  validator: (v) => (v == null || v.trim().isEmpty) ? 'Required' : null,
+                ),
+                TextFormField(
+                  controller: descCtrl,
+                  decoration: const InputDecoration(labelText: 'Description (optional)'),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: SwitchListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: const Text('Public'),
+                        value: isPublic,
+                        onChanged: (v) => setState(() => isPublic = v),
+                      ),
+                    ),
+                    Expanded(
+                      child: SwitchListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: const Text('Active'),
+                        value: isActive,
+                        onChanged: (v) => setState(() => isActive = v),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(c, false), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () async {
+              if (!formKey.currentState!.validate()) return;
+              final service = context.read<SyncSourceService>();
+              bool ok;
+              if (source == null) {
+                ok = await service.createSource(
+                  name: nameCtrl.text.trim(),
+                  kmzUrl: urlCtrl.text.trim(),
+                  description: descCtrl.text.trim().isEmpty ? null : descCtrl.text.trim(),
+                  isPublic: isPublic,
+                  isActive: isActive,
+                );
+              } else {
+                ok = await service.updateSource(
+                  sourceId: source.id,
+                  name: nameCtrl.text.trim(),
+                  kmzUrl: urlCtrl.text.trim(),
+                  description: descCtrl.text.trim(),
+                  isPublic: isPublic,
+                  isActive: isActive,
+                );
+              }
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(ok ? 'Saved' : 'Failed to save')),
+                );
+              }
+              Navigator.pop(c, ok);
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+
+    if (saved == true) {
+      await context.read<SyncSourceService>().fetchSyncSources(includeInactive: true);
+    }
+  }
+}
+

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -246,6 +246,38 @@ class ProfileScreen extends StatelessWidget {
           ),
           
           const SizedBox(height: 16),
+
+          if (authService.isAdmin) ...[
+            // Administrator Section
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Administrator',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    _buildActionTile(
+                      context,
+                      Icons.admin_panel_settings,
+                      'Admin Tools',
+                      'Manage sources and administrative tasks',
+                      () {
+                        context.go('/admin');
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+          ],
           
           // App Info
           Card(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -8,6 +8,7 @@ class AuthService extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   
   User? get currentUser => _auth.currentUser;
+  bool get isAdmin => _userProfile?.isAdmin == true;
   bool get isAuthenticated {
     final user = _auth.currentUser;
     if (user == null) return false;
@@ -62,6 +63,7 @@ class AuthService extends ChangeNotifier {
           photoURL: _auth.currentUser?.photoURL,
           createdAt: DateTime.now(),
           lastLoginAt: DateTime.now(),
+          isAdmin: false,
         );
         await _firestore.collection('users').doc(uid).set(_userProfile!.toMap());
         debugPrint('New user profile created in Firestore');
@@ -131,6 +133,7 @@ class AuthService extends ChangeNotifier {
           displayName: displayName,
           createdAt: DateTime.now(),
           lastLoginAt: DateTime.now(),
+          isAdmin: false,
         );
         
         await _firestore.collection('users').doc(user.id).set(user.toMap());


### PR DESCRIPTION
Adds administrator role with a dedicated admin section and a CRUD interface for managing sync sources.

This PR introduces an `isAdmin` flag for users, secures backend functions for sync source management, and provides a UI for administrators to add, edit, delete, and sync external spot data sources. This enables granular control over application data and features for designated users.

---
<a href="https://cursor.com/background-agent?bcId=bc-319a4e9e-012d-40bf-bc07-fe7483de8ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-319a4e9e-012d-40bf-bc07-fe7483de8ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

