### PR TITLE
Add location search with autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ GOOGLE_MAPS_API_KEY_ANDROID=your_android_maps_key_here
 GOOGLE_MAPS_API_KEY_IOS=your_ios_maps_key_here
 ```
 
+### Backend Google Maps API key
+
+The autocomplete and geocoding features use a server-side Google Maps API key via Firebase Functions secrets. Make sure to set the secret in your Firebase project:
+
+```bash
+firebase functions:secrets:set GOOGLE_MAPS_API_KEY
+```
+
+This key should have at least the following APIs enabled:
+
+- Places API
+- Geocoding API
+
+The Flutter client calls callable functions `placesAutocomplete`, `placeDetails`, `geocodeCoordinates`, and `reverseGeocodeAddress`, which proxy Google APIs securely using the backend key.
+
 ### 4. **Run the App**
 ```bash
 # Web

--- a/functions/test-places.js
+++ b/functions/test-places.js
@@ -1,0 +1,32 @@
+const https = require('https');
+
+// Simple manual test: calls Google Places Autocomplete using a provided key.
+// Usage: node test-places.js "amsterdam" YOUR_KEY
+const [,, input, key] = process.argv;
+if (!input || !key) {
+  console.log('Usage: node test-places.js "query" GOOGLE_API_KEY');
+  process.exit(1);
+}
+
+const params = new URLSearchParams();
+params.append('input', input);
+params.append('key', key);
+params.append('types', 'geocode');
+
+const url = `https://maps.googleapis.com/maps/api/place/autocomplete/json?${params.toString()}`;
+
+https.get(url, (res) => {
+  let data = '';
+  res.on('data', (chunk) => data += chunk);
+  res.on('end', () => {
+    try {
+      const json = JSON.parse(data);
+      console.log(JSON.stringify(json, null, 2));
+    } catch (e) {
+      console.error('Failed to parse response', e);
+    }
+  });
+}).on('error', (err) => {
+  console.error('HTTP error', err);
+});
+


### PR DESCRIPTION
Add location search with autocomplete to the search bar to allow users to find and center the map on specific addresses, cities, or countries using the Google Places API.

---
<a href="https://cursor.com/background-agent?bcId=bc-54207836-7010-46a9-9dc4-f0065923afc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54207836-7010-46a9-9dc4-f0065923afc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

