### PR TITLE
Show external source directly in spot labels

### DIFF
--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -1405,7 +1405,9 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
                                                 ),
                                                 const SizedBox(width: 3),
                                                 Text(
-                                                  'External',
+                                                  Provider.of<SyncSourceService>(context, listen: false)
+                                                          .getSourceNameSync(_selectedSpot!.spotSource!) ??
+                                                      _selectedSpot!.spotSource!,
                                                   style: TextStyle(
                                                     color: Colors.white,
                                                     fontSize: 10,

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -329,7 +329,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                           ),
                           const SizedBox(width: 4),
                           Text(
-                            'External',
+                            Provider.of<SyncSourceService>(context, listen: false)
+                                    .getSourceNameSync(widget.spot.spotSource!) ??
+                                widget.spot.spotSource!,
                             style: TextStyle(
                               color: Colors.white,
                               fontSize: 12,

--- a/lib/widgets/spot_card.dart
+++ b/lib/widgets/spot_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:provider/provider.dart';
+import '../services/sync_source_service.dart';
 import '../models/spot.dart';
 
 class SpotCard extends StatefulWidget {
@@ -322,7 +324,9 @@ class _SpotCardState extends State<SpotCard> {
                       ),
                       const SizedBox(width: 3),
                       Text(
-                        'External',
+                        Provider.of<SyncSourceService>(context, listen: false)
+                                .getSourceNameSync(widget.spot.spotSource!) ??
+                            widget.spot.spotSource!,
                         style: TextStyle(
                           color: Colors.white,
                           fontSize: 10,


### PR DESCRIPTION
Replace 'External' labels with specific external source names on the Search page and spot detail page.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f2cdb5a-4058-4e9c-a944-3e0cfe04ad96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f2cdb5a-4058-4e9c-a944-3e0cfe04ad96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

