### PR TITLE
Configure KML folder import and recording

### DIFF
--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -10,6 +10,7 @@ class Spot {
   final String? city;
   final String? countryCode;
   final List<String>? imageUrls;
+  final String? folderName;
   final String? createdBy;
   final String? createdByName;
   final DateTime? createdAt;
@@ -31,6 +32,7 @@ class Spot {
     this.city,
     this.countryCode,
     this.imageUrls,
+    this.folderName,
     this.createdBy,
     this.createdByName,
     this.createdAt,
@@ -57,6 +59,7 @@ class Spot {
       imageUrls: data['imageUrls'] != null
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl']] : null),
+      folderName: data['folderName'],
       createdBy: data['createdBy'],
       createdByName: data['createdByName'],
       createdAt: data['createdAt']?.toDate(),
@@ -80,6 +83,7 @@ class Spot {
       'city': city,
       'countryCode': countryCode,
       'imageUrls': imageUrls,
+      'folderName': folderName,
       'createdBy': createdBy,
       'createdByName': createdByName,
       'createdAt': createdAt,
@@ -103,6 +107,7 @@ class Spot {
     String? city,
     String? countryCode,
     List<String>? imageUrls,
+    String? folderName,
     String? createdBy,
     String? createdByName,
     DateTime? createdAt,
@@ -124,6 +129,7 @@ class Spot {
       city: city ?? this.city,
       countryCode: countryCode ?? this.countryCode,
       imageUrls: imageUrls ?? this.imageUrls,
+      folderName: folderName ?? this.folderName,
       createdBy: createdBy ?? this.createdBy,
       createdByName: createdByName ?? this.createdByName,
       createdAt: createdAt ?? this.createdAt,

--- a/lib/screens/admin/sync_sources_screen.dart
+++ b/lib/screens/admin/sync_sources_screen.dart
@@ -257,8 +257,14 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
     final urlCtrl = TextEditingController(text: source?.kmzUrl ?? '');
     final descCtrl = TextEditingController(text: source?.description ?? '');
     final publicUrlCtrl = TextEditingController(text: source?.publicUrl ?? '');
+    final includeFoldersCtrl = TextEditingController(
+      text: (source?.includeFolders == null || source!.includeFolders!.isEmpty)
+          ? ''
+          : source.includeFolders!.join(', '),
+    );
     bool isPublic = source?.isPublic ?? true;
     bool isActive = source?.isActive ?? true;
+    bool recordFolderName = source?.recordFolderName ?? false;
 
     final saved = await showDialog<bool>(
       context: context,
@@ -291,6 +297,14 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
                   keyboardType: TextInputType.url,
                 ),
                 const SizedBox(height: 8),
+                TextFormField(
+                  controller: includeFoldersCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Include Folders (optional)',
+                    helperText: 'Comma-separated list of folder names to include when importing',
+                  ),
+                ),
+                const SizedBox(height: 8),
                 Row(
                   children: [
                     Expanded(
@@ -311,6 +325,13 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
                     ),
                   ],
                 ),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Record Folder Name on Spots'),
+                  subtitle: const Text('If enabled, store the KML folder name on each imported spot'),
+                  value: recordFolderName,
+                  onChanged: (v) => setState(() => recordFolderName = v),
+                ),
               ],
             ),
           ),
@@ -330,6 +351,14 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
                   publicUrl: publicUrlCtrl.text.trim().isEmpty ? null : publicUrlCtrl.text.trim(),
                   isPublic: isPublic,
                   isActive: isActive,
+                  includeFolders: includeFoldersCtrl.text.trim().isEmpty
+                      ? null
+                      : includeFoldersCtrl.text
+                          .split(',')
+                          .map((s) => s.trim())
+                          .where((s) => s.isNotEmpty)
+                          .toList(),
+                  recordFolderName: recordFolderName,
                 );
               } else {
                 ok = await service.updateSource(
@@ -340,6 +369,14 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
                   publicUrl: publicUrlCtrl.text.trim(),
                   isPublic: isPublic,
                   isActive: isActive,
+                  includeFolders: includeFoldersCtrl.text.trim().isEmpty
+                      ? <String>[]
+                      : includeFoldersCtrl.text
+                          .split(',')
+                          .map((s) => s.trim())
+                          .where((s) => s.isNotEmpty)
+                          .toList(),
+                  recordFolderName: recordFolderName,
                 );
               }
               if (context.mounted) {

--- a/lib/services/sync_source_service.dart
+++ b/lib/services/sync_source_service.dart
@@ -10,6 +10,8 @@ class SyncSource {
   final String? publicUrl;
   final bool isPublic;
   final bool isActive;
+  final List<String>? includeFolders; // Optional list of folders to include
+  final bool? recordFolderName; // Whether to store folder name on spots
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final DateTime? lastSyncAt;
@@ -23,6 +25,8 @@ class SyncSource {
     this.publicUrl,
     required this.isPublic,
     required this.isActive,
+    this.includeFolders,
+    this.recordFolderName,
     this.createdAt,
     this.updatedAt,
     this.lastSyncAt,
@@ -38,6 +42,10 @@ class SyncSource {
       publicUrl: data['publicUrl'],
       isPublic: data['isPublic'] ?? true,
       isActive: data['isActive'] ?? true,
+      includeFolders: data['includeFolders'] != null
+          ? List<String>.from((data['includeFolders'] as List).map((e) => e.toString()))
+          : null,
+      recordFolderName: data['recordFolderName'] is bool ? data['recordFolderName'] as bool : null,
       createdAt: _parseTimestamp(data['createdAt']),
       updatedAt: _parseTimestamp(data['updatedAt']),
       lastSyncAt: _parseTimestamp(data['lastSyncAt']),
@@ -125,6 +133,8 @@ class SyncSourceService extends ChangeNotifier {
     String? publicUrl,
     bool isPublic = true,
     bool isActive = true,
+    List<String>? includeFolders,
+    bool? recordFolderName,
   }) async {
     try {
       final callable = _functions.httpsCallable('createSyncSource');
@@ -135,6 +145,8 @@ class SyncSourceService extends ChangeNotifier {
         'publicUrl': publicUrl,
         'isPublic': isPublic,
         'isActive': isActive,
+        if (includeFolders != null) 'includeFolders': includeFolders,
+        if (recordFolderName != null) 'recordFolderName': recordFolderName,
       });
       final success = result.data['success'] == true;
       if (success) {
@@ -157,6 +169,8 @@ class SyncSourceService extends ChangeNotifier {
     String? publicUrl,
     bool? isPublic,
     bool? isActive,
+    List<String>? includeFolders,
+    bool? recordFolderName,
   }) async {
     try {
       final callable = _functions.httpsCallable('updateSyncSource');
@@ -167,6 +181,8 @@ class SyncSourceService extends ChangeNotifier {
       if (publicUrl != null) payload['publicUrl'] = publicUrl;
       if (isPublic != null) payload['isPublic'] = isPublic;
       if (isActive != null) payload['isActive'] = isActive;
+      if (includeFolders != null) payload['includeFolders'] = includeFolders;
+      if (recordFolderName != null) payload['recordFolderName'] = recordFolderName;
       final result = await callable.call(payload);
       final success = result.data['success'] == true;
       if (success) {


### PR DESCRIPTION
Add KML folder filtering and optional folder name recording to spot sources for more granular import control.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6c6eff5-1c74-41a5-bf9a-c9037045a6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6c6eff5-1c74-41a5-bf9a-c9037045a6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

