### PR TITLE
Align search bar with map edges

### DIFF
--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -982,7 +982,7 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
 
               // Top Search Bar
               Positioned(
-                top: MediaQuery.of(context).padding.top + 8,
+                top: MediaQuery.of(context).padding.top + 16,
                 left: 16,
                 right: 16,
                 child: Container(


### PR DESCRIPTION
Adjust search bar top offset to match side margins for consistent spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b46fc6d5-ddc2-482c-b347-0481ac7d3ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b46fc6d5-ddc2-482c-b347-0481ac7d3ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

