### PR TITLE
Update spot deletion and moderator permissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,28 +1,33 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Spots collection - users can read public spots, authenticated users can create, owners can edit/delete, admins can read/delete any spot
+    // Spots collection - users can read public spots, authenticated users can create, only admins/moderators can edit/delete any spot
     match /spots/{spotId} {
       allow read: if resource.data.isPublic == true || 
         (request.auth != null && 
          exists(/databases/$(database)/documents/users/$(request.auth.uid)) && 
-         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true);
+         (get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true ||
+          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true));
       allow create: if request.auth != null;
-      allow update: if request.auth != null && (
-        request.auth.uid == resource.data.createdBy ||
-        exists(/databases/$(database)/documents/users/$(request.auth.uid)) && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true
-      );
-      allow delete: if request.auth != null && (
-        request.auth.uid == resource.data.createdBy || 
-        exists(/databases/$(database)/documents/users/$(request.auth.uid)) && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true
-      );
+      allow update: if request.auth != null && exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+        (get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true ||
+         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true);
+      allow delete: if request.auth != null && exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+        (get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true ||
+         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true);
     }
     
     // Users collection - users can only manage their own profile
     match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read: if request.auth != null && request.auth.uid == userId;
+      // Allow create only for self and forbid setting privileged flags
+      allow create: if request.auth != null && request.auth.uid == userId &&
+        request.resource.data.isAdmin == false &&
+        request.resource.data.isModerator == false;
+      // Allow update for self but prevent privilege escalation on admin/moderator flags
+      allow update: if request.auth != null && request.auth.uid == userId &&
+        request.resource.data.isAdmin == resource.data.isAdmin &&
+        request.resource.data.isModerator == resource.data.isModerator;
     }
     
     // Ratings collection - users can read all ratings, authenticated users can create their own

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -8,6 +8,7 @@ class User {
   final List<String>? favoriteSpots;
   final bool isEmailVerified;
   final bool isAdmin;
+  final bool isModerator;
 
   User({
     required this.id,
@@ -19,6 +20,7 @@ class User {
     this.favoriteSpots,
     this.isEmailVerified = false,
     this.isAdmin = false,
+    this.isModerator = false,
   });
 
   factory User.fromMap(Map<String, dynamic> map) {
@@ -34,6 +36,7 @@ class User {
           : null,
       isEmailVerified: map['isEmailVerified'] ?? false,
       isAdmin: map['isAdmin'] ?? false,
+      isModerator: map['isModerator'] ?? false,
     );
   }
 
@@ -48,6 +51,7 @@ class User {
       'favoriteSpots': favoriteSpots,
       'isEmailVerified': isEmailVerified,
       'isAdmin': isAdmin,
+      'isModerator': isModerator,
     };
   }
 
@@ -61,6 +65,7 @@ class User {
     List<String>? favoriteSpots,
     bool? isEmailVerified,
     bool? isAdmin,
+    bool? isModerator,
   }) {
     return User(
       id: id ?? this.id,
@@ -72,6 +77,7 @@ class User {
       favoriteSpots: favoriteSpots ?? this.favoriteSpots,
       isEmailVerified: isEmailVerified ?? this.isEmailVerified,
       isAdmin: isAdmin ?? this.isAdmin,
+      isModerator: isModerator ?? this.isModerator,
     );
   }
 

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -356,7 +356,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                   ),
                   const SizedBox(width: 8),
                 ],
-                // Edit and Delete buttons - only show after auth state is restored
+                // Moderation actions - only show after auth state is restored
                 Consumer<AuthService>(
                   builder: (context, authService, child) {
                     // Wait for auth state to be restored before checking ownership
@@ -380,10 +380,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                       );
                     }
                     
-                    // Check if current user owns this spot
-                    if (authService.isAuthenticated && 
-                        authService.userProfile != null &&
-                        widget.spot.createdBy == authService.userProfile!.id) {
+                    // Show delete for admins or moderators only
+                    if (authService.isAuthenticated && authService.userProfile != null &&
+                        (authService.isAdmin || authService.isModerator)) {
                       return Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -9,6 +9,7 @@ class AuthService extends ChangeNotifier {
   
   User? get currentUser => _auth.currentUser;
   bool get isAdmin => _userProfile?.isAdmin == true;
+  bool get isModerator => _userProfile?.isModerator == true;
   bool get isAuthenticated {
     final user = _auth.currentUser;
     if (user == null) return false;
@@ -59,6 +60,7 @@ class AuthService extends ChangeNotifier {
           createdAt: DateTime.now(),
           lastLoginAt: DateTime.now(),
           isAdmin: false,
+          isModerator: false,
         );
         await _firestore.collection('users').doc(uid).set(_userProfile!.toMap());
       }


### PR DESCRIPTION
Introduce a moderator role and restrict spot editing/deletion to only admins and moderators, removing self-deletion for regular users.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b2722d8-79e1-49f5-a52f-97e4a996f3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b2722d8-79e1-49f5-a52f-97e4a996f3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

