### PR TITLE
Extend map beyond status bar on mobile

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,12 +17,14 @@
   <base href="$FLUTTER_BASE_HREF">
 
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Discover and share parkour spots around the world">
 
   <!-- iOS meta tags & icons -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Parkour.Spot">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 


### PR DESCRIPTION
Add `viewport-fit=cover` and Apple PWA meta tags to extend the map under the status bar on mobile web.

This change allows the map on the Search screen to render edge-to-edge on iOS Progressive Web Apps (PWAs), matching the behavior of native applications like Google Maps.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f9ee63a-d2d4-4abd-88e5-b363bb09b818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f9ee63a-d2d4-4abd-88e5-b363bb09b818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

