### PR TITLE
Add youtube videos to spot model and page

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   # Deep Linking & Navigation
   url_launcher: ^6.3.1
   go_router: ^14.2.7
+  youtube_player_iframe: ^5.1.3
   
   # Web
   web: ^1.1.0


### PR DESCRIPTION
Add YouTube video storage to the Spot model and display embedded videos on the spot detail page.

---
<a href="https://cursor.com/background-agent?bcId=bc-50f78764-0679-4b31-b91a-e0f278c61d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50f78764-0679-4b31-b91a-e0f278c61d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

