### PR TITLE
Prevent map clicks through overlays

### DIFF
--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -1129,20 +1129,22 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
                 Positioned(
                   top: MediaQuery.of(context).padding.top + 80,
                   right: 16,
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
-                          const SizedBox(width: 8),
-                          const Text('Finding location...'),
-                        ],
+                  child: PointerInterceptor(
+                    child: Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                            const SizedBox(width: 8),
+                            const Text('Finding location...'),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -1552,24 +1554,26 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
                 Positioned(
                   right: 16,
                   bottom: MediaQuery.of(context).size.height * 0.09 + 144, // Position above map/satellite button
-                  child: FloatingActionButton(
-                    onPressed: _isLoadingSpotsForView ? null : () {
-                      _loadSpotsForCurrentView();
-                    },
-                    mini: true,
-                    tooltip: 'Refresh spots in current view',
-                    child: _isLoadingSpotsForView
-                        ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  child: PointerInterceptor(
+                    child: FloatingActionButton(
+                      onPressed: _isLoadingSpotsForView ? null : () {
+                        _loadSpotsForCurrentView();
+                      },
+                      mini: true,
+                      tooltip: 'Refresh spots in current view',
+                      child: _isLoadingSpotsForView
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                              ),
+                            )
+                          : const ReliableIcon(
+                              icon: Icons.refresh,
                             ),
-                          )
-                        : const ReliableIcon(
-                            icon: Icons.refresh,
-                          ),
+                    ),
                   ),
                 ),
 
@@ -1578,18 +1582,20 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
                 Positioned(
                   right: 16,
                   bottom: MediaQuery.of(context).size.height * 0.09 + 80, // Position above location button
-                  child: FloatingActionButton(
-                    onPressed: () {
-                      setState(() {
-                        _isSatelliteView = !_isSatelliteView;
-                      });
-                      final searchState = Provider.of<SearchStateService>(context, listen: false);
-                      searchState.setSatellite(_isSatelliteView);
-                    },
-                    mini: true,
-                    tooltip: _isSatelliteView ? 'Switch to Map' : 'Switch to Satellite',
-                    child: ReliableIcon(
-                      icon: _isSatelliteView ? Icons.map : Icons.terrain,
+                  child: PointerInterceptor(
+                    child: FloatingActionButton(
+                      onPressed: () {
+                        setState(() {
+                          _isSatelliteView = !_isSatelliteView;
+                        });
+                        final searchState = Provider.of<SearchStateService>(context, listen: false);
+                        searchState.setSatellite(_isSatelliteView);
+                      },
+                      mini: true,
+                      tooltip: _isSatelliteView ? 'Switch to Map' : 'Switch to Satellite',
+                      child: ReliableIcon(
+                        icon: _isSatelliteView ? Icons.map : Icons.terrain,
+                      ),
                     ),
                   ),
                 ),
@@ -1599,20 +1605,22 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
                 Positioned(
                   right: 16,
                   bottom: MediaQuery.of(context).size.height * 0.09 + 16, // Position above bottom sheet
-                  child: FloatingActionButton(
-                    onPressed: _getCurrentLocation,
-                    mini: true,
-                    tooltip: 'Center on my location',
-                    child: _isGettingLocation
-                        ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                            ),
-                          )
-                        : const Icon(Icons.my_location),
+                  child: PointerInterceptor(
+                    child: FloatingActionButton(
+                      onPressed: _getCurrentLocation,
+                      mini: true,
+                      tooltip: 'Center on my location',
+                      child: _isGettingLocation
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                              ),
+                            )
+                          : const Icon(Icons.my_location),
+                    ),
                   ),
                 ),
             ],
@@ -1635,7 +1643,9 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
           _showFiltersDialog = false;
         });
       },
-      child: Container(
+      child: PointerInterceptor(
+        // Intercept pointer events on the full-screen barrier area
+        child: Container(
         color: Colors.black.withValues(alpha: 0.5), // Semi-transparent background
         child: Center(
           child: PointerInterceptor(
@@ -1714,6 +1724,7 @@ class _SearchScreenState extends State<SearchScreen> with TickerProviderStateMix
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -811,11 +811,13 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                 ),
                                 if (!_isShareModalOpen)
                                   Positioned.fill(
-                                    child: Material(
-                                      color: Colors.transparent,
-                                      child: InkWell(
-                                        onTap: () => _openInMaps(),
-                                        borderRadius: BorderRadius.circular(12),
+                                    child: PointerInterceptor(
+                                      child: Material(
+                                        color: Colors.transparent,
+                                        child: InkWell(
+                                          onTap: () => _openInMaps(),
+                                          borderRadius: BorderRadius.circular(12),
+                                        ),
                                       ),
                                     ),
                                   ),
@@ -823,32 +825,34 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                   Positioned(
                                     bottom: 8,
                                     right: 8,
-                                    child: Container(
-                                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-                                      decoration: BoxDecoration(
-                                        color: Colors.black.withValues(alpha: 0.7),
-                                        borderRadius: BorderRadius.circular(12),
-                                      ),
-                                      child: Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          Icon(
-                                            MobileDetectionService.isMobileDevice 
-                                              ? Icons.phone_android 
-                                              : Icons.touch_app,
-                                            color: Colors.white,
-                                            size: 14,
-                                          ),
-                                          const SizedBox(width: 4),
-                                          Text(
-                                            'Tap to open map',
-                                            style: const TextStyle(
+                                    child: PointerInterceptor(
+                                      child: Container(
+                                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                                        decoration: BoxDecoration(
+                                          color: Colors.black.withValues(alpha: 0.7),
+                                          borderRadius: BorderRadius.circular(12),
+                                        ),
+                                        child: Row(
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: [
+                                            Icon(
+                                              MobileDetectionService.isMobileDevice 
+                                                ? Icons.phone_android 
+                                                : Icons.touch_app,
                                               color: Colors.white,
-                                              fontSize: 11,
-                                              fontWeight: FontWeight.w500,
+                                              size: 14,
                                             ),
-                                          ),
-                                        ],
+                                            const SizedBox(width: 4),
+                                            Text(
+                                              'Tap to open map',
+                                              style: const TextStyle(
+                                                color: Colors.white,
+                                                fontSize: 11,
+                                                fontWeight: FontWeight.w500,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
                                       ),
                                     ),
                                   ),

--- a/lib/widgets/source_details_dialog.dart
+++ b/lib/widgets/source_details_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../services/sync_source_service.dart';
 
@@ -16,7 +17,8 @@ class SourceDetailsDialog extends StatelessWidget {
     // Get spot count from lastSyncStats.total
     final spotCount = source.lastSyncStats?['total'] ?? 0;
     
-    return AlertDialog(
+    return PointerInterceptor(
+      child: AlertDialog(
       title: Text(source.name),
       content: SingleChildScrollView(
         child: Column(
@@ -151,6 +153,7 @@ class SourceDetailsDialog extends StatelessWidget {
           child: const Text('Close'),
         ),
       ],
+    ),
     );
   }
 


### PR DESCRIPTION
Integrate `PointerInterceptor` across several overlays to prevent unintended Google Maps interactions on web.

On web, Google Maps uses `HtmlElementView`, which renders below Flutter widgets. Without `PointerInterceptor`, clicks on Flutter overlays can bleed through to the map below, causing unwanted map shifts or marker interactions. This PR wraps key overlays to ensure they correctly capture pointer events.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f44e375-cf03-40ff-91bf-da96e4713fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f44e375-cf03-40ff-91bf-da96e4713fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

