### PR TITLE
Import openstreetmap geojson data

### DIFF
--- a/lib/screens/admin/sync_sources_screen.dart
+++ b/lib/screens/admin/sync_sources_screen.dart
@@ -993,7 +993,10 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
               ),
               TextFormField(
                 controller: urlCtrl,
-                decoration: const InputDecoration(labelText: 'KMZ URL'),
+                decoration: const InputDecoration(
+                  labelText: 'Source URL (KMZ/KML/GeoJSON)',
+                  helperText: 'Paste Google My Maps KMZ/KML or OpenStreetMap uMap GeoJSON URL',
+                ),
                 validator: (v) => (v == null || v.trim().isEmpty) ? 'Required' : null,
               ),
               TextFormField(
@@ -1044,8 +1047,8 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
               ),
               SwitchListTile(
                 contentPadding: EdgeInsets.zero,
-                title: const Text('Record Folder Name on Spots'),
-                subtitle: const Text('If enabled, store the KML folder name on each imported spot'),
+                title: const Text('Record Folder/Layer on Spots'),
+                subtitle: const Text('If enabled, store the KML folder name or uMap layer on each imported spot'),
                 value: recordFolderName,
                 onChanged: (v) => setState(() => recordFolderName = v),
               ),


### PR DESCRIPTION
Add GeoJSON import support to allow importing spots from OpenStreetMap uMap files.

---
<a href="https://cursor.com/background-agent?bcId=bc-78550df8-a904-48c7-916e-cbae36dd0135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78550df8-a904-48c7-916e-cbae36dd0135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

