### PR TITLE
Standardize duplicate spot representation

### DIFF
--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -28,6 +28,8 @@ class Spot {
   final List<String>? goodFor;
   final String? duplicateOf; // ID of the original spot if this is a duplicate
 
+  static const Object _unset = Object();
+
   Spot({
     this.id,
     required this.name,
@@ -254,7 +256,7 @@ class Spot {
       if (spotFeatures != null) 'spotFeatures': spotFeatures,
       if (spotFacilities != null) 'spotFacilities': spotFacilities,
       if (goodFor != null) 'goodFor': goodFor,
-      if (duplicateOf != null) 'duplicateOf': duplicateOf,
+      'duplicateOf': duplicateOf,
     };
   }
 
@@ -284,7 +286,7 @@ class Spot {
     List<String>? spotFeatures,
     Map<String, String>? spotFacilities,
     List<String>? goodFor,
-    String? duplicateOf,
+    Object? duplicateOf = _unset,
   }) {
     return Spot(
       id: id ?? this.id,
@@ -312,7 +314,7 @@ class Spot {
       spotFeatures: spotFeatures ?? this.spotFeatures,
       spotFacilities: spotFacilities ?? this.spotFacilities,
       goodFor: goodFor ?? this.goodFor,
-      duplicateOf: duplicateOf ?? this.duplicateOf,
+      duplicateOf: identical(duplicateOf, _unset) ? this.duplicateOf : duplicateOf as String?,
     );
   }
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -9,6 +9,7 @@ import '../screens/admin/sync_sources_screen.dart';
 import '../screens/admin/geocoding_admin_screen.dart';
 import '../screens/admin/spot_management_screen.dart';
 import '../screens/admin/user_management_screen.dart';
+import '../screens/admin/duplicate_field_backfill_screen.dart';
 import '../screens/moderator/moderator_tools_screen.dart';
 import '../screens/moderator/spot_report_queue_screen.dart';
 import '../screens/spots/spot_detail_screen.dart';
@@ -110,6 +111,10 @@ class AppRouter {
         GoRoute(
           path: '/admin/spot-management',
           builder: (context, state) => const SpotManagementScreen(),
+        ),
+        GoRoute(
+          path: '/admin/duplicate-field-backfill',
+          builder: (context, state) => const DuplicateFieldBackfillScreen(),
         ),
         GoRoute(
           path: '/admin/users',

--- a/lib/screens/admin/admin_home_screen.dart
+++ b/lib/screens/admin/admin_home_screen.dart
@@ -87,6 +87,16 @@ class AdminHomeScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Card(
               child: ListTile(
+                leading: const Icon(Icons.content_paste_off),
+                title: const Text('Backfill Duplicate Field'),
+                subtitle: const Text('Set duplicateOf to null on spots missing the field'),
+                trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+                onTap: () => context.go('/admin/duplicate-field-backfill'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Card(
+              child: ListTile(
                 leading: const Icon(Icons.star_rate),
                 title: const Text('Recompute Ratings for Rated Spots'),
                 subtitle: const Text('Recalculate average, count, and Wilson lower bound from ratings'),

--- a/lib/screens/admin/duplicate_field_backfill_screen.dart
+++ b/lib/screens/admin/duplicate_field_backfill_screen.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/auth_service.dart';
+import '../../services/spot_service.dart';
+
+class DuplicateFieldBackfillScreen extends StatefulWidget {
+  const DuplicateFieldBackfillScreen({super.key});
+
+  @override
+  State<DuplicateFieldBackfillScreen> createState() => _DuplicateFieldBackfillScreenState();
+}
+
+class _DuplicateFieldBackfillScreenState extends State<DuplicateFieldBackfillScreen> {
+  bool _isRunning = false;
+  Map<String, int>? _lastStats;
+  String? _error;
+
+  Future<void> _runBackfill() async {
+    if (_isRunning) return;
+    setState(() {
+      _isRunning = true;
+      _error = null;
+    });
+
+    final spotService = context.read<SpotService>();
+
+    spotService.clearError();
+
+    try {
+      final stats = await spotService.backfillMissingDuplicateOf();
+      if (!mounted) return;
+
+      setState(() {
+        _lastStats = stats;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Backfill complete. Updated ${stats['updated']} spot(s).'),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Backfill failed: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRunning = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = context.select<AuthService, bool>((service) => service.isAdmin);
+
+    if (!isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Duplicate Field Backfill')),
+        body: const Center(child: Text('Administrator access required')),
+      );
+    }
+
+    final spotService = context.watch<SpotService>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Backfill Duplicate Field'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/admin'),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: const [
+                  Text('What this does', style: TextStyle(fontWeight: FontWeight.bold)),
+                  SizedBox(height: 8),
+                  Text('• Finds spots where the duplicateOf field is missing'),
+                  Text('• Sets duplicateOf to null so all records have the field'),
+                  Text('• Does NOT change spots already marked as duplicates'),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          if (_error != null)
+            Card(
+              color: Colors.red.withValues(alpha: 0.1),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Text(
+                  _error!,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              ),
+            ),
+          if (_lastStats != null) ...[
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Last run', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                    const SizedBox(height: 12),
+                    _buildStatRow('Matched spots', _lastStats!['matched']),
+                    const SizedBox(height: 8),
+                    _buildStatRow('Updated spots', _lastStats!['updated']),
+                    const SizedBox(height: 8),
+                    _buildStatRow('Already had field', _lastStats!['skipped']),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Spot service status: ${spotService.isLoading ? 'Busy' : 'Idle'}'),
+                  if (spotService.error != null) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      spotService.error!,
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                  ],
+                  const SizedBox(height: 16),
+                  ElevatedButton.icon(
+                    onPressed: _isRunning ? null : _runBackfill,
+                    icon: _isRunning
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.play_arrow),
+                    label: Text(_isRunning ? 'Running...' : 'Run Backfill'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatRow(String label, int? value) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label),
+        Text((value ?? 0).toString(), style: const TextStyle(fontWeight: FontWeight.bold)),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Standardize the `duplicateOf` field on spots to always be present (null if not a duplicate) and add an admin tool to backfill existing spots.

The previous implementation omitted the `duplicateOf` field entirely when a spot was not a duplicate, leading to inconsistent data schema and requiring special handling (like explicit field deletion in Firestore) when clearing the field. By always including the field with `null` when not a duplicate, the data model becomes more consistent and simplifies CRUD operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-e242582f-0839-4249-8cf6-a5eab987ec4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e242582f-0839-4249-8cf6-a5eab987ec4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

