### PR TITLE
feat: better sizes for desktop view + improved login page with new logo

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import '../../services/auth_service.dart';
 import '../../widgets/custom_text_field.dart';
 import '../../widgets/custom_button.dart';
@@ -24,6 +25,7 @@ class _LoginScreenState extends State<LoginScreen> {
   String? _intendedDestination;
   bool _hasCapturedDestination = false;
   bool _hasRedirected = false;
+  bool _hasSetMode = false;
 
   Future<void> _showForgotPasswordDialog() async {
     final emailController = TextEditingController(text: _emailController.text.trim());
@@ -161,6 +163,23 @@ class _LoginScreenState extends State<LoginScreen> {
     if (!_hasCapturedDestination) {
       _captureIntendedDestination();
       _hasCapturedDestination = true;
+    }
+    
+    // Check for mode query parameter to set sign up mode (only once)
+    if (!_hasSetMode) {
+      try {
+        final routerState = GoRouterState.of(context);
+        final mode = routerState.uri.queryParameters['mode'];
+        if (mode == 'signup' && _isLogin) {
+          setState(() {
+            _isLogin = false;
+          });
+        }
+        _hasSetMode = true;
+      } catch (e) {
+        // Ignore errors
+        _hasSetMode = true;
+      }
     }
   }
 
@@ -370,77 +389,88 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            context.go('/explore?tab=profile');
+          },
+        ),
+        elevation: 0,
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        foregroundColor: Theme.of(context).colorScheme.onSurface,
+      ),
       body: SafeArea(
         child: Center(
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(24.0),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // App Logo and Title
-                  Container(
-                    width: 100,
-                    height: 100,
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: const Icon(
-                      Icons.park,
-                      size: 60,
-                      color: Colors.white,
-                    ),
-                  ),
-                  
-                  const SizedBox(height: 24),
-                  
-                  Text(
-                    'Parkour·Spot',
-                    style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                  ),
-                  
-                  const SizedBox(height: 8),
-                  
-                  Text(
-                    _isLogin ? 'Welcome back!' : 'Create your account',
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-                    ),
-                  ),
-                  
-                  const SizedBox(height: 32),
-                  
-                  // Google Sign-In Button
-                  OutlinedButton.icon(
-                    onPressed: (_isLoading || _isGoogleSignInLoading) ? null : _signInWithGoogle,
-                    icon: _isGoogleSignInLoading
-                        ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.g_mobiledata, size: 24),
-                    label: Text(
-                      _isGoogleSignInLoading ? 'Signing in...' : 'Continue with Google',
-                      style: const TextStyle(fontSize: 16),
-                    ),
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 500),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // App Logo
+                      Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 400),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: AspectRatio(
+                              aspectRatio: 2773 / 646, // From SVG viewBox
+                              child: SvgPicture.asset(
+                                Theme.of(context).brightness == Brightness.dark
+                                    ? 'assets/images/logo-with-text-dark.svg'
+                                    : 'assets/images/logo-with-text.svg',
+                                fit: BoxFit.contain,
+                              ),
+                            ),
+                          ),
+                        ),
                       ),
-                      side: BorderSide(
-                        color: Theme.of(context).colorScheme.outline,
+                      
+                      const SizedBox(height: 32),
+                      
+                      Text(
+                        _isLogin ? 'Welcome back!' : 'Create your account',
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
                       ),
-                    ),
-                  ),
+                      
+                      const SizedBox(height: 32),
+                      
+                      // Google Sign-In Button
+                      ElevatedButton.icon(
+                        onPressed: (_isLoading || _isGoogleSignInLoading) ? null : _signInWithGoogle,
+                        icon: _isGoogleSignInLoading
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                ),
+                              )
+                            : const Icon(Icons.g_mobiledata, size: 24, color: Colors.white),
+                        label: Text(
+                          _isGoogleSignInLoading ? 'Signing in...' : 'Continue with Google',
+                          style: const TextStyle(fontSize: 16, color: Colors.white),
+                        ),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFEA4335), // Google red
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          elevation: 2,
+                        ),
+                      ),
                   
                   const SizedBox(height: 24),
                   
@@ -572,9 +602,11 @@ class _LoginScreenState extends State<LoginScreen> {
                   ],
                 ],
               ),
+              ),
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -45,59 +45,108 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Widget _buildAppInfo(BuildContext context) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // App Info Card
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: _buildAboutSection(context),
-            ),
-          ),
-          
-          const SizedBox(height: 16),
-          
-          // Sign In Prompt
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                children: [
-                  Icon(
-                    Icons.person_outline,
-                    size: 48,
-                    color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    'Sign in to access your profile',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Sign in to manage your spots, rate locations, and save favorites.',
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  CustomButton(
-                    onPressed: () {
-                      context.go('/login?redirectTo=${Uri.encodeComponent('/explore?tab=profile')}');
-                    },
-                    text: 'Sign In',
-                    width: double.infinity,
-                  ),
-                ],
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1200),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // App Info Card
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: _buildAboutSection(context),
+                ),
               ),
-            ),
+              
+              const SizedBox(height: 16),
+              
+              // Sign In Prompt
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: Column(
+                    children: [
+                      Icon(
+                        Icons.person_outline,
+                        size: 48,
+                        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Sign in to access your profile',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Sign in to manage your spots, rate locations, and save favorites.',
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 400),
+                          child: CustomButton(
+                            onPressed: () {
+                              context.go('/login?redirectTo=${Uri.encodeComponent('/explore?tab=profile')}');
+                            },
+                            text: 'Sign In',
+                            width: double.infinity,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      // OR divider
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Divider(
+                              color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: Text(
+                              'OR',
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Divider(
+                              color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 400),
+                          child: CustomButton(
+                            onPressed: () {
+                              context.go('/login?mode=signup&redirectTo=${Uri.encodeComponent('/explore?tab=profile')}');
+                            },
+                            text: 'Create an Account',
+                            width: double.infinity,
+                            isOutlined: true,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -107,163 +156,168 @@ class _ProfileScreenState extends State<ProfileScreen> {
     
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16.0),
-      child: Column(
-        children: [
-          // Profile Header
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                children: [
-                  // Profile Picture
-                  CircleAvatar(
-                    radius: 50,
-                    backgroundColor: Theme.of(context).colorScheme.primary,
-                    backgroundImage: user?.photoURL != null
-                        ? NetworkImage(user!.photoURL!)
-                        : null,
-                    child: user?.photoURL == null
-                        ? Text(
-                            user?.displayName?.substring(0, 1).toUpperCase() ?? 'U',
-                            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          )
-                        : null,
-                  ),
-                  
-                  const SizedBox(height: 16),
-                  
-                  // User Name
-                  Text(
-                    user?.displayName ?? 'User',
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  
-                  // User Email
-                  Text(
-                    user?.email ?? '',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          
-          const SizedBox(height: 16),
-
-          if (authService.isModerator || authService.isAdmin) ...[
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Moderator',
-                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold,
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1200),
+          child: Column(
+            children: [
+              // Profile Header
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: Column(
+                    children: [
+                      // Profile Picture
+                      CircleAvatar(
+                        radius: 50,
+                        backgroundColor: Theme.of(context).colorScheme.primary,
+                        backgroundImage: user?.photoURL != null
+                            ? NetworkImage(user!.photoURL!)
+                            : null,
+                        child: user?.photoURL == null
+                            ? Text(
+                                user?.displayName?.substring(0, 1).toUpperCase() ?? 'U',
+                                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              )
+                            : null,
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    _buildActionTile(
-                      context,
-                      Icons.shield,
-                      'Moderator Tools',
-                      'Review and resolve incoming spot reports',
-                      () {
-                        context.go('/moderator');
-                      },
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-            const SizedBox(height: 16),
-          ],
-
-          if (authService.isAdmin) ...[
-            // Administrator Section
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Administrator',
-                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold,
+                      
+                      const SizedBox(height: 16),
+                      
+                      // User Name
+                      Text(
+                        user?.displayName ?? 'User',
+                        style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    _buildActionTile(
-                      context,
-                      Icons.admin_panel_settings,
-                      'Admin Tools',
-                      'Manage sources and administrative tasks',
-                      () {
-                        context.go('/admin');
-                      },
-                    ),
-                  ],
+                      
+                      // User Email
+                      Text(
+                        user?.email ?? '',
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-
-            const SizedBox(height: 16),
-          ],
-          
-          // App Info Card
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: _buildAboutSection(context),
-            ),
-          ),
-          
-          const SizedBox(height: 24),
-          
-          // Sign Out Button
-          CustomButton(
-            onPressed: () async {
-              final shouldSignOut = await showDialog<bool>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: const Text('Sign Out'),
-                  content: const Text('Are you sure you want to sign out?'),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context, false),
-                      child: const Text('Cancel'),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.pop(context, true),
-                      child: const Text('Sign Out'),
-                    ),
-                  ],
-                ),
-              );
               
-              if (shouldSignOut == true) {
-                await authService.signOut();
-                if (context.mounted) {
-                  context.go('/explore?tab=profile');
-                }
-              }
-            },
-            text: 'Sign Out',
-            icon: Icons.logout,
-            backgroundColor: Theme.of(context).colorScheme.error,
-            width: double.infinity,
+              const SizedBox(height: 16),
+
+              if (authService.isModerator || authService.isAdmin) ...[
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Moderator',
+                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        _buildActionTile(
+                          context,
+                          Icons.shield,
+                          'Moderator Tools',
+                          'Review and resolve incoming spot reports',
+                          () {
+                            context.go('/moderator');
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+              ],
+
+              if (authService.isAdmin) ...[
+                // Administrator Section
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Administrator',
+                          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        _buildActionTile(
+                          context,
+                          Icons.admin_panel_settings,
+                          'Admin Tools',
+                          'Manage sources and administrative tasks',
+                          () {
+                            context.go('/admin');
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+              ],
+              
+              // App Info Card
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: _buildAboutSection(context),
+                ),
+              ),
+              
+              const SizedBox(height: 24),
+              
+              // Sign Out Button
+              CustomButton(
+                onPressed: () async {
+                  final shouldSignOut = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Sign Out'),
+                      content: const Text('Are you sure you want to sign out?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: const Text('Sign Out'),
+                        ),
+                      ],
+                    ),
+                  );
+                  
+                  if (shouldSignOut == true) {
+                    await authService.signOut();
+                    if (context.mounted) {
+                      context.go('/explore?tab=profile');
+                    }
+                  }
+                },
+                text: 'Sign Out',
+                icon: Icons.logout,
+                backgroundColor: Theme.of(context).colorScheme.error,
+                width: double.infinity,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -359,145 +413,155 @@ class _ProfileScreenState extends State<ProfileScreen> {
       builder: (context, constraints) {
         final isWideScreen = constraints.maxWidth > 600;
         
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 500),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: AspectRatio(
-                    aspectRatio: 2773 / 646, // From SVG viewBox
-                    child: SvgPicture.asset(
-                      Theme.of(context).brightness == Brightness.dark
-                          ? 'assets/images/logo-with-text-dark.svg'
-                          : 'assets/images/logo-with-text.svg',
-                      fit: BoxFit.contain,
+        return Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 1200),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 500),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: AspectRatio(
+                        aspectRatio: 2773 / 646, // From SVG viewBox
+                        child: SvgPicture.asset(
+                          Theme.of(context).brightness == Brightness.dark
+                              ? 'assets/images/logo-with-text-dark.svg'
+                              : 'assets/images/logo-with-text.svg',
+                          fit: BoxFit.contain,
+                        ),
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ),
-            const SizedBox(height: 16),
-            isWideScreen
-                ? Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
+                SizedBox(height: isWideScreen ? 32 : 16),
+                isWideScreen
+                    ? Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                SelectableText(
-                                  'Parkour·Spot is a community-driven app for discovering and sharing parkour and freerunning spots worldwide. We\'re making it simple to find quality locations—wherever you train.',
-                                  style: textStyle,
-                                ),
-                                if (!_isExpanded) ...[
-                                  const SizedBox(height: 8),
-                                  GestureDetector(
-                                    onTap: () {
-                                      setState(() {
-                                        _isExpanded = true;
-                                      });
-                                    },
-                                    child: Text(
-                                      'Read more',
-                                      style: textStyle?.copyWith(
-                                        color: Theme.of(context).colorScheme.primary,
-                                        decoration: TextDecoration.underline,
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    SelectableText(
+                                      'Parkour·Spot is a community-driven app for discovering and sharing parkour and freerunning spots worldwide. We\'re making it simple to find quality locations—wherever you train.',
+                                      style: textStyle,
+                                    ),
+                                    if (!_isExpanded) ...[
+                                      const SizedBox(height: 8),
+                                      GestureDetector(
+                                        onTap: () {
+                                          setState(() {
+                                            _isExpanded = true;
+                                          });
+                                        },
+                                        child: Text(
+                                          'Read more',
+                                          style: textStyle?.copyWith(
+                                            color: Theme.of(context).colorScheme.primary,
+                                            decoration: TextDecoration.underline,
+                                          ),
+                                        ),
                                       ),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                              const SizedBox(width: 24),
+                              Expanded(
+                                child: Center(
+                                  child: ConstrainedBox(
+                                    constraints: const BoxConstraints(maxWidth: 350),
+                                    child: Column(
+                                      children: [
+                                        InstagramButton(
+                                          handle: 'parkourdotspot',
+                                          label: '@parkourdotspot',
+                                        ),
+                                        const SizedBox(height: 16),
+                                        GitHubButton(
+                                          url: 'https://github.com/wardweistra/Parkour.Spot/',
+                                          label: 'View source code',
+                                        ),
+                                        const SizedBox(height: 16),
+                                        ReportIssueButton(
+                                          url: 'https://github.com/wardweistra/Parkour.Spot/issues',
+                                        ),
+                                        const SizedBox(height: 16),
+                                        EmailButton(
+                                          email: 'parkour.spot@wardweistra.nl',
+                                          label: 'Contact us',
+                                        ),
+                                      ],
                                     ),
                                   ),
-                                ],
-                              ],
-                            ),
+                                ),
+                              ),
+                            ],
                           ),
-                          const SizedBox(width: 24),
-                          Expanded(
-                            child: Column(
-                              children: [
-                                InstagramButton(
-                                  handle: 'parkourdotspot',
-                                  label: '@parkourdotspot',
+                          if (_isExpanded) ...[
+                            const SizedBox(height: 16),
+                            _buildExpandedText(context),
+                          ],
+                        ],
+                      )
+                    : Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SelectableText(
+                            'Parkour·Spot is a community-driven app for discovering and sharing parkour and freerunning spots worldwide. We\'re making it simple to find quality locations—wherever you train.',
+                            style: textStyle,
+                          ),
+                          if (!_isExpanded) ...[
+                            const SizedBox(height: 8),
+                            GestureDetector(
+                              onTap: () {
+                                setState(() {
+                                  _isExpanded = true;
+                                });
+                              },
+                              child: Text(
+                                'Read more',
+                                style: textStyle?.copyWith(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  decoration: TextDecoration.underline,
                                 ),
-                                const SizedBox(height: 16),
-                                GitHubButton(
-                                  url: 'https://github.com/wardweistra/Parkour.Spot/',
-                                  label: 'View source code',
-                                ),
-                                const SizedBox(height: 16),
-                                ReportIssueButton(
-                                  url: 'https://github.com/wardweistra/Parkour.Spot/issues',
-                                ),
-                                const SizedBox(height: 16),
-                                EmailButton(
-                                  email: 'parkour.spot@wardweistra.nl',
-                                  label: 'Contact us',
-                                ),
-                              ],
+                              ),
                             ),
+                          ],
+                          if (_isExpanded) ...[
+                            const SizedBox(height: 16),
+                            _buildExpandedText(context),
+                          ],
+                          const SizedBox(height: 16),
+                          InstagramButton(
+                            handle: 'parkourdotspot',
+                            label: '@parkourdotspot',
+                          ),
+                          const SizedBox(height: 16),
+                          GitHubButton(
+                            url: 'https://github.com/wardweistra/Parkour.Spot/',
+                            label: 'View source code',
+                          ),
+                          const SizedBox(height: 16),
+                          ReportIssueButton(
+                            url: 'https://github.com/wardweistra/Parkour.Spot/issues',
+                          ),
+                          const SizedBox(height: 16),
+                          EmailButton(
+                            email: 'parkour.spot@wardweistra.nl',
+                            label: 'Contact us',
                           ),
                         ],
                       ),
-                      if (_isExpanded) ...[
-                        const SizedBox(height: 16),
-                        _buildExpandedText(context),
-                      ],
-                    ],
-                  )
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SelectableText(
-                        'Parkour·Spot is a community-driven app for discovering and sharing parkour and freerunning spots worldwide. We\'re making it simple to find quality locations—wherever you train.',
-                        style: textStyle,
-                      ),
-                      if (!_isExpanded) ...[
-                        const SizedBox(height: 8),
-                        GestureDetector(
-                          onTap: () {
-                            setState(() {
-                              _isExpanded = true;
-                            });
-                          },
-                          child: Text(
-                            'Read more',
-                            style: textStyle?.copyWith(
-                              color: Theme.of(context).colorScheme.primary,
-                              decoration: TextDecoration.underline,
-                            ),
-                          ),
-                        ),
-                      ],
-                      if (_isExpanded) ...[
-                        const SizedBox(height: 16),
-                        _buildExpandedText(context),
-                      ],
-                      const SizedBox(height: 16),
-                      InstagramButton(
-                        handle: 'parkourdotspot',
-                        label: '@parkourdotspot',
-                      ),
-                      const SizedBox(height: 16),
-                      GitHubButton(
-                        url: 'https://github.com/wardweistra/Parkour.Spot/',
-                        label: 'View source code',
-                      ),
-                      const SizedBox(height: 16),
-                      ReportIssueButton(
-                        url: 'https://github.com/wardweistra/Parkour.Spot/issues',
-                      ),
-                      const SizedBox(height: 16),
-                      EmailButton(
-                        email: 'parkour.spot@wardweistra.nl',
-                        label: 'Contact us',
-                      ),
-                    ],
-                  ),
-          ],
+              ],
+            ),
+          ),
         );
       },
     );


### PR DESCRIPTION
Worked on the login page and the profile page to make them look better.
- Added logo to login page
- Made the Google login button red
- Added a back button on login/register to go back to app
- Changed the padding and added maxWidth to profile page so it looks better on desktop view
- Added button to go straight to register from profile when not logged in

**Before**
<img width="1600" height="745" alt="image" src="https://github.com/user-attachments/assets/29774339-df8f-48ce-ba7b-6dd11a3c7774" />
**After**
<img width="1600" height="722" alt="image" src="https://github.com/user-attachments/assets/6ffb289b-567e-48c3-9b5e-127df26f484e" />

**Before**
<img width="1600" height="740" alt="image" src="https://github.com/user-attachments/assets/7cd3e7f3-e5e2-4921-b90b-9253bfcd37fa" />
**After**
<img width="1600" height="869" alt="image" src="https://github.com/user-attachments/assets/cf671a1a-6d7f-4454-9b59-96fbb54a877c" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps login and profile UIs with SVG branding, desktop-friendly max widths, red Google button, back navigation, and query-driven signup mode with CTA from profile.
> 
> - **Auth/Login (`lib/screens/auth/login_screen.dart`)**:
>   - Adds AppBar with back navigation to `'/explore?tab=profile'`.
>   - Uses SVG logo (`assets/images/logo-with-text*.svg`) and centers content within `maxWidth: 500`.
>   - Styles Google sign-in as red `ElevatedButton` with loading indicator.
>   - Supports `?mode=signup` query to auto-switch to sign-up (one-time via `_hasSetMode`).
> - **Profile (`lib/screens/profile/profile_screen.dart`)**:
>   - Desktop-friendly layout with centered `maxWidth: 1200` wrappers for app info and profile content.
>   - Sign-in card tweaks: constrained button width, adds OR divider, and a "Create an Account" button linking to `'/login?mode=signup&redirectTo=...'`.
>   - About section uses centered SVG logo, responsive spacing, and preserved expandable text and action buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2bb15d5ebe58397f0f457580bb64a82e6cd3603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->