### PR TITLE
Track and log removed spots during sync

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2361,7 +2361,12 @@ async function processSyncSource(source, sourceId, apiKey) {
   let updated = 0;
   let geocoded = 0;
   let geocodingFailed = 0;
+  let removed = 0;
   const skipped = 0;
+  const processedSpotIds = new Set();
+  const addedSpotSummaries = [];
+  const updatedSpotSummaries = [];
+  const removedSpotSummaries = [];
 
   // Collect all unique folder names from successfully processed spots if recordFolderName is enabled
   const allFolders = new Set();
@@ -2545,6 +2550,8 @@ async function processSyncSource(source, sourceId, apiKey) {
       countryCode: countryCode,
       spotSource: sourceId,
       spotSourceName: source.name,
+      spotSourceRemoved: false,
+      spotSourceRemovedAt: admin.firestore.FieldValue.delete(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     };
 
@@ -2583,8 +2590,13 @@ async function processSyncSource(source, sourceId, apiKey) {
       spotData.duplicateOf = null; // Initialize duplicateOf field
       spotData.hidden = false; // Initialize hidden field
       spotData.createdAt = admin.firestore.FieldValue.serverTimestamp();
-      await db.collection("spots").add(cleanUndefinedValues(spotData));
+      const newSpotRef = await db.collection("spots").add(cleanUndefinedValues(spotData));
       created++;
+      processedSpotIds.add(newSpotRef.id);
+      addedSpotSummaries.push({
+        id: newSpotRef.id,
+        name: spotData.name,
+      });
       console.log(
           `Created new spot: ${name} from source: ${source.name} with ${imageResult.imageUrls.length} images and geocoded address`,
       );
@@ -2617,6 +2629,11 @@ async function processSyncSource(source, sourceId, apiKey) {
       }
 
       await existingSpot.ref.update(cleanUndefinedValues(spotData));
+      processedSpotIds.add(existingSpot.id);
+      updatedSpotSummaries.push({
+        id: existingSpot.id,
+        name: spotData.name,
+      });
       updated++;
       console.log(
           `Updated existing spot: ${name} from source: ${source.name} with ${imageResult.imageUrls.length} images (preserved rating: ${existingData.averageRating || 0}, count: ${existingData.ratingCount || 0})`,
@@ -2641,23 +2658,56 @@ async function processSyncSource(source, sourceId, apiKey) {
     }
   }
 
+  // Identify and label spots that were not present in this sync
+  const sourceSpotsSnapshot = await db
+      .collection("spots")
+      .where("spotSource", "==", sourceId)
+      .get();
+
+  for (const doc of sourceSpotsSnapshot.docs) {
+    if (processedSpotIds.has(doc.id)) {
+      continue;
+    }
+
+    const spotRecord = doc.data() || {};
+    if (spotRecord.spotSourceRemoved === true) {
+      continue; // Already labeled as removed
+    }
+
+    await doc.ref.update({
+      spotSourceRemoved: true,
+      spotSourceRemovedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    removed++;
+    removedSpotSummaries.push({
+      id: doc.id,
+      name: spotRecord.name || doc.id,
+    });
+  }
+
+  const geocodingSuccessRate =
+    placemarks.length > 0 ?
+      ((geocoded / placemarks.length) * 100).toFixed(1) + "%" :
+      "0%";
+
+  const stats = {
+    total: placemarks.length,
+    created,
+    updated,
+    removed,
+    skipped,
+    geocoded,
+    geocodingFailed,
+    geocodingSuccessRate,
+  };
+
   // Update source last sync time and folder information
   const sourceDoc = await db.collection("syncSources").doc(sourceId).get();
   if (sourceDoc.exists) {
     const updateData = {
       lastSyncAt: admin.firestore.FieldValue.serverTimestamp(),
-      lastSyncStats: {
-        total: placemarks.length,
-        created: created,
-        updated: updated,
-        skipped: skipped,
-        geocoded: geocoded,
-        geocodingFailed: geocodingFailed,
-        geocodingSuccessRate:
-          placemarks.length > 0 ?
-            ((geocoded / placemarks.length) * 100).toFixed(1) + "%" :
-            "0%",
-      },
+      lastSyncStats: stats,
     };
 
     // Update allFolders if recordFolderName is enabled
@@ -2697,21 +2747,33 @@ async function processSyncSource(source, sourceId, apiKey) {
     await sourceDoc.ref.update(updateData);
   }
 
+  try {
+    await db.collection("auditLog").add({
+      action: "spotSourceSync",
+      spotId: `syncSource:${sourceId}`,
+      userId: null,
+      userName: "Spot Sync Service",
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      metadata: {
+        sourceId: sourceId,
+        sourceName: source.name,
+        stats: stats,
+        addedSpots: addedSpotSummaries,
+        updatedSpots: updatedSpotSummaries,
+        removedSpots: removedSpotSummaries,
+      },
+    });
+  } catch (error) {
+    console.error(
+        `Failed to write audit log entry for source ${sourceId}:`,
+        error,
+    );
+  }
+
   return {
     sourceId: sourceId,
     sourceName: source.name,
-    stats: {
-      total: placemarks.length,
-      created: created,
-      updated: updated,
-      skipped: skipped,
-      geocoded: geocoded,
-      geocodingFailed: geocodingFailed,
-      geocodingSuccessRate:
-        placemarks.length > 0 ?
-          ((geocoded / placemarks.length) * 100).toFixed(1) + "%" :
-          "0%",
-    },
+    stats,
   };
 }
 

--- a/lib/models/audit_log.dart
+++ b/lib/models/audit_log.dart
@@ -7,6 +7,7 @@ enum AuditLogAction {
   spotUnhidden,
   spotReportStatusChange,
   spotDelete,
+  spotSourceSync,
 }
 
 class AuditLog {

--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -18,6 +18,8 @@ class Spot {
   final DateTime? updatedAt;
   final String? spotSource;
   final String? spotSourceName;
+  final bool spotSourceRemoved;
+  final DateTime? spotSourceRemovedAt;
   final double? averageRating;
   final int? ratingCount;
   final double? wilsonLowerBound;
@@ -49,6 +51,8 @@ class Spot {
     this.updatedAt,
     this.spotSource,
     this.spotSourceName,
+    this.spotSourceRemoved = false,
+    this.spotSourceRemovedAt,
     this.averageRating,
     this.ratingCount,
     this.wilsonLowerBound,
@@ -131,6 +135,10 @@ class Spot {
       updatedAt: data['updatedAt']?.toDate(),
       spotSource: data['spotSource'],
       spotSourceName: data['spotSourceName'],
+      spotSourceRemoved: data['spotSourceRemoved'] == true,
+      spotSourceRemovedAt: data['spotSourceRemovedAt'] is Timestamp
+          ? (data['spotSourceRemovedAt'] as Timestamp).toDate()
+          : null,
       averageRating: data['averageRating'] != null ? (data['averageRating'] as num).toDouble() : null,
       ratingCount: data['ratingCount'],
       wilsonLowerBound: data['wilsonLowerBound'] != null ? (data['wilsonLowerBound'] as num).toDouble() : null,
@@ -221,6 +229,8 @@ class Spot {
       updatedAt: parseDate(data['updatedAt']),
       spotSource: data['spotSource'] as String?,
       spotSourceName: data['spotSourceName'] as String?,
+      spotSourceRemoved: data['spotSourceRemoved'] == true,
+      spotSourceRemovedAt: parseDate(data['spotSourceRemovedAt']),
       averageRating: (data['averageRating'] as num?)?.toDouble(),
       ratingCount: (data['ratingCount'] is int) ? data['ratingCount'] as int : (data['ratingCount'] as num?)?.toInt(),
       wilsonLowerBound: (data['wilsonLowerBound'] as num?)?.toDouble(),
@@ -252,6 +262,8 @@ class Spot {
       'updatedAt': updatedAt,
       'spotSource': spotSource,
       'spotSourceName': spotSourceName,
+      'spotSourceRemoved': spotSourceRemoved,
+      if (spotSourceRemovedAt != null) 'spotSourceRemovedAt': spotSourceRemovedAt,
       if (averageRating != null) 'averageRating': averageRating,
       if (ratingCount != null) 'ratingCount': ratingCount,
       if (wilsonLowerBound != null) 'wilsonLowerBound': wilsonLowerBound,
@@ -283,6 +295,8 @@ class Spot {
     DateTime? updatedAt,
     String? spotSource,
     String? spotSourceName,
+    bool? spotSourceRemoved,
+    Object? spotSourceRemovedAt = _unset,
     double? averageRating,
     int? ratingCount,
     double? wilsonLowerBound,
@@ -312,6 +326,10 @@ class Spot {
       updatedAt: updatedAt ?? this.updatedAt,
       spotSource: spotSource ?? this.spotSource,
       spotSourceName: spotSourceName ?? this.spotSourceName,
+      spotSourceRemoved: spotSourceRemoved ?? this.spotSourceRemoved,
+      spotSourceRemovedAt: identical(spotSourceRemovedAt, _unset)
+          ? this.spotSourceRemovedAt
+          : spotSourceRemovedAt as DateTime?,
       averageRating: averageRating ?? this.averageRating,
       ratingCount: ratingCount ?? this.ratingCount,
       wilsonLowerBound: wilsonLowerBound ?? this.wilsonLowerBound,

--- a/lib/screens/admin/audit_log_viewer_screen.dart
+++ b/lib/screens/admin/audit_log_viewer_screen.dart
@@ -614,6 +614,67 @@ class _AuditLogViewerScreenState extends State<AuditLogViewerScreen> {
               details = 'Spot permanently deleted';
             }
             break;
+          case AuditLogAction.spotSourceSync:
+            title = 'Spot Source Synced';
+            final syncMetadata = auditLog.metadata ?? {};
+            final sourceName = syncMetadata['sourceName'] as String? ?? 'Unknown source';
+            subtitle = 'Source: $sourceName';
+
+            List<String> _formatSpotList(dynamic value) {
+              if (value is List) {
+                return value
+                    .map((entry) {
+                      if (entry is Map<String, dynamic>) {
+                        final name = (entry['name'] as String?)?.trim();
+                        if (name != null && name.isNotEmpty) {
+                          return name;
+                        }
+                        final id = entry['id'] as String?;
+                        if (id != null && id.isNotEmpty) {
+                          return id;
+                        }
+                      }
+                      if (entry is String) {
+                        return entry;
+                      }
+                      return null;
+                    })
+                    .whereType<String>()
+                    .toList();
+              }
+              return const [];
+            }
+
+            final addedNames = _formatSpotList(syncMetadata['addedSpots']);
+            final updatedNames = _formatSpotList(syncMetadata['updatedSpots']);
+            final removedNames = _formatSpotList(syncMetadata['removedSpots']);
+            final statsMap = syncMetadata['stats'] is Map<String, dynamic>
+                ? Map<String, dynamic>.from(syncMetadata['stats'] as Map)
+                : null;
+
+            final summaryLines = <String>[];
+            if (statsMap != null) {
+              final total = statsMap['total'] ?? 0;
+              final created = statsMap['created'] ?? 0;
+              final updatedCount = statsMap['updated'] ?? 0;
+              final removedCount = statsMap['removed'] ?? 0;
+              summaryLines.add('Total spots in feed: $total');
+              summaryLines.add('Created: $created • Updated: $updatedCount • Removed: $removedCount');
+            }
+            if (addedNames.isNotEmpty) {
+              summaryLines.add('Added (${addedNames.length}): ${addedNames.join(', ')}');
+            }
+            if (updatedNames.isNotEmpty) {
+              summaryLines.add('Updated (${updatedNames.length}): ${updatedNames.join(', ')}');
+            }
+            if (removedNames.isNotEmpty) {
+              summaryLines.add('Removed (${removedNames.length}): ${removedNames.join(', ')}');
+            }
+
+            details = summaryLines.isEmpty
+                ? 'Sync completed without changes.'
+                : summaryLines.join('\n');
+            break;
         }
 
         newEntries.add(AuditLogEntry(
@@ -624,7 +685,7 @@ class _AuditLogViewerScreenState extends State<AuditLogViewerScreen> {
           subtitle: subtitle,
           details: details,
           metadata: {
-            'spotId': auditLog.spotId,
+            if (auditLog.action != AuditLogAction.spotSourceSync) 'spotId': auditLog.spotId,
             if (auditLog.reportId != null) 'reportId': auditLog.reportId,
             'userId': auditLog.userId,
             'userName': auditLog.userName,

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -2294,6 +2294,39 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                             trailing: const Icon(Icons.info_outline, size: 16),
                           ),
                         ),
+                        const SizedBox(height: 8),
+                      ],
+                      if (widget.spot.spotSourceRemoved) ...[
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 16),
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.errorContainer.withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.error.withValues(alpha: 0.6),
+                              width: 1,
+                            ),
+                          ),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Icon(
+                                Icons.warning_amber_rounded,
+                                color: Theme.of(context).colorScheme.error,
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Text(
+                                  'This spot is no longer listed in ${widget.spot.spotSourceName ?? 'its original source'}. Details might be outdated, so double-check before visiting.',
+                                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                        color: Theme.of(context).colorScheme.onErrorContainer,
+                                      ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                       ],
                       if (widget.spot.createdAt != null) ...[
                         ListTile(

--- a/lib/widgets/spot_card.dart
+++ b/lib/widgets/spot_card.dart
@@ -364,6 +364,13 @@ class _SpotCardState extends State<SpotCard> {
                 ),
               ),
 
+            if (widget.spot.spotSourceRemoved)
+              Positioned(
+                top: 8,
+                right: 8,
+                child: _buildRemovedBadge(context),
+              ),
+
             // "Added by" text positioned at bottom left
             if (widget.spot.createdBy != null || widget.spot.createdByName != null)
               Positioned(
@@ -609,6 +616,13 @@ class _SpotCardState extends State<SpotCard> {
                               ),
                             ),
                           ),
+
+                        if (widget.spot.spotSourceRemoved)
+                          Positioned(
+                            top: 8,
+                            right: 8,
+                            child: _buildRemovedBadge(context),
+                          ),
                       ],
                     ),
                   ),
@@ -715,6 +729,45 @@ class _SpotCardState extends State<SpotCard> {
     ),
   );
 }
+
+  Widget _buildRemovedBadge(BuildContext context) {
+    final textStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Colors.white,
+          fontWeight: FontWeight.w600,
+        ) ??
+        const TextStyle(
+          color: Colors.white,
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+        );
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.red.withValues(alpha: 0.85),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(
+          color: Colors.white.withValues(alpha: 0.4),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            size: 14,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            'Removed from source',
+            style: textStyle,
+          ),
+        ],
+      ),
+    );
+  }
 
 String _formatDate(DateTime date) {
     final now = DateTime.now();


### PR DESCRIPTION
Adds a `spotSourceRemoved` label to spots no longer found in their source and logs detailed sync activity to the audit log, improving spot tracking and sync transparency.

---
<a href="https://cursor.com/background-agent?bcId=bc-33fe35e6-c8af-4d2c-9271-53c758961c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33fe35e6-c8af-4d2c-9271-53c758961c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks spots no longer present in a source as removed during sync, logs detailed sync stats to the audit log, and surfaces removal status in the app UI.
> 
> - **Backend (functions/index.js)**:
>   - Track processed spot IDs; add `spotSourceRemoved` and `spotSourceRemovedAt` defaults on upsert.
>   - After sync, label unprocessed source spots as removed (`spotSourceRemoved: true`, timestamp) and collect `removed` stats with spot summaries.
>   - Consolidate `stats` (incl. `removed`) and persist to `syncSources.lastSyncStats`.
>   - Write `auditLog` entry (`action: spotSourceSync`) with `stats` and lists of `addedSpots`, `updatedSpots`, `removedSpots`.
> - **Models**:
>   - `AuditLogAction`: add `spotSourceSync`.
>   - `Spot`: add `spotSourceRemoved` and `spotSourceRemovedAt` fields with (de)serialization and `copyWith` support.
> - **Admin UI (Audit Log Viewer)**:
>   - Render `spotSourceSync` entries with source, totals, and added/updated/removed spot names; omit `spotId` in metadata for this action.
> - **Spots UI**:
>   - Spot Detail: show warning banner when `spotSourceRemoved` is true.
>   - Spot Card: show "Removed from source" badge when `spotSourceRemoved` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ec8a1fcdab45aceec73ed17648de43da6bef944. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->