### PR TITLE
Folder spot attributes

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -483,6 +483,445 @@ function cleanUndefinedValues(obj) {
   return cleaned;
 }
 
+// Spot attribute defaults supported for sync source defaults/backfills.
+const VALID_SPOT_ACCESS_VALUES = new Set(["public", "restricted", "paid"]);
+const VALID_SPOT_FEATURE_VALUES = new Set([
+  "walls_low",
+  "walls_medium",
+  "walls_high",
+  "bars_low",
+  "bars_medium",
+  "bars_high",
+  "climbing_tree",
+  "rocks",
+  "soft_landing_pit",
+  "roof_gap",
+  "bouncy_equipment",
+]);
+const VALID_GOOD_FOR_VALUES = new Set([
+  "vaults",
+  "balance",
+  "ascend",
+  "descend",
+  "speed_run",
+  "water_challenges",
+  "pole_slide",
+  "precisions",
+  "wall_runs",
+  "strides",
+  "rolls",
+  "cats",
+  "flow",
+  "flips",
+  "swings",
+]);
+const VALID_SPOT_FACILITY_KEYS = new Set([
+  "covered",
+  "lighting",
+  "water_tap",
+  "toilet",
+  "parking",
+]);
+const VALID_SPOT_FACILITY_VALUES = new Set(["yes", "no"]);
+
+/**
+ * Normalizes a list of strings.
+ * @param {Array<*>} values
+ * @param {Set<string>=} allowedValues
+ * @return {Array<string>}
+ */
+function normalizeStringArray(values, allowedValues = undefined) {
+  if (!Array.isArray(values)) return [];
+  const result = [];
+  const seen = new Set();
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const cleaned = value.trim().toLowerCase();
+    if (!cleaned) continue;
+    if (allowedValues && !allowedValues.has(cleaned)) continue;
+    if (seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    result.push(cleaned);
+  }
+  return result;
+}
+
+/**
+ * Keeps existing string arrays stable without dropping unknown values.
+ * @param {Array<*>} values
+ * @return {Array<string>}
+ */
+function normalizeExistingStringArray(values) {
+  if (!Array.isArray(values)) return [];
+  const result = [];
+  const seen = new Set();
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const cleaned = value.trim();
+    if (!cleaned) continue;
+    if (seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    result.push(cleaned);
+  }
+  return result;
+}
+
+/**
+ * Normalizes one default-attributes object.
+ * @param {*} rawDefaults
+ * @return {Object|null}
+ */
+function normalizeSpotAttributeDefaults(rawDefaults) {
+  if (!rawDefaults || typeof rawDefaults !== "object" || Array.isArray(rawDefaults)) {
+    return null;
+  }
+
+  const normalized = {};
+
+  if (typeof rawDefaults.spotAccess === "string") {
+    const access = rawDefaults.spotAccess.trim().toLowerCase();
+    if (VALID_SPOT_ACCESS_VALUES.has(access)) {
+      normalized.spotAccess = access;
+    }
+  }
+
+  const normalizedSpotFeatures = normalizeStringArray(
+      rawDefaults.spotFeatures,
+      VALID_SPOT_FEATURE_VALUES,
+  );
+  if (normalizedSpotFeatures.length > 0) {
+    normalized.spotFeatures = normalizedSpotFeatures;
+  }
+
+  const normalizedGoodFor = normalizeStringArray(
+      rawDefaults.goodFor,
+      VALID_GOOD_FOR_VALUES,
+  );
+  if (normalizedGoodFor.length > 0) {
+    normalized.goodFor = normalizedGoodFor;
+  }
+
+  if (
+    rawDefaults.spotFacilities &&
+    typeof rawDefaults.spotFacilities === "object" &&
+    !Array.isArray(rawDefaults.spotFacilities)
+  ) {
+    const facilities = {};
+    for (const [key, value] of Object.entries(rawDefaults.spotFacilities)) {
+      const facilityKey = String(key).trim().toLowerCase();
+      const facilityValue = typeof value === "string" ?
+        value.trim().toLowerCase() :
+        "";
+      if (!VALID_SPOT_FACILITY_KEYS.has(facilityKey)) continue;
+      if (!VALID_SPOT_FACILITY_VALUES.has(facilityValue)) continue;
+      facilities[facilityKey] = facilityValue;
+    }
+    if (Object.keys(facilities).length > 0) {
+      normalized.spotFacilities = facilities;
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+/**
+ * Normalizes folder-specific default attributes map.
+ * @param {*} rawFolderDefaults
+ * @return {Object<string, Object>}
+ */
+function normalizeFolderSpotAttributeDefaults(rawFolderDefaults) {
+  if (
+    !rawFolderDefaults ||
+    typeof rawFolderDefaults !== "object" ||
+    Array.isArray(rawFolderDefaults)
+  ) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [rawFolderName, rawDefaults] of Object.entries(rawFolderDefaults)) {
+    if (typeof rawFolderName !== "string") continue;
+    const folderName = rawFolderName.trim();
+    if (!folderName) continue;
+    const defaults = normalizeSpotAttributeDefaults(rawDefaults);
+    if (defaults) {
+      normalized[folderName] = defaults;
+    }
+  }
+  return normalized;
+}
+
+/**
+ * Builds case-insensitive lookup for folder defaults.
+ * @param {Object<string, Object>} folderDefaults
+ * @return {Object<string, Object>}
+ */
+function buildFolderDefaultsLookup(folderDefaults) {
+  const lookup = {};
+  for (const [folderName, defaults] of Object.entries(folderDefaults || {})) {
+    const key = folderName.trim().toLowerCase();
+    if (!key) continue;
+    lookup[key] = defaults;
+  }
+  return lookup;
+}
+
+/**
+ * Merges two default-attribute objects into one effective set.
+ * Arrays are unioned, facilities/access in overrideDefaults win.
+ * @param {Object|null} baseDefaults
+ * @param {Object|null} overrideDefaults
+ * @return {Object|null}
+ */
+function mergeSpotAttributeDefaults(baseDefaults, overrideDefaults) {
+  const hasBase = baseDefaults && typeof baseDefaults === "object";
+  const hasOverride = overrideDefaults && typeof overrideDefaults === "object";
+  if (!hasBase && !hasOverride) return null;
+
+  const merged = {};
+
+  const baseSpotFeatures = hasBase ?
+    normalizeStringArray(baseDefaults.spotFeatures, VALID_SPOT_FEATURE_VALUES) :
+    [];
+  const overrideSpotFeatures = hasOverride ?
+    normalizeStringArray(overrideDefaults.spotFeatures, VALID_SPOT_FEATURE_VALUES) :
+    [];
+  const mergedSpotFeatures = mergeUniqueStringArrays(
+      baseSpotFeatures,
+      overrideSpotFeatures,
+  );
+  if (mergedSpotFeatures.length > 0) {
+    merged.spotFeatures = mergedSpotFeatures;
+  }
+
+  const baseGoodFor = hasBase ?
+    normalizeStringArray(baseDefaults.goodFor, VALID_GOOD_FOR_VALUES) :
+    [];
+  const overrideGoodFor = hasOverride ?
+    normalizeStringArray(overrideDefaults.goodFor, VALID_GOOD_FOR_VALUES) :
+    [];
+  const mergedGoodFor = mergeUniqueStringArrays(baseGoodFor, overrideGoodFor);
+  if (mergedGoodFor.length > 0) {
+    merged.goodFor = mergedGoodFor;
+  }
+
+  const baseFacilities = (
+    hasBase &&
+    baseDefaults.spotFacilities &&
+    typeof baseDefaults.spotFacilities === "object" &&
+    !Array.isArray(baseDefaults.spotFacilities)
+  ) ? baseDefaults.spotFacilities : {};
+  const overrideFacilities = (
+    hasOverride &&
+    overrideDefaults.spotFacilities &&
+    typeof overrideDefaults.spotFacilities === "object" &&
+    !Array.isArray(overrideDefaults.spotFacilities)
+  ) ? overrideDefaults.spotFacilities : {};
+  const mergedFacilities = {};
+  for (const [key, value] of Object.entries(baseFacilities)) {
+    const facilityKey = String(key).trim().toLowerCase();
+    const facilityValue = typeof value === "string" ?
+      value.trim().toLowerCase() :
+      "";
+    if (!VALID_SPOT_FACILITY_KEYS.has(facilityKey)) continue;
+    if (!VALID_SPOT_FACILITY_VALUES.has(facilityValue)) continue;
+    mergedFacilities[facilityKey] = facilityValue;
+  }
+  for (const [key, value] of Object.entries(overrideFacilities)) {
+    const facilityKey = String(key).trim().toLowerCase();
+    const facilityValue = typeof value === "string" ?
+      value.trim().toLowerCase() :
+      "";
+    if (!VALID_SPOT_FACILITY_KEYS.has(facilityKey)) continue;
+    if (!VALID_SPOT_FACILITY_VALUES.has(facilityValue)) continue;
+    mergedFacilities[facilityKey] = facilityValue;
+  }
+  if (Object.keys(mergedFacilities).length > 0) {
+    merged.spotFacilities = mergedFacilities;
+  }
+
+  const baseAccess = hasBase && typeof baseDefaults.spotAccess === "string" ?
+    baseDefaults.spotAccess.trim().toLowerCase() :
+    null;
+  if (baseAccess && VALID_SPOT_ACCESS_VALUES.has(baseAccess)) {
+    merged.spotAccess = baseAccess;
+  }
+  const overrideAccess = hasOverride && typeof overrideDefaults.spotAccess === "string" ?
+    overrideDefaults.spotAccess.trim().toLowerCase() :
+    null;
+  if (overrideAccess && VALID_SPOT_ACCESS_VALUES.has(overrideAccess)) {
+    merged.spotAccess = overrideAccess;
+  }
+
+  return Object.keys(merged).length > 0 ? merged : null;
+}
+
+/**
+ * Returns effective defaults for a spot based on source + folder scope.
+ * @param {Object|null} sourceDefaults
+ * @param {Object<string, Object>} folderDefaultsLookup
+ * @param {string|null|undefined} folderName
+ * @return {Object|null}
+ */
+function getEffectiveSpotAttributeDefaults(
+    sourceDefaults,
+    folderDefaultsLookup,
+    folderName,
+) {
+  const folderKey = typeof folderName === "string" ?
+    folderName.trim().toLowerCase() :
+    "";
+  const folderDefaults = folderKey ? folderDefaultsLookup[folderKey] || null : null;
+  return mergeSpotAttributeDefaults(sourceDefaults, folderDefaults);
+}
+
+/**
+ * Merges unique string arrays preserving original order.
+ * @param {Array<string>} existingValues
+ * @param {Array<string>} valuesToAdd
+ * @return {Array<string>}
+ */
+function mergeUniqueStringArrays(existingValues, valuesToAdd) {
+  const merged = normalizeExistingStringArray(existingValues);
+  for (const value of normalizeExistingStringArray(valuesToAdd)) {
+    if (!merged.includes(value)) {
+      merged.push(value);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Compares two string arrays for exact equality.
+ * @param {Array<string>} a
+ * @param {Array<string>} b
+ * @return {boolean}
+ */
+function areStringArraysEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Applies defaults into spotData. Returns true if any field changed.
+ * @param {Object} spotData
+ * @param {Object|null} defaults
+ * @return {boolean}
+ */
+function applySpotAttributeDefaultsToSpotData(spotData, defaults) {
+  if (!spotData || !defaults) return false;
+  let changed = false;
+
+  if (
+    typeof defaults.spotAccess === "string" &&
+    VALID_SPOT_ACCESS_VALUES.has(defaults.spotAccess)
+  ) {
+    if (spotData.spotAccess !== defaults.spotAccess) {
+      spotData.spotAccess = defaults.spotAccess;
+      changed = true;
+    }
+  }
+
+  if (Array.isArray(defaults.spotFeatures) && defaults.spotFeatures.length > 0) {
+    const existingSpotFeatures = normalizeExistingStringArray(spotData.spotFeatures);
+    const mergedSpotFeatures = mergeUniqueStringArrays(
+        existingSpotFeatures,
+        defaults.spotFeatures,
+    );
+    if (!areStringArraysEqual(existingSpotFeatures, mergedSpotFeatures)) {
+      spotData.spotFeatures = mergedSpotFeatures;
+      changed = true;
+    }
+  }
+
+  if (Array.isArray(defaults.goodFor) && defaults.goodFor.length > 0) {
+    const existingGoodFor = normalizeExistingStringArray(spotData.goodFor);
+    const mergedGoodFor = mergeUniqueStringArrays(
+        existingGoodFor,
+        defaults.goodFor,
+    );
+    if (!areStringArraysEqual(existingGoodFor, mergedGoodFor)) {
+      spotData.goodFor = mergedGoodFor;
+      changed = true;
+    }
+  }
+
+  if (
+    defaults.spotFacilities &&
+    typeof defaults.spotFacilities === "object" &&
+    !Array.isArray(defaults.spotFacilities)
+  ) {
+    const existingFacilities = (
+      spotData.spotFacilities &&
+      typeof spotData.spotFacilities === "object" &&
+      !Array.isArray(spotData.spotFacilities)
+    ) ? {...spotData.spotFacilities} : {};
+    const mergedFacilities = {...existingFacilities};
+    let facilitiesChanged = false;
+    for (const [key, value] of Object.entries(defaults.spotFacilities)) {
+      if (mergedFacilities[key] !== value) {
+        mergedFacilities[key] = value;
+        facilitiesChanged = true;
+      }
+    }
+    if (facilitiesChanged) {
+      spotData.spotFacilities = mergedFacilities;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+/**
+ * Builds a Firestore update payload for spot attributes.
+ * @param {Object} spotData
+ * @return {Object}
+ */
+function buildSpotAttributeUpdateData(spotData) {
+  return cleanUndefinedValues({
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    spotAccess: spotData.spotAccess,
+    spotFeatures: spotData.spotFeatures,
+    goodFor: spotData.goodFor,
+    spotFacilities: spotData.spotFacilities,
+  });
+}
+
+/**
+ * Queues a batched update and flushes when needed.
+ * @param {Object} batchState
+ * @param {FirebaseFirestore.DocumentReference} docRef
+ * @param {Object} updateData
+ * @return {Promise<void>}
+ */
+async function queueBatchUpdate(batchState, docRef, updateData) {
+  batchState.batch.update(docRef, updateData);
+  batchState.operationCount += 1;
+  if (batchState.operationCount >= 450) {
+    await batchState.batch.commit();
+    batchState.batch = db.batch();
+    batchState.operationCount = 0;
+  }
+}
+
+/**
+ * Flushes pending batched writes if any remain.
+ * @param {Object} batchState
+ * @return {Promise<void>}
+ */
+async function commitPendingBatch(batchState) {
+  if (batchState.operationCount > 0) {
+    await batchState.batch.commit();
+    batchState.batch = db.batch();
+    batchState.operationCount = 0;
+  }
+}
+
 // ========== Ranked Spots within Bounds ==========
 /**
  * Returns the top N spots within given map bounds ranked by ranking field,
@@ -2443,6 +2882,26 @@ async function processSyncSource(source, sourceId, apiKey, updateImagesForExisti
     );
   }
 
+  const sourceDefaultSpotAttributes = normalizeSpotAttributeDefaults(
+      source.defaultSpotAttributes,
+  );
+  const folderSpotAttributeDefaults = normalizeFolderSpotAttributeDefaults(
+      source.folderSpotAttributes,
+  );
+  const folderSpotAttributeDefaultsLookup = buildFolderDefaultsLookup(
+      folderSpotAttributeDefaults,
+  );
+  const hasAnySpotAttributeDefaults = Boolean(sourceDefaultSpotAttributes) ||
+    Object.keys(folderSpotAttributeDefaultsLookup).length > 0;
+
+  if (hasAnySpotAttributeDefaults) {
+    console.log(
+        `[ATTRIBUTE DEFAULTS] Source ${source.name} has defaults configured ` +
+        `(source=${Boolean(sourceDefaultSpotAttributes)}, ` +
+        `folders=${Object.keys(folderSpotAttributeDefaultsLookup).length})`,
+    );
+  }
+
   // Clear file buffer to free memory
   fileBuffer = null;
 
@@ -2716,6 +3175,11 @@ async function processSyncSource(source, sourceId, apiKey, updateImagesForExisti
 
     // Clean the description to remove HTML
     const cleanedDescription = cleanDescription(description);
+    const effectiveSpotAttributeDefaults = getEffectiveSpotAttributeDefaults(
+        sourceDefaultSpotAttributes,
+        folderSpotAttributeDefaultsLookup,
+        placemark.folderName,
+    );
 
     const spotData = {
       name: name.trim(),
@@ -2738,6 +3202,13 @@ async function processSyncSource(source, sourceId, apiKey, updateImagesForExisti
       } else {
         spotData.folderName = null;
       }
+    }
+
+    if (existingSpots.empty && effectiveSpotAttributeDefaults) {
+      applySpotAttributeDefaultsToSpotData(
+          spotData,
+          effectiveSpotAttributeDefaults,
+      );
     }
 
     // Add YouTube video IDs
@@ -3472,6 +3943,8 @@ exports.createSyncSource = onCall(
           isActive = true,
           includeFolders,
           recordFolderName,
+          defaultSpotAttributes,
+          folderSpotAttributes,
           lightSyncSchedule,
           fullSyncSchedule,
           autoSyncEnabled = false,
@@ -3509,6 +3982,20 @@ exports.createSyncSource = onCall(
 
         if (typeof recordFolderName === "boolean") {
           sourceData.recordFolderName = recordFolderName;
+        }
+
+        const normalizedDefaultSpotAttributes = normalizeSpotAttributeDefaults(
+            defaultSpotAttributes,
+        );
+        if (normalizedDefaultSpotAttributes) {
+          sourceData.defaultSpotAttributes = normalizedDefaultSpotAttributes;
+        }
+
+        const normalizedFolderSpotAttributes = normalizeFolderSpotAttributeDefaults(
+            folderSpotAttributes,
+        );
+        if (Object.keys(normalizedFolderSpotAttributes).length > 0) {
+          sourceData.folderSpotAttributes = normalizedFolderSpotAttributes;
         }
 
         if (lightSyncSchedule) {
@@ -3550,6 +4037,8 @@ exports.updateSyncSource = onCall(
           isActive,
           includeFolders,
           recordFolderName,
+          defaultSpotAttributes,
+          folderSpotAttributes,
           lightSyncSchedule,
           fullSyncSchedule,
           autoSyncEnabled,
@@ -3591,6 +4080,34 @@ exports.updateSyncSource = onCall(
             updateData.recordFolderName = recordFolderName;
           } else if (recordFolderName === null) {
             updateData.recordFolderName = admin.firestore.FieldValue.delete();
+          }
+        }
+        if (defaultSpotAttributes !== undefined) {
+          if (defaultSpotAttributes === null) {
+            updateData.defaultSpotAttributes = admin.firestore.FieldValue.delete();
+          } else {
+            const normalizedDefaultSpotAttributes = normalizeSpotAttributeDefaults(
+                defaultSpotAttributes,
+            );
+            if (normalizedDefaultSpotAttributes) {
+              updateData.defaultSpotAttributes = normalizedDefaultSpotAttributes;
+            } else {
+              updateData.defaultSpotAttributes = admin.firestore.FieldValue.delete();
+            }
+          }
+        }
+        if (folderSpotAttributes !== undefined) {
+          if (folderSpotAttributes === null) {
+            updateData.folderSpotAttributes = admin.firestore.FieldValue.delete();
+          } else {
+            const normalizedFolderSpotAttributes = normalizeFolderSpotAttributeDefaults(
+                folderSpotAttributes,
+            );
+            if (Object.keys(normalizedFolderSpotAttributes).length > 0) {
+              updateData.folderSpotAttributes = normalizedFolderSpotAttributes;
+            } else {
+              updateData.folderSpotAttributes = admin.firestore.FieldValue.delete();
+            }
           }
         }
         if (lightSyncSchedule !== undefined) {
@@ -3735,6 +4252,211 @@ exports.getSyncSource = onCall({region: "europe-west1"}, async (request) => {
     throw new Error(`Failed to get sync source: ${error.message}`);
   }
 });
+
+// Admin callable to backfill source/folder default spot attributes.
+exports.backfillSourceSpotAttributes = onCall(
+    {
+      region: "europe-west1",
+      timeoutSeconds: 540,
+      memory: "1GiB",
+    },
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const {sourceId = null} = request.data || {};
+        if (sourceId !== null && sourceId !== undefined && typeof sourceId !== "string") {
+          throw new Error("sourceId must be a string when provided");
+        }
+
+        let sourceDocs = [];
+        if (sourceId && sourceId.trim().length > 0) {
+          const sourceDoc = await db.collection("syncSources").doc(sourceId).get();
+          if (!sourceDoc.exists) {
+            throw new Error(`Sync source with ID ${sourceId} not found`);
+          }
+          sourceDocs = [sourceDoc];
+        } else {
+          const sourcesSnapshot = await db.collection("syncSources").get();
+          sourceDocs = sourcesSnapshot.docs;
+        }
+
+        const batchState = {
+          batch: db.batch(),
+          operationCount: 0,
+        };
+
+        const results = [];
+        let totalSpotsScanned = 0;
+        let totalSpotsUpdated = 0;
+        let totalOriginalSpotsUpdated = 0;
+        let sourcesWithDefaults = 0;
+        let sourcesSkippedNoDefaults = 0;
+        let sourcesFailed = 0;
+
+        for (const sourceDoc of sourceDocs) {
+          const sourceData = sourceDoc.data() || {};
+          const sourceName = sourceData.name || sourceDoc.id;
+
+          try {
+            const sourceDefaults = normalizeSpotAttributeDefaults(
+                sourceData.defaultSpotAttributes,
+            );
+            const folderDefaults = normalizeFolderSpotAttributeDefaults(
+                sourceData.folderSpotAttributes,
+            );
+            const folderDefaultsLookup = buildFolderDefaultsLookup(folderDefaults);
+            const hasDefaults = Boolean(sourceDefaults) ||
+              Object.keys(folderDefaultsLookup).length > 0;
+
+            if (!hasDefaults) {
+              sourcesSkippedNoDefaults += 1;
+              results.push({
+                sourceId: sourceDoc.id,
+                sourceName: sourceName,
+                skipped: true,
+                reason: "No default attributes configured",
+                spotsScanned: 0,
+                spotsUpdated: 0,
+                originalSpotsUpdated: 0,
+              });
+              continue;
+            }
+
+            sourcesWithDefaults += 1;
+
+            const sourceResult = {
+              sourceId: sourceDoc.id,
+              sourceName: sourceName,
+              skipped: false,
+              spotsScanned: 0,
+              spotsUpdated: 0,
+              originalSpotsUpdated: 0,
+            };
+
+            const sourceSpotsSnapshot = await db
+                .collection("spots")
+                .where("spotSource", "==", sourceDoc.id)
+                .get();
+
+            sourceResult.spotsScanned = sourceSpotsSnapshot.size;
+            totalSpotsScanned += sourceSpotsSnapshot.size;
+
+            // For duplicate spots, accumulate defaults to also apply to originals.
+            const originalDefaultsBySpotId = new Map();
+
+            for (const spotDoc of sourceSpotsSnapshot.docs) {
+              const currentSpotData = spotDoc.data() || {};
+              const effectiveDefaults = getEffectiveSpotAttributeDefaults(
+                  sourceDefaults,
+                  folderDefaultsLookup,
+                  currentSpotData.folderName,
+              );
+              if (!effectiveDefaults) {
+                continue;
+              }
+
+              const mutableSpotData = {...currentSpotData};
+              const changedSpot = applySpotAttributeDefaultsToSpotData(
+                  mutableSpotData,
+                  effectiveDefaults,
+              );
+              if (changedSpot) {
+                await queueBatchUpdate(
+                    batchState,
+                    spotDoc.ref,
+                    buildSpotAttributeUpdateData(mutableSpotData),
+                );
+                sourceResult.spotsUpdated += 1;
+                totalSpotsUpdated += 1;
+              }
+
+              const duplicateOfId = typeof currentSpotData.duplicateOf === "string" ?
+                currentSpotData.duplicateOf.trim() :
+                "";
+              if (duplicateOfId) {
+                const previousDefaults = originalDefaultsBySpotId.get(duplicateOfId) || null;
+                const mergedDefaults = mergeSpotAttributeDefaults(
+                    previousDefaults,
+                    effectiveDefaults,
+                );
+                if (mergedDefaults) {
+                  originalDefaultsBySpotId.set(duplicateOfId, mergedDefaults);
+                }
+              }
+            }
+
+            const originalIds = Array.from(originalDefaultsBySpotId.keys());
+            for (let i = 0; i < originalIds.length; i += 200) {
+              const chunk = originalIds.slice(i, i + 200);
+              const refs = chunk.map((id) => db.collection("spots").doc(id));
+              const originalDocs = await db.getAll(...refs);
+
+              for (const originalDoc of originalDocs) {
+                if (!originalDoc.exists) continue;
+
+                const defaultsForOriginal = originalDefaultsBySpotId.get(originalDoc.id);
+                if (!defaultsForOriginal) continue;
+
+                const mutableOriginalData = {...(originalDoc.data() || {})};
+                const changedOriginal = applySpotAttributeDefaultsToSpotData(
+                    mutableOriginalData,
+                    defaultsForOriginal,
+                );
+                if (changedOriginal) {
+                  await queueBatchUpdate(
+                      batchState,
+                      originalDoc.ref,
+                      buildSpotAttributeUpdateData(mutableOriginalData),
+                  );
+                  sourceResult.originalSpotsUpdated += 1;
+                  totalOriginalSpotsUpdated += 1;
+                }
+              }
+            }
+
+            results.push(sourceResult);
+          } catch (sourceError) {
+            sourcesFailed += 1;
+            console.error(
+                `Failed backfilling spot attributes for source ${sourceDoc.id}:`,
+                sourceError,
+            );
+            results.push({
+              sourceId: sourceDoc.id,
+              sourceName: sourceName,
+              skipped: false,
+              spotsScanned: 0,
+              spotsUpdated: 0,
+              originalSpotsUpdated: 0,
+              error: sourceError.message,
+            });
+          }
+        }
+
+        await commitPendingBatch(batchState);
+
+        return {
+          success: true,
+          message: sourceId && sourceId.trim().length > 0 ?
+            `Backfill completed for source ${sourceId}` :
+            `Backfill completed for ${sourceDocs.length} source(s)`,
+          summary: {
+            sourcesRequested: sourceDocs.length,
+            sourcesWithDefaults: sourcesWithDefaults,
+            sourcesSkippedNoDefaults: sourcesSkippedNoDefaults,
+            sourcesFailed: sourcesFailed,
+            spotsScanned: totalSpotsScanned,
+            spotsUpdated: totalSpotsUpdated,
+            originalSpotsUpdated: totalOriginalSpotsUpdated,
+          },
+          results: results,
+        };
+      } catch (error) {
+        console.error("Error backfilling source spot attributes:", error);
+        throw new Error(`Failed to backfill source spot attributes: ${error.message}`);
+      }
+    },
+);
 
 // Admin tool: set or unset a user's admin status
 exports.setUserAdmin = onCall({region: "europe-west1"}, async (request) => {

--- a/lib/screens/admin/sync_sources_screen.dart
+++ b/lib/screens/admin/sync_sources_screen.dart
@@ -6,8 +6,10 @@ import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../constants/spot_attributes.dart';
 import '../../services/auth_service.dart';
 import '../../services/sync_source_service.dart';
+import '../../widgets/spot_form/attributes_section.dart';
 
 class SyncSourcesScreen extends StatefulWidget {
   const SyncSourcesScreen({super.key});
@@ -208,6 +210,11 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
             icon: const Icon(Icons.update),
             tooltip: 'Update Spot Source Names',
             onPressed: () => _showUpdateSourceNamesDialog(context),
+          ),
+          IconButton(
+            icon: const Icon(Icons.auto_fix_high),
+            tooltip: 'Backfill Source Attributes',
+            onPressed: () => _showBackfillSpotAttributesDialog(context),
           ),
           IconButton(
             icon: const Icon(Icons.add),
@@ -494,6 +501,32 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
                               label: Text(folder, style: const TextStyle(fontSize: 11)),
                               backgroundColor: Colors.blue.shade100,
                             )),
+                          ],
+                        ),
+                      ],
+                      if ((s.defaultSpotAttributes?.isNotEmpty ?? false) ||
+                          (s.folderSpotAttributes?.isNotEmpty ?? false)) ...[
+                        const SizedBox(height: 4),
+                        Wrap(
+                          spacing: 4,
+                          runSpacing: 2,
+                          children: [
+                            if (s.defaultSpotAttributes?.isNotEmpty ?? false)
+                              Chip(
+                                label: const Text(
+                                  'Source defaults enabled',
+                                  style: TextStyle(fontSize: 11),
+                                ),
+                                backgroundColor: Colors.teal.shade100,
+                              ),
+                            if (s.folderSpotAttributes?.isNotEmpty ?? false)
+                              Chip(
+                                label: Text(
+                                  'Folder defaults: ${s.folderSpotAttributes!.length}',
+                                  style: const TextStyle(fontSize: 11),
+                                ),
+                                backgroundColor: Colors.indigo.shade100,
+                              ),
                           ],
                         ),
                       ],
@@ -1255,6 +1288,147 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
     }
   }
 
+  Future<void> _showBackfillSpotAttributesDialog(BuildContext context) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Backfill Source Attributes'),
+          content: const Text(
+            'This will apply configured source/folder default attributes to existing spots. '
+            'If a matching source spot is marked as duplicateOf another spot, the defaults are also merged into that original spot.\n\n'
+            'Do you want to backfill all sources or select one source?'
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('All Sources'),
+              onPressed: () async {
+                Navigator.of(context).pop();
+                await _runBackfillSpotAttributes(context, null);
+              },
+            ),
+            TextButton(
+              child: const Text('Select Source'),
+              onPressed: () {
+                Navigator.of(context).pop();
+                _showBackfillSourceSelectionDialog(context);
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _showBackfillSourceSelectionDialog(BuildContext context) async {
+    final syncService = context.read<SyncSourceService>();
+    final sortedSources = [...syncService.sources]..sort((a, b) => a.name.compareTo(b.name));
+
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Select Source'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: sortedSources.length,
+              itemBuilder: (context, index) {
+                final source = sortedSources[index];
+                return ListTile(
+                  title: Text(source.name),
+                  subtitle: Text(source.id),
+                  onTap: () async {
+                    Navigator.of(context).pop();
+                    await _runBackfillSpotAttributes(context, source.id);
+                  },
+                );
+              },
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _runBackfillSpotAttributes(BuildContext context, String? sourceId) async {
+    final syncService = context.read<SyncSourceService>();
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+
+    late NavigatorState navigator;
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext dialogContext) {
+        navigator = Navigator.of(dialogContext);
+        return const AlertDialog(
+          content: Row(
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(width: 16),
+              Text('Backfilling source attributes...'),
+            ],
+          ),
+        );
+      },
+    );
+
+    try {
+      final result = await syncService.backfillSourceSpotAttributes(sourceId: sourceId);
+
+      navigator.pop();
+
+      if (!mounted) return;
+      if (result != null && result['success'] == true) {
+        final summary = result['summary'] as Map<String, dynamic>?;
+        final message = summary != null
+            ? 'Backfill done! Sources: ${summary['sourcesRequested']}, '
+                'spots updated: ${summary['spotsUpdated']}, '
+                'originals updated: ${summary['originalSpotsUpdated']}'
+            : (result['message']?.toString() ?? 'Backfill completed');
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(message),
+            backgroundColor: Colors.green,
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      } else {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(syncService.error ?? 'Backfill failed'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } catch (e) {
+      navigator.pop();
+      if (!mounted) return;
+      scaffoldMessenger.showSnackBar(
+        SnackBar(
+          content: Text('Backfill failed: $e'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
   Future<void> _showUpdateSourceNamesDialog(BuildContext context) async {
     return showDialog<void>(
       context: context,
@@ -1417,11 +1591,14 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
   late final TextEditingController publicUrlCtrl;
   late final TextEditingController instagramHandleCtrl;
   late final TextEditingController includeFoldersCtrl;
+  late final TextEditingController folderRuleNameCtrl;
   late final TextEditingController lightSyncScheduleCtrl;
   late final TextEditingController fullSyncScheduleCtrl;
   late bool isActive;
   late bool recordFolderName;
   late bool autoSyncEnabled;
+  late _EditableSpotAttributes _sourceDefaultAttributes;
+  final Map<String, _EditableSpotAttributes> _folderDefaultAttributes = {};
 
   @override
   void initState() {
@@ -1436,11 +1613,23 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
           ? ''
           : widget.source!.includeFolders!.join('\n'),
     );
+    folderRuleNameCtrl = TextEditingController();
     lightSyncScheduleCtrl = TextEditingController(text: widget.source?.lightSyncSchedule ?? '');
     fullSyncScheduleCtrl = TextEditingController(text: widget.source?.fullSyncSchedule ?? '');
     isActive = widget.source?.isActive ?? true;
     recordFolderName = widget.source?.recordFolderName ?? false;
     autoSyncEnabled = widget.source?.autoSyncEnabled ?? false;
+    _sourceDefaultAttributes = _EditableSpotAttributes.fromMap(
+      widget.source?.defaultSpotAttributes,
+    );
+    final existingFolderDefaults = widget.source?.folderSpotAttributes ?? const {};
+    for (final entry in existingFolderDefaults.entries) {
+      final folderName = entry.key.trim();
+      if (folderName.isEmpty) continue;
+      _folderDefaultAttributes[folderName] = _EditableSpotAttributes.fromMap(
+        entry.value,
+      );
+    }
   }
 
   @override
@@ -1451,9 +1640,51 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
     publicUrlCtrl.dispose();
     instagramHandleCtrl.dispose();
     includeFoldersCtrl.dispose();
+    folderRuleNameCtrl.dispose();
     lightSyncScheduleCtrl.dispose();
     fullSyncScheduleCtrl.dispose();
     super.dispose();
+  }
+
+  String? _findExistingFolderRuleKey(String folderName) {
+    final target = folderName.trim().toLowerCase();
+    for (final key in _folderDefaultAttributes.keys) {
+      if (key.trim().toLowerCase() == target) {
+        return key;
+      }
+    }
+    return null;
+  }
+
+  void _addFolderRule(String rawFolderName) {
+    final folderName = rawFolderName.trim();
+    if (folderName.isEmpty) return;
+
+    final existingKey = _findExistingFolderRuleKey(folderName);
+    if (existingKey != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Folder rule for "$existingKey" already exists'),
+        ),
+      );
+      return;
+    }
+
+    setState(() {
+      _folderDefaultAttributes[folderName] = _EditableSpotAttributes.empty();
+      folderRuleNameCtrl.clear();
+    });
+  }
+
+  Map<String, dynamic>? _serializeFolderDefaultAttributes() {
+    final result = <String, dynamic>{};
+    for (final entry in _folderDefaultAttributes.entries) {
+      final serialized = entry.value.toMapOrNull();
+      if (serialized != null) {
+        result[entry.key] = serialized;
+      }
+    }
+    return result.isEmpty ? null : result;
   }
 
   @override
@@ -1506,6 +1737,199 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
                 maxLines: 5,
                 minLines: 3,
               ),
+              const SizedBox(height: 8),
+              const Divider(),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Default Spot Attributes',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ),
+              const SizedBox(height: 4),
+              const Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Applied to all newly created spots in this source.',
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ),
+              const SizedBox(height: 8),
+              SpotAttributesSection(
+                selectedAccess: _sourceDefaultAttributes.selectedAccess,
+                selectedFeatures: _sourceDefaultAttributes.selectedFeatures,
+                selectedFacilities: _sourceDefaultAttributes.selectedFacilities,
+                selectedGoodFor: _sourceDefaultAttributes.selectedGoodFor,
+                onAccessChanged: (value) {
+                  setState(() {
+                    _sourceDefaultAttributes.selectedAccess = value;
+                  });
+                },
+                onToggleFeature: (key, selected) {
+                  setState(() {
+                    if (selected) {
+                      _sourceDefaultAttributes.selectedFeatures.add(key);
+                    } else {
+                      _sourceDefaultAttributes.selectedFeatures.remove(key);
+                    }
+                  });
+                },
+                onFacilityChanged: (key, value) {
+                  setState(() {
+                    if (value == 'unknown') {
+                      _sourceDefaultAttributes.selectedFacilities.remove(key);
+                    } else {
+                      _sourceDefaultAttributes.selectedFacilities[key] = value;
+                    }
+                  });
+                },
+                onToggleGoodFor: (key, selected) {
+                  setState(() {
+                    if (selected) {
+                      _sourceDefaultAttributes.selectedGoodFor.add(key);
+                    } else {
+                      _sourceDefaultAttributes.selectedGoodFor.remove(key);
+                    }
+                  });
+                },
+              ),
+              const SizedBox(height: 8),
+              const Divider(),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Folder-specific Defaults',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ),
+              const SizedBox(height: 4),
+              const Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Optional overrides/additions for newly created spots in specific folders.',
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: folderRuleNameCtrl,
+                      decoration: const InputDecoration(
+                        labelText: 'Folder name',
+                        hintText: 'e.g. Dry spots',
+                      ),
+                      onFieldSubmitted: _addFolderRule,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: () => _addFolderRule(folderRuleNameCtrl.text),
+                    child: const Text('Add'),
+                  ),
+                ],
+              ),
+              if (widget.source?.allFolders != null &&
+                  widget.source!.allFolders!.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: widget.source!.allFolders!
+                        .where((folder) =>
+                            _findExistingFolderRuleKey(folder) == null)
+                        .map((folder) => ActionChip(
+                              label: Text(folder),
+                              onPressed: () => _addFolderRule(folder),
+                            ))
+                        .toList(),
+                  ),
+                ),
+              ],
+              if (_folderDefaultAttributes.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                ..._folderDefaultAttributes.entries.map((entry) {
+                  final folderName = entry.key;
+                  final folderAttributes = entry.value;
+                  return Card(
+                    margin: const EdgeInsets.symmetric(vertical: 6),
+                    child: ExpansionTile(
+                      tilePadding: const EdgeInsets.symmetric(horizontal: 12),
+                      title: Text(folderName),
+                      subtitle: Text(folderAttributes.summary),
+                      children: [
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton.icon(
+                            onPressed: () {
+                              setState(() {
+                                _folderDefaultAttributes.remove(folderName);
+                              });
+                            },
+                            icon: const Icon(Icons.delete, size: 18),
+                            label: const Text('Remove rule'),
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.red,
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                          child: SpotAttributesSection(
+                            selectedAccess:
+                                folderAttributes.selectedAccess,
+                            selectedFeatures:
+                                folderAttributes.selectedFeatures,
+                            selectedFacilities:
+                                folderAttributes.selectedFacilities,
+                            selectedGoodFor:
+                                folderAttributes.selectedGoodFor,
+                            onAccessChanged: (value) {
+                              setState(() {
+                                folderAttributes.selectedAccess = value;
+                              });
+                            },
+                            onToggleFeature: (key, selected) {
+                              setState(() {
+                                if (selected) {
+                                  folderAttributes.selectedFeatures.add(key);
+                                } else {
+                                  folderAttributes.selectedFeatures.remove(key);
+                                }
+                              });
+                            },
+                            onFacilityChanged: (key, value) {
+                              setState(() {
+                                if (value == 'unknown') {
+                                  folderAttributes.selectedFacilities.remove(key);
+                                } else {
+                                  folderAttributes.selectedFacilities[key] = value;
+                                }
+                              });
+                            },
+                            onToggleGoodFor: (key, selected) {
+                              setState(() {
+                                if (selected) {
+                                  folderAttributes.selectedGoodFor.add(key);
+                                } else {
+                                  folderAttributes.selectedGoodFor.remove(key);
+                                }
+                              });
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }),
+              ],
               const SizedBox(height: 8),
               SwitchListTile(
                 contentPadding: EdgeInsets.zero,
@@ -1586,6 +2010,10 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
           onPressed: () async {
             if (!formKey.currentState!.validate()) return;
             final service = context.read<SyncSourceService>();
+            final sourceDefaultAttributesPayload =
+                _sourceDefaultAttributes.toMapOrNull();
+            final folderDefaultAttributesPayload =
+                _serializeFolderDefaultAttributes();
             bool ok;
             if (widget.source == null) {
               ok = await service.createSource(
@@ -1603,6 +2031,8 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
                         .where((s) => s.isNotEmpty)
                         .toList(),
                 recordFolderName: recordFolderName,
+                defaultSpotAttributes: sourceDefaultAttributesPayload,
+                folderSpotAttributes: folderDefaultAttributesPayload,
                 lightSyncSchedule: lightSyncScheduleCtrl.text.trim().isEmpty ? null : lightSyncScheduleCtrl.text.trim(),
                 fullSyncSchedule: fullSyncScheduleCtrl.text.trim().isEmpty ? null : fullSyncScheduleCtrl.text.trim(),
                 autoSyncEnabled: autoSyncEnabled,
@@ -1624,6 +2054,9 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
                         .where((s) => s.isNotEmpty)
                         .toList(),
                 recordFolderName: recordFolderName,
+                defaultSpotAttributes: sourceDefaultAttributesPayload,
+                folderSpotAttributes: folderDefaultAttributesPayload,
+                updateSpotAttributeDefaults: true,
                 lightSyncSchedule: lightSyncScheduleCtrl.text.trim(),
                 fullSyncSchedule: fullSyncScheduleCtrl.text.trim(),
                 autoSyncEnabled: autoSyncEnabled,
@@ -1642,6 +2075,132 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
         ),
       ],
     );
+  }
+}
+
+class _EditableSpotAttributes {
+  _EditableSpotAttributes({
+    required this.selectedAccess,
+    required Set<String> selectedFeatures,
+    required Map<String, String> selectedFacilities,
+    required Set<String> selectedGoodFor,
+  })  : selectedFeatures = selectedFeatures,
+        selectedFacilities = selectedFacilities,
+        selectedGoodFor = selectedGoodFor;
+
+  factory _EditableSpotAttributes.empty() {
+    return _EditableSpotAttributes(
+      selectedAccess: null,
+      selectedFeatures: <String>{},
+      selectedFacilities: <String, String>{},
+      selectedGoodFor: <String>{},
+    );
+  }
+
+  factory _EditableSpotAttributes.fromMap(Map<String, dynamic>? map) {
+    if (map == null) {
+      return _EditableSpotAttributes.empty();
+    }
+
+    final validAccess = SpotAttributes.getKeys('access').toSet();
+    final validFeatures = SpotAttributes.getKeys('features').toSet();
+    final validGoodFor = SpotAttributes.getKeys('goodFor').toSet();
+    final validFacilities = SpotAttributes.getKeys('facilities').toSet();
+
+    String? selectedAccess;
+    final rawAccess = map['spotAccess'];
+    if (rawAccess is String && validAccess.contains(rawAccess)) {
+      selectedAccess = rawAccess;
+    }
+
+    final selectedFeatures = <String>{};
+    final rawFeatures = map['spotFeatures'];
+    if (rawFeatures is List) {
+      for (final value in rawFeatures) {
+        if (value is String && validFeatures.contains(value)) {
+          selectedFeatures.add(value);
+        }
+      }
+    }
+
+    final selectedGoodFor = <String>{};
+    final rawGoodFor = map['goodFor'];
+    if (rawGoodFor is List) {
+      for (final value in rawGoodFor) {
+        if (value is String && validGoodFor.contains(value)) {
+          selectedGoodFor.add(value);
+        }
+      }
+    }
+
+    final selectedFacilities = <String, String>{};
+    final rawFacilities = map['spotFacilities'];
+    if (rawFacilities is Map) {
+      for (final entry in rawFacilities.entries) {
+        final key = entry.key.toString();
+        final value = entry.value?.toString();
+        if (!validFacilities.contains(key)) continue;
+        if (value == 'yes' || value == 'no') {
+          selectedFacilities[key] = value!;
+        }
+      }
+    }
+
+    return _EditableSpotAttributes(
+      selectedAccess: selectedAccess,
+      selectedFeatures: selectedFeatures,
+      selectedFacilities: selectedFacilities,
+      selectedGoodFor: selectedGoodFor,
+    );
+  }
+
+  String? selectedAccess;
+  final Set<String> selectedFeatures;
+  final Map<String, String> selectedFacilities;
+  final Set<String> selectedGoodFor;
+
+  Map<String, dynamic>? toMapOrNull() {
+    final map = <String, dynamic>{};
+    if (selectedAccess != null && selectedAccess!.isNotEmpty) {
+      map['spotAccess'] = selectedAccess;
+    }
+    if (selectedFeatures.isNotEmpty) {
+      final list = selectedFeatures.toList()..sort();
+      map['spotFeatures'] = list;
+    }
+    if (selectedGoodFor.isNotEmpty) {
+      final list = selectedGoodFor.toList()..sort();
+      map['goodFor'] = list;
+    }
+    if (selectedFacilities.isNotEmpty) {
+      final cleaned = <String, String>{};
+      for (final entry in selectedFacilities.entries) {
+        if (entry.value == 'yes' || entry.value == 'no') {
+          cleaned[entry.key] = entry.value;
+        }
+      }
+      if (cleaned.isNotEmpty) {
+        map['spotFacilities'] = cleaned;
+      }
+    }
+    return map.isEmpty ? null : map;
+  }
+
+  String get summary {
+    final parts = <String>[];
+    if (selectedAccess != null) {
+      parts.add('Access: ${SpotAttributes.getLabel('access', selectedAccess!)}');
+    }
+    if (selectedFeatures.isNotEmpty) {
+      parts.add('${selectedFeatures.length} feature${selectedFeatures.length == 1 ? '' : 's'}');
+    }
+    if (selectedGoodFor.isNotEmpty) {
+      parts.add('${selectedGoodFor.length} good-for');
+    }
+    if (selectedFacilities.isNotEmpty) {
+      parts.add('${selectedFacilities.length} facilit${selectedFacilities.length == 1 ? 'y' : 'ies'}');
+    }
+    return parts.isEmpty ? 'No attributes configured' : parts.join(' • ');
   }
 }
 

--- a/lib/services/sync_source_service.dart
+++ b/lib/services/sync_source_service.dart
@@ -40,6 +40,8 @@ class SyncSource {
   final List<String>? includeFolders; // Optional list of folders to include
   final bool? recordFolderName; // Whether to store folder name on spots
   final List<String>? allFolders; // List of all folders found during sync (when recordFolderName is true)
+  final Map<String, dynamic>? defaultSpotAttributes; // Defaults for all new spots in this source
+  final Map<String, Map<String, dynamic>>? folderSpotAttributes; // Folder-specific defaults for new spots
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final DateTime? lastSyncAt;
@@ -64,6 +66,8 @@ class SyncSource {
     this.includeFolders,
     this.recordFolderName,
     this.allFolders,
+    this.defaultSpotAttributes,
+    this.folderSpotAttributes,
     this.createdAt,
     this.updatedAt,
     this.lastSyncAt,
@@ -94,6 +98,8 @@ class SyncSource {
       allFolders: data['allFolders'] != null
           ? List<String>.from((data['allFolders'] as List).map((e) => e.toString()))
           : null,
+      defaultSpotAttributes: _parseDefaultSpotAttributes(data['defaultSpotAttributes']),
+      folderSpotAttributes: _parseFolderSpotAttributes(data['folderSpotAttributes']),
       createdAt: _parseTimestamp(data['createdAt']),
       updatedAt: _parseTimestamp(data['updatedAt']),
       lastSyncAt: _parseTimestamp(data['lastSyncAt']),
@@ -131,6 +137,26 @@ class SyncSource {
     }
     
     return null;
+  }
+
+  static Map<String, dynamic>? _parseDefaultSpotAttributes(dynamic raw) {
+    if (raw is! Map) return null;
+    final parsed = Map<String, dynamic>.from(raw);
+    return parsed.isEmpty ? null : parsed;
+  }
+
+  static Map<String, Map<String, dynamic>>? _parseFolderSpotAttributes(dynamic raw) {
+    if (raw is! Map) return null;
+    final parsed = <String, Map<String, dynamic>>{};
+    for (final entry in raw.entries) {
+      final key = entry.key.toString().trim();
+      if (key.isEmpty) continue;
+      if (entry.value is! Map) continue;
+      final valueMap = Map<String, dynamic>.from(entry.value as Map);
+      if (valueMap.isEmpty) continue;
+      parsed[key] = valueMap;
+    }
+    return parsed.isEmpty ? null : parsed;
   }
 }
 
@@ -256,6 +282,8 @@ class SyncSourceService extends ChangeNotifier {
     bool isActive = true,
     List<String>? includeFolders,
     bool? recordFolderName,
+    Map<String, dynamic>? defaultSpotAttributes,
+    Map<String, dynamic>? folderSpotAttributes,
     String? lightSyncSchedule,
     String? fullSyncSchedule,
     bool autoSyncEnabled = false,
@@ -271,6 +299,8 @@ class SyncSourceService extends ChangeNotifier {
         'isActive': isActive,
         if (includeFolders != null) 'includeFolders': includeFolders,
         if (recordFolderName != null) 'recordFolderName': recordFolderName,
+        if (defaultSpotAttributes != null) 'defaultSpotAttributes': defaultSpotAttributes,
+        if (folderSpotAttributes != null) 'folderSpotAttributes': folderSpotAttributes,
         if (lightSyncSchedule != null && lightSyncSchedule.isNotEmpty) 'lightSyncSchedule': lightSyncSchedule,
         if (fullSyncSchedule != null && fullSyncSchedule.isNotEmpty) 'fullSyncSchedule': fullSyncSchedule,
         'autoSyncEnabled': autoSyncEnabled,
@@ -298,6 +328,9 @@ class SyncSourceService extends ChangeNotifier {
     bool? isActive,
     List<String>? includeFolders,
     bool? recordFolderName,
+    Map<String, dynamic>? defaultSpotAttributes,
+    Map<String, dynamic>? folderSpotAttributes,
+    bool updateSpotAttributeDefaults = false,
     String? lightSyncSchedule,
     String? fullSyncSchedule,
     bool? autoSyncEnabled,
@@ -313,6 +346,10 @@ class SyncSourceService extends ChangeNotifier {
       if (isActive != null) payload['isActive'] = isActive;
       if (includeFolders != null) payload['includeFolders'] = includeFolders;
       if (recordFolderName != null) payload['recordFolderName'] = recordFolderName;
+      if (updateSpotAttributeDefaults) {
+        payload['defaultSpotAttributes'] = defaultSpotAttributes;
+        payload['folderSpotAttributes'] = folderSpotAttributes;
+      }
       if (lightSyncSchedule != null) {
         payload['lightSyncSchedule'] = lightSyncSchedule.isEmpty ? null : lightSyncSchedule;
       }
@@ -569,6 +606,26 @@ class SyncSourceService extends ChangeNotifier {
       return result.data;
     } catch (e) {
       _error = 'Failed to update spot source names: $e';
+      debugPrint(_error);
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<Map<String, dynamic>?> backfillSourceSpotAttributes({String? sourceId}) async {
+    try {
+      final callable = _functions.httpsCallable(
+        'backfillSourceSpotAttributes',
+        options: HttpsCallableOptions(
+          timeout: const Duration(minutes: 9),
+        ),
+      );
+      final result = await callable.call({
+        if (sourceId != null) 'sourceId': sourceId,
+      });
+      return result.data;
+    } catch (e) {
+      _error = 'Failed to backfill source spot attributes: $e';
       debugPrint(_error);
       notifyListeners();
       return null;


### PR DESCRIPTION
Add configurable default spot attributes at source and folder levels, applied to new spots and backfilled to existing ones with `duplicateOf` propagation.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-45562473-7d6b-4d12-84a0-10701bdc710d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45562473-7d6b-4d12-84a0-10701bdc710d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

