### PR TITLE
Spot list visibility options

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -179,6 +179,15 @@
       ]
     },
     {
+      "collectionGroup": "spotLists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "createdBy", "order": "ASCENDING" },
+        { "fieldPath": "visibility", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "spots",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -94,16 +94,32 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
-    // SpotLists collection - all lists are publicly readable, users can only manage their own lists
+    // SpotLists collection - users manage their own lists, visibility controls read access
     match /spotLists/{listId} {
-      // All lists are publicly readable
-      allow read: if true;
+      function hasValidSpotListVisibility(data) {
+        return !('visibility' in data) ||
+          data.visibility in ['public', 'unlisted', 'private'];
+      }
+      function canReadSpotList(data) {
+        // Legacy lists without visibility default to unlisted behavior.
+        return !('visibility' in data) ||
+          data.visibility == 'public' ||
+          data.visibility == 'unlisted';
+      }
+
+      // Owners can always read; others can only read public/unlisted lists.
+      allow read: if (request.auth != null &&
+        resource.data.createdBy == request.auth.uid) ||
+        canReadSpotList(resource.data);
       // Users can create lists (service validates feature access)
       allow create: if request.auth != null &&
-        request.resource.data.createdBy == request.auth.uid;
+        request.resource.data.createdBy == request.auth.uid &&
+        hasValidSpotListVisibility(request.resource.data);
       // Users can update their own lists
       allow update: if request.auth != null &&
-        resource.data.createdBy == request.auth.uid;
+        resource.data.createdBy == request.auth.uid &&
+        request.resource.data.createdBy == resource.data.createdBy &&
+        hasValidSpotListVisibility(request.resource.data);
       // Users can delete their own lists
       allow delete: if request.auth != null &&
         resource.data.createdBy == request.auth.uid;

--- a/lib/models/spot_list.dart
+++ b/lib/models/spot_list.dart
@@ -1,10 +1,63 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+enum SpotListVisibility {
+  public,
+  unlisted,
+  private;
+
+  static SpotListVisibility fromString(String? value) {
+    switch (value) {
+      case 'public':
+        return SpotListVisibility.public;
+      case 'private':
+        return SpotListVisibility.private;
+      case 'unlisted':
+      default:
+        // Legacy lists without this field default to unlisted.
+        return SpotListVisibility.unlisted;
+    }
+  }
+
+  String get firestoreValue {
+    switch (this) {
+      case SpotListVisibility.public:
+        return 'public';
+      case SpotListVisibility.unlisted:
+        return 'unlisted';
+      case SpotListVisibility.private:
+        return 'private';
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case SpotListVisibility.public:
+        return 'Public';
+      case SpotListVisibility.unlisted:
+        return 'Unlisted';
+      case SpotListVisibility.private:
+        return 'Private';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case SpotListVisibility.public:
+        return 'Listed on your profile and visible to everyone';
+      case SpotListVisibility.unlisted:
+        return 'Visible with a direct link, but hidden from your profile';
+      case SpotListVisibility.private:
+        return 'Only visible to you';
+    }
+  }
+}
+
 class SpotList {
   final String? id;
   final String name;
   final String? description;
   final List<String> spotIds;
+  final SpotListVisibility visibility;
   final String createdBy;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -14,6 +67,7 @@ class SpotList {
     required this.name,
     this.description,
     required this.spotIds,
+    this.visibility = SpotListVisibility.unlisted,
     required this.createdBy,
     required this.createdAt,
     required this.updatedAt,
@@ -28,6 +82,7 @@ class SpotList {
       spotIds: data['spotIds'] != null
           ? List<String>.from(data['spotIds'])
           : [],
+      visibility: SpotListVisibility.fromString(data['visibility'] as String?),
       createdBy: data['createdBy'] ?? '',
       createdAt: data['createdAt']?.toDate() ?? DateTime.now(),
       updatedAt: data['updatedAt']?.toDate() ?? DateTime.now(),
@@ -55,6 +110,7 @@ class SpotList {
       spotIds: data['spotIds'] is List
           ? List<String>.from(data['spotIds'])
           : [],
+      visibility: SpotListVisibility.fromString(data['visibility'] as String?),
       createdBy: (data['createdBy'] ?? '') as String,
       createdAt: parseDate(data['createdAt']) ?? DateTime.now(),
       updatedAt: parseDate(data['updatedAt']) ?? DateTime.now(),
@@ -66,6 +122,7 @@ class SpotList {
       'name': name,
       if (description != null) 'description': description,
       'spotIds': spotIds,
+      'visibility': visibility.firestoreValue,
       'createdBy': createdBy,
       'createdAt': createdAt,
       'updatedAt': updatedAt,
@@ -77,6 +134,7 @@ class SpotList {
     String? name,
     String? description,
     List<String>? spotIds,
+    SpotListVisibility? visibility,
     String? createdBy,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -86,6 +144,7 @@ class SpotList {
       name: name ?? this.name,
       description: description ?? this.description,
       spotIds: spotIds ?? this.spotIds,
+      visibility: visibility ?? this.visibility,
       createdBy: createdBy ?? this.createdBy,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -96,7 +155,7 @@ class SpotList {
 
   @override
   String toString() {
-    return 'SpotList(id: $id, name: $name, spotCount: $spotCount)';
+    return 'SpotList(id: $id, name: $name, visibility: ${visibility.label}, spotCount: $spotCount)';
   }
 }
 

--- a/lib/screens/profile/public_profile_screen.dart
+++ b/lib/screens/profile/public_profile_screen.dart
@@ -368,11 +368,12 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
                 ),
               ),
               
-              // Spot Lists (only for own profile)
-              if (isOwnProfile) ...[
-                const SizedBox(height: 16),
-                _buildSpotListsSection(context),
-              ],
+              // Spot Lists
+              _buildSpotListsSection(
+                context,
+                profileUserId: user.id,
+                isOwnProfile: isOwnProfile,
+              ),
             ],
           ),
         ),
@@ -380,291 +381,446 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
     );
   }
 
-  Widget _buildSpotListsSection(BuildContext context) {
+  Widget _buildSpotListsSection(
+    BuildContext context, {
+    required String profileUserId,
+    required bool isOwnProfile,
+  }) {
     final authService = Provider.of<AuthService>(context, listen: false);
     final featureAccessService = FeatureAccessService(authService);
-
-    if (!featureAccessService.hasFeatureAccess('spotLists')) {
-      return const SizedBox.shrink();
-    }
+    final canManageLists =
+        isOwnProfile && featureAccessService.hasFeatureAccess('spotLists');
 
     return Consumer<SpotListService>(
       builder: (context, spotListService, child) {
-        return Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      'Spot Lists',
-                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold,
+        return FutureBuilder<List<SpotList>>(
+          future: spotListService.getSpotListsByUser(profileUserId),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Center(
+                      child: CircularProgressIndicator(
+                        color: Theme.of(context).colorScheme.primary,
                       ),
                     ),
-                    IconButton(
-                      icon: const Icon(Icons.add),
-                      tooltip: 'Create New List',
-                      onPressed: () => _showCreateListDialog(context, spotListService),
-                    ),
-                  ],
+                  ),
                 ),
-                const SizedBox(height: 8),
-                FutureBuilder<List<SpotList>>(
-                  future: spotListService.getUserSpotLists(),
-                  builder: (context, snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return const Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: Center(child: CircularProgressIndicator()),
-                      );
-                    }
+              );
+            }
 
-                    if (snapshot.hasError) {
-                      return Padding(
-                        padding: const EdgeInsets.all(16.0),
-                        child: Text(
-                          'Error loading lists: ${snapshot.error}',
-                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            if (snapshot.hasError) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      'Error loading lists: ${snapshot.error}',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                             color: Theme.of(context).colorScheme.error,
                           ),
-                        ),
-                      );
-                    }
+                    ),
+                  ),
+                ),
+              );
+            }
 
-                    final lists = snapshot.data ?? [];
+            final lists = snapshot.data ?? [];
 
-                    if (lists.isEmpty) {
-                      return Padding(
-                        padding: const EdgeInsets.all(16.0),
-                        child: Column(
-                          children: [
-                            Icon(
-                              Icons.list_outlined,
-                              size: 48,
-                              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.3),
-                            ),
-                            const SizedBox(height: 8),
-                            Text(
-                              'No lists yet',
-                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+            if (lists.isEmpty && !isOwnProfile) {
+              return const SizedBox.shrink();
+            }
+
+            return Padding(
+              padding: const EdgeInsets.only(top: 16),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            isOwnProfile ? 'Spot Lists' : 'Public Spot Lists',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge
+                                ?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          ),
+                          if (canManageLists)
+                            IconButton(
+                              icon: const Icon(Icons.add),
+                              tooltip: 'Create New List',
+                              onPressed: () => _showCreateListDialog(
+                                context,
+                                spotListService,
                               ),
                             ),
-                            const SizedBox(height: 8),
-                            TextButton(
-                              onPressed: () => _showCreateListDialog(context, spotListService),
-                              child: const Text('Create your first list'),
-                            ),
-                          ],
-                        ),
-                      );
-                    }
-
-                    return Column(
-                      children: lists.map((list) {
-                        return Card(
-                          margin: const EdgeInsets.only(bottom: 8),
-                          child: ListTile(
-                            title: Text(list.name),
-                            subtitle: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                if (list.description != null && list.description!.isNotEmpty)
-                                  Padding(
-                                    padding: const EdgeInsets.only(top: 4),
-                                    child: Text(
-                                      list.description!,
-                                      style: Theme.of(context).textTheme.bodySmall,
-                                      maxLines: 2,
-                                      overflow: TextOverflow.ellipsis,
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      if (lists.isEmpty) ...[
+                        Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Column(
+                            children: [
+                              Icon(
+                                Icons.list_outlined,
+                                size: 48,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSurface
+                                    .withValues(alpha: 0.3),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                'No lists yet',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
+                                    ?.copyWith(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurface
+                                          .withValues(alpha: 0.6),
                                     ),
+                              ),
+                              const SizedBox(height: 8),
+                              if (canManageLists)
+                                TextButton(
+                                  onPressed: () => _showCreateListDialog(
+                                    context,
+                                    spotListService,
                                   ),
-                                Padding(
-                                  padding: const EdgeInsets.only(top: 4),
-                                  child: Text(
-                                    '${list.spotCount} ${list.spotCount == 1 ? 'spot' : 'spots'}',
-                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
-                                    ),
-                                  ),
+                                  child: const Text('Create your first list'),
                                 ),
-                              ],
-                            ),
-                            trailing: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                IconButton(
-                                  icon: const Icon(Icons.edit),
-                                  tooltip: 'Edit',
-                                  onPressed: () => _showEditListDialog(context, spotListService, list),
-                                ),
-                                IconButton(
-                                  icon: const Icon(Icons.delete),
-                                  tooltip: 'Delete',
-                                  onPressed: () => _showDeleteListDialog(context, spotListService, list),
-                                ),
-                              ],
-                            ),
-                            onTap: () {
-                              if (list.id != null) {
-                                context.push('/list/${list.id}');
-                              }
-                            },
+                            ],
                           ),
-                        );
-                      }).toList(),
-                    );
-                  },
+                        ),
+                      ] else ...[
+                        Column(
+                          children: lists.map((list) {
+                            final visibilityAndCount =
+                                '${list.visibility.label} • ${list.spotCount} ${list.spotCount == 1 ? 'spot' : 'spots'}';
+                            return Card(
+                              margin: const EdgeInsets.only(bottom: 8),
+                              child: ListTile(
+                                title: Text(list.name),
+                                subtitle: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    if (list.description != null &&
+                                        list.description!.isNotEmpty)
+                                      Padding(
+                                        padding: const EdgeInsets.only(top: 4),
+                                        child: Text(
+                                          list.description!,
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall,
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ),
+                                    Padding(
+                                      padding: const EdgeInsets.only(top: 4),
+                                      child: Text(
+                                        visibilityAndCount,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onSurface
+                                                  .withValues(alpha: 0.6),
+                                            ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                trailing: canManageLists
+                                    ? Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          IconButton(
+                                            icon: const Icon(Icons.edit),
+                                            tooltip: 'Edit',
+                                            onPressed: list.id == null
+                                                ? null
+                                                : () => _showEditListDialog(
+                                                      context,
+                                                      spotListService,
+                                                      list,
+                                                    ),
+                                          ),
+                                          IconButton(
+                                            icon: const Icon(Icons.delete),
+                                            tooltip: 'Delete',
+                                            onPressed: list.id == null
+                                                ? null
+                                                : () => _showDeleteListDialog(
+                                                      context,
+                                                      spotListService,
+                                                      list,
+                                                    ),
+                                          ),
+                                        ],
+                                      )
+                                    : null,
+                                onTap: () {
+                                  if (list.id != null) {
+                                    context.push('/list/${list.id}');
+                                  }
+                                },
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ],
+                    ],
+                  ),
                 ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         );
       },
     );
   }
 
-  void _showCreateListDialog(BuildContext context, SpotListService spotListService) {
+  void _showCreateListDialog(
+    BuildContext context,
+    SpotListService spotListService,
+  ) {
     final nameController = TextEditingController();
     final descriptionController = TextEditingController();
+    SpotListVisibility selectedVisibility = SpotListVisibility.unlisted;
 
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Create New List'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: nameController,
-              decoration: const InputDecoration(
-                labelText: 'List Name',
-                hintText: 'e.g., My Favorite Spots',
-              ),
-              autofocus: true,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) => AlertDialog(
+          title: const Text('Create New List'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'List Name',
+                    hintText: 'e.g., My Favorite Spots',
+                  ),
+                  autofocus: true,
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: descriptionController,
+                  decoration: const InputDecoration(
+                    labelText: 'Description (optional)',
+                    hintText: 'Add a description for this list',
+                  ),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<SpotListVisibility>(
+                  value: selectedVisibility,
+                  decoration: const InputDecoration(
+                    labelText: 'Visibility',
+                  ),
+                  items: SpotListVisibility.values
+                      .map(
+                        (visibility) => DropdownMenuItem<SpotListVisibility>(
+                          value: visibility,
+                          child: Text(visibility.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setDialogState(() {
+                      selectedVisibility = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    selectedVisibility.description,
+                    style: Theme.of(dialogContext).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(dialogContext)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.7),
+                        ),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: descriptionController,
-              decoration: const InputDecoration(
-                labelText: 'Description (optional)',
-                hintText: 'Add a description for this list',
-              ),
-              maxLines: 3,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                if (nameController.text.trim().isEmpty) {
+                  ScaffoldMessenger.of(dialogContext).showSnackBar(
+                    const SnackBar(content: Text('List name cannot be empty')),
+                  );
+                  return;
+                }
+
+                final listId = await spotListService.createSpotList(
+                  nameController.text.trim(),
+                  description: descriptionController.text.trim().isEmpty
+                      ? null
+                      : descriptionController.text.trim(),
+                  visibility: selectedVisibility,
+                );
+
+                if (dialogContext.mounted) {
+                  Navigator.pop(dialogContext);
+                  if (listId != null) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('List created successfully')),
+                    );
+                  } else if (spotListService.error != null) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(spotListService.error!)),
+                    );
+                  }
+                }
+              },
+              child: const Text('Create'),
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () async {
-              if (nameController.text.trim().isEmpty) {
-                ScaffoldMessenger.of(dialogContext).showSnackBar(
-                  const SnackBar(content: Text('List name cannot be empty')),
-                );
-                return;
-              }
-
-              final listId = await spotListService.createSpotList(
-                nameController.text.trim(),
-                description: descriptionController.text.trim().isEmpty
-                    ? null
-                    : descriptionController.text.trim(),
-              );
-
-              if (dialogContext.mounted) {
-                Navigator.pop(dialogContext);
-                if (listId != null) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('List created successfully')),
-                  );
-                } else if (spotListService.error != null) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text(spotListService.error!)),
-                  );
-                }
-              }
-            },
-            child: const Text('Create'),
-          ),
-        ],
       ),
     );
   }
 
-  void _showEditListDialog(BuildContext context, SpotListService spotListService, SpotList list) {
+  void _showEditListDialog(
+    BuildContext context,
+    SpotListService spotListService,
+    SpotList list,
+  ) {
     final nameController = TextEditingController(text: list.name);
     final descriptionController = TextEditingController(text: list.description ?? '');
+    SpotListVisibility selectedVisibility = list.visibility;
 
     showDialog(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Edit List'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: nameController,
-              decoration: const InputDecoration(
-                labelText: 'List Name',
-              ),
-              autofocus: true,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) => AlertDialog(
+          title: const Text('Edit List'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'List Name',
+                  ),
+                  autofocus: true,
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: descriptionController,
+                  decoration: const InputDecoration(
+                    labelText: 'Description (optional)',
+                  ),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<SpotListVisibility>(
+                  value: selectedVisibility,
+                  decoration: const InputDecoration(
+                    labelText: 'Visibility',
+                  ),
+                  items: SpotListVisibility.values
+                      .map(
+                        (visibility) => DropdownMenuItem<SpotListVisibility>(
+                          value: visibility,
+                          child: Text(visibility.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setDialogState(() {
+                      selectedVisibility = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    selectedVisibility.description,
+                    style: Theme.of(dialogContext).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(dialogContext)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.7),
+                        ),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: descriptionController,
-              decoration: const InputDecoration(
-                labelText: 'Description (optional)',
-              ),
-              maxLines: 3,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                if (nameController.text.trim().isEmpty) {
+                  ScaffoldMessenger.of(dialogContext).showSnackBar(
+                    const SnackBar(content: Text('List name cannot be empty')),
+                  );
+                  return;
+                }
+
+                final success = await spotListService.updateSpotList(
+                  list.id!,
+                  name: nameController.text.trim(),
+                  description: descriptionController.text.trim().isEmpty
+                      ? null
+                      : descriptionController.text.trim(),
+                  visibility: selectedVisibility,
+                );
+
+                if (dialogContext.mounted) {
+                  Navigator.pop(dialogContext);
+                  if (success) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('List updated successfully')),
+                    );
+                  } else if (spotListService.error != null) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(spotListService.error!)),
+                    );
+                  }
+                }
+              },
+              child: const Text('Save'),
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () async {
-              if (nameController.text.trim().isEmpty) {
-                ScaffoldMessenger.of(dialogContext).showSnackBar(
-                  const SnackBar(content: Text('List name cannot be empty')),
-                );
-                return;
-              }
-
-              final success = await spotListService.updateSpotList(
-                list.id!,
-                name: nameController.text.trim(),
-                description: descriptionController.text.trim().isEmpty
-                    ? null
-                    : descriptionController.text.trim(),
-              );
-
-              if (dialogContext.mounted) {
-                Navigator.pop(dialogContext);
-                if (success) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('List updated successfully')),
-                  );
-                } else if (spotListService.error != null) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text(spotListService.error!)),
-                  );
-                }
-              }
-            },
-            child: const Text('Save'),
-          ),
-        ],
       ),
     );
   }

--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -1925,16 +1925,31 @@ class SearchScreenState extends State<SearchScreen> with TickerProviderStateMixi
     try {
       final spotListService = Provider.of<SpotListService>(context, listen: false);
       final list = await spotListService.getSpotListById(listId);
-      
-      if (mounted && list != null) {
+
+      if (!mounted) return;
+
+      if (list == null) {
         setState(() {
-          _selectedList = list;
-          _selectedListName = list.name;
-          _highlightedSpotIds = list.spotIds.toSet();
-          // Rebuild markers to reflect highlighting
+          _selectedList = null;
+          _selectedListName = null;
+          _showListPreview = false;
+          _highlightedSpotIds.clear();
           _markers = _buildMarkers(_visibleSpots);
         });
+
+        if (_selectedListId == listId) {
+          _searchStateServiceRef?.setSelectedListId(null);
+        }
+        return;
       }
+
+      setState(() {
+        _selectedList = list;
+        _selectedListName = list.name;
+        _highlightedSpotIds = list.spotIds.toSet();
+        // Rebuild markers to reflect highlighting
+        _markers = _buildMarkers(_visibleSpots);
+      });
     } catch (e) {
       debugPrint('Error loading spot list: $e');
     }
@@ -1946,6 +1961,8 @@ class SearchScreenState extends State<SearchScreen> with TickerProviderStateMixi
     if (_selectedListId != listId || _selectedList == null) {
       await _loadSpotList(listId);
     }
+
+    if (!mounted || _selectedList == null) return;
     
     // Collapse bottom sheet if open
     if (_isBottomSheetOpen) {

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -5817,6 +5817,7 @@ class _AddToListDialogState extends State<_AddToListDialog> {
   final Set<String> _selectedListIds = {};
   final _nameController = TextEditingController();
   final _descriptionController = TextEditingController();
+  SpotListVisibility _newListVisibility = SpotListVisibility.unlisted;
   bool _showCreateForm = false;
   bool _isCreating = false;
   bool _isAdding = false;
@@ -5845,6 +5846,7 @@ class _AddToListDialogState extends State<_AddToListDialog> {
       description: _descriptionController.text.trim().isEmpty
           ? null
           : _descriptionController.text.trim(),
+      visibility: _newListVisibility,
     );
 
     if (!mounted) return;
@@ -6047,6 +6049,39 @@ class _AddToListDialogState extends State<_AddToListDialog> {
                   enabled: !_isCreating && !_isAdding,
                 ),
                 const SizedBox(height: 16),
+                DropdownButtonFormField<SpotListVisibility>(
+                  value: _newListVisibility,
+                  decoration: const InputDecoration(
+                    labelText: 'Visibility',
+                  ),
+                  items: SpotListVisibility.values
+                      .map(
+                        (visibility) => DropdownMenuItem<SpotListVisibility>(
+                          value: visibility,
+                          child: Text(visibility.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (_isCreating || _isAdding)
+                      ? null
+                      : (value) {
+                          if (value == null) return;
+                          setState(() {
+                            _newListVisibility = value;
+                          });
+                        },
+                ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    _newListVisibility.description,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
                 TextButton(
                   onPressed: (_isCreating || _isAdding)
                       ? null
@@ -6055,6 +6090,7 @@ class _AddToListDialogState extends State<_AddToListDialog> {
                             _showCreateForm = false;
                             _nameController.clear();
                             _descriptionController.clear();
+                            _newListVisibility = SpotListVisibility.unlisted;
                           });
                         },
                   child: const Text('Cancel'),

--- a/lib/screens/spots/spot_list_detail_screen.dart
+++ b/lib/screens/spots/spot_list_detail_screen.dart
@@ -89,7 +89,7 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
     if (list == null) {
       setState(() {
         _isLoading = false;
-        _error = 'List not found';
+        _error = 'List not found or not accessible';
       });
       return;
     }
@@ -297,49 +297,88 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
 
     final nameController = TextEditingController(text: _list!.name);
     final descriptionController = TextEditingController(text: _list!.description ?? '');
+    SpotListVisibility selectedVisibility = _list!.visibility;
 
     final result = await showDialog<bool>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Edit List'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: nameController,
-              decoration: const InputDecoration(
-                labelText: 'List Name',
-              ),
-              autofocus: true,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) => AlertDialog(
+          title: const Text('Edit List'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'List Name',
+                  ),
+                  autofocus: true,
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: descriptionController,
+                  decoration: const InputDecoration(
+                    labelText: 'Description (optional)',
+                  ),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<SpotListVisibility>(
+                  value: selectedVisibility,
+                  decoration: const InputDecoration(
+                    labelText: 'Visibility',
+                  ),
+                  items: SpotListVisibility.values
+                      .map(
+                        (visibility) => DropdownMenuItem<SpotListVisibility>(
+                          value: visibility,
+                          child: Text(visibility.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setDialogState(() {
+                      selectedVisibility = value;
+                    });
+                  },
+                ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    selectedVisibility.description,
+                    style: Theme.of(dialogContext).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(dialogContext)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.7),
+                        ),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: descriptionController,
-              decoration: const InputDecoration(
-                labelText: 'Description (optional)',
-              ),
-              maxLines: 3,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                if (nameController.text.trim().isEmpty) {
+                  ScaffoldMessenger.of(dialogContext).showSnackBar(
+                    const SnackBar(content: Text('List name cannot be empty')),
+                  );
+                  return;
+                }
+                Navigator.pop(dialogContext, true);
+              },
+              child: const Text('Save'),
             ),
           ],
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              if (nameController.text.trim().isEmpty) {
-                ScaffoldMessenger.of(dialogContext).showSnackBar(
-                  const SnackBar(content: Text('List name cannot be empty')),
-                );
-                return;
-              }
-              Navigator.pop(dialogContext, true);
-            },
-            child: const Text('Save'),
-          ),
-        ],
       ),
     );
 
@@ -352,6 +391,7 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
         description: descriptionController.text.trim().isEmpty
             ? null
             : descriptionController.text.trim(),
+        visibility: selectedVisibility,
       );
 
       if (success) {
@@ -373,6 +413,28 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
     
     final featureAccessService = FeatureAccessService(authService);
     return featureAccessService.hasFeatureAccess('spotLists');
+  }
+
+  IconData _visibilityIcon(SpotListVisibility visibility) {
+    switch (visibility) {
+      case SpotListVisibility.public:
+        return Icons.public;
+      case SpotListVisibility.unlisted:
+        return Icons.link;
+      case SpotListVisibility.private:
+        return Icons.lock;
+    }
+  }
+
+  String _visibilitySummary(SpotListVisibility visibility) {
+    switch (visibility) {
+      case SpotListVisibility.public:
+        return 'Public list';
+      case SpotListVisibility.unlisted:
+        return 'Unlisted list';
+      case SpotListVisibility.private:
+        return 'Private list';
+    }
   }
 
   // Copy list URL to clipboard (same style as spot detail page)
@@ -739,6 +801,27 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
           children: [
             // Map showing all spots
             if (_spots.isNotEmpty) _buildMap(),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              child: Row(
+                children: [
+                  Icon(
+                    _visibilityIcon(_list!.visibility),
+                    size: 18,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    _visibilitySummary(_list!.visibility),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                ],
+              ),
+            ),
             // List info header
             if (_list!.description != null && _list!.description!.isNotEmpty)
               Container(

--- a/lib/services/spot_list_service.dart
+++ b/lib/services/spot_list_service.dart
@@ -33,7 +33,11 @@ class SpotListService extends ChangeNotifier {
   }
 
   /// Create a new spot list
-  Future<String?> createSpotList(String name, {String? description}) async {
+  Future<String?> createSpotList(
+    String name, {
+    String? description,
+    SpotListVisibility visibility = SpotListVisibility.unlisted,
+  }) async {
     if (!_isAuthenticated()) {
       _error = 'You must be signed in to create a list';
       notifyListeners();
@@ -69,6 +73,7 @@ class SpotListService extends ChangeNotifier {
         name: name.trim(),
         description: description?.trim(),
         spotIds: [],
+        visibility: visibility,
         createdBy: userId,
         createdAt: now,
         updatedAt: now,
@@ -125,15 +130,32 @@ class SpotListService extends ChangeNotifier {
     }
   }
 
-  /// Get all spot lists for a specific user (public access, no feature flag required)
+  /// Get spot lists for a specific user.
+  /// - Owners see all their lists.
+  /// - Other users only see public lists.
   /// Note: This method does not update loading state or notify listeners
   Future<List<SpotList>> getSpotListsByUser(String userId) async {
     try {
-      final querySnapshot = await _firestore
-          .collection('spotLists')
-          .where('createdBy', isEqualTo: userId)
-          .orderBy('updatedAt', descending: true)
-          .get();
+      final currentUserId = _getCurrentUserId();
+      late final QuerySnapshot<Map<String, dynamic>> querySnapshot;
+
+      if (currentUserId == userId) {
+        querySnapshot = await _firestore
+            .collection('spotLists')
+            .where('createdBy', isEqualTo: userId)
+            .orderBy('updatedAt', descending: true)
+            .get();
+      } else {
+        querySnapshot = await _firestore
+            .collection('spotLists')
+            .where('createdBy', isEqualTo: userId)
+            .where(
+              'visibility',
+              isEqualTo: SpotListVisibility.public.firestoreValue,
+            )
+            .orderBy('updatedAt', descending: true)
+            .get();
+      }
 
       final lists = querySnapshot.docs
           .map((doc) => SpotList.fromFirestore(doc))
@@ -146,12 +168,16 @@ class SpotListService extends ChangeNotifier {
     }
   }
 
-  /// Get a specific spot list by ID (public access)
+  /// Get a specific spot list by ID (visibility-aware access)
   Future<SpotList?> getSpotListById(String listId) async {
     try {
       final doc = await _firestore.collection('spotLists').doc(listId).get();
       if (doc.exists) {
-        return SpotList.fromFirestore(doc);
+        final list = SpotList.fromFirestore(doc);
+        final currentUserId = _getCurrentUserId();
+        final canView = list.visibility != SpotListVisibility.private ||
+            list.createdBy == currentUserId;
+        return canView ? list : null;
       }
       return null;
     } catch (e) {
@@ -160,11 +186,12 @@ class SpotListService extends ChangeNotifier {
     }
   }
 
-  /// Update spot list metadata (name and description)
+  /// Update spot list metadata (name, description, visibility)
   Future<bool> updateSpotList(
     String listId, {
     String? name,
     String? description,
+    SpotListVisibility? visibility,
   }) async {
     if (!_isAuthenticated()) {
       _error = 'You must be signed in to update a list';
@@ -210,6 +237,10 @@ class SpotListService extends ChangeNotifier {
         updates['description'] = description.trim().isEmpty
             ? FieldValue.delete()
             : description.trim();
+      }
+
+      if (visibility != null) {
+        updates['visibility'] = visibility.firestoreValue;
       }
 
       await _firestore.collection('spotLists').doc(listId).update(updates);


### PR DESCRIPTION
Add support for public, unlisted, and private spot lists to give users more control over list visibility.

---
<p><a href="https://cursor.com/agents?id=bc-2e2e6d7d-4c63-4dd0-8a95-03775081bed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e2e6d7d-4c63-4dd0-8a95-03775081bed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Firestore security rules and read/query logic for `spotLists`, which is privacy-sensitive and could unintentionally expose or hide lists if misconfigured. Also introduces a new indexed query path (`createdBy` + `visibility` + `updatedAt`) that must match production query patterns.
> 
> **Overview**
> Adds per-list `visibility` (`public`, `unlisted`, `private`) to `SpotList`, persists it to Firestore, and exposes it in create/edit flows (profile list dialogs, add-to-list dialog, and list detail edit).
> 
> Tightens Firestore access by making `spotLists` reads visibility-aware (owners always read; others only `public`/`unlisted`, with legacy lists defaulting to `unlisted`) and updates `SpotListService` to hide private lists and to only return `public` lists when viewing another user’s profile; includes a new composite Firestore index to support the filtered profile query and improves UI handling when a list is missing/inaccessible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65828749210bd9ea91d457b065522d32d430eda4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->