### PR TITLE
Align spot list Save/Edit/Share with spot detail quick actions

### DIFF
--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -35,6 +35,7 @@ import '../../models/spot_list.dart';
 import '../../utils/resized_spot_image_provider.dart';
 import '../../widgets/resized_spot_image.dart';
 import '../../widgets/spot_detail_community_section.dart';
+import '../../widgets/spot_detail_quick_action_chip.dart';
 import '../../utils/image_preparation.dart';
 import '../../services/user_profile_service.dart';
 import '../../services/jumpflix_service.dart';
@@ -827,8 +828,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
         if (authService.isLoading) {
           return Padding(
             padding: EdgeInsets.only(bottom: bottom),
-            child: _spotDetailLabeledQuickActionContent(
-              context: context,
+            child: SpotDetailQuickActionChip(
               icon: Icons.edit_outlined,
               iconColor: Theme.of(
                 context,
@@ -1347,8 +1347,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
 
         return items;
       },
-      child: _spotDetailLabeledQuickActionContent(
-        context: context,
+      child: SpotDetailQuickActionChip(
         icon: Icons.edit_outlined,
         iconColor: Theme.of(
           context,
@@ -1878,17 +1877,15 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                             SpotDetailUi.surfaceRadius,
                                           ),
                                           onTap: _copySpotToClipboard,
-                                          child:
-                                              _spotDetailLabeledQuickActionContent(
-                                                context: context,
-                                                icon: Icons.share_outlined,
-                                                iconColor: Theme.of(context)
-                                                    .colorScheme
-                                                    .onSurface
-                                                    .withValues(alpha: 0.75),
-                                                label: _l10n
-                                                    .spotDetailQuickActionShare,
-                                              ),
+                                          child: SpotDetailQuickActionChip(
+                                            icon: Icons.share_outlined,
+                                            iconColor: Theme.of(context)
+                                                .colorScheme
+                                                .onSurface
+                                                .withValues(alpha: 0.75),
+                                            label: _l10n
+                                                .spotDetailQuickActionShare,
+                                          ),
                                         ),
                                       ),
                                     ),
@@ -7429,55 +7426,6 @@ class _SuggestEditDialogState extends State<_SuggestEditDialog> {
   }
 }
 
-/// Labeled chip for spot detail quick actions (wide layouts). Same shell for
-/// Save, Edit, and Share so the strip reads as one control family.
-Widget _spotDetailLabeledQuickActionContent({
-  required BuildContext context,
-  required IconData icon,
-  required Color? iconColor,
-  required String label,
-  bool showSpinner = false,
-}) {
-  final theme = Theme.of(context);
-  final cs = theme.colorScheme;
-  return ConstrainedBox(
-    constraints: const BoxConstraints(minHeight: 40),
-    child: Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: cs.surfaceContainerHighest.withValues(alpha: 0.45),
-        borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
-        border: SpotDetailUi.outlineBorder(cs),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          if (showSpinner)
-            SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: cs.primary,
-              ),
-            )
-          else
-            Icon(icon, size: 20, color: iconColor),
-          const SizedBox(width: 8),
-          Text(
-            label,
-            style: theme.textTheme.labelLarge,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
-      ),
-    ),
-  );
-}
-
 class _SpotSaveMenu extends StatelessWidget {
   final String spotId;
   final VoidCallback onAddToCustomList;
@@ -7506,8 +7454,7 @@ class _SpotSaveMenu extends StatelessWidget {
             padding: EdgeInsets.only(bottom: bottomInset),
             child: Align(
               alignment: Alignment.centerLeft,
-              child: _spotDetailLabeledQuickActionContent(
-                context: context,
+              child: SpotDetailQuickActionChip(
                 icon: Icons.bookmark_border,
                 iconColor: colorScheme.onSurface.withValues(alpha: 0.38),
                 label: l10n.spotDetailLoading,
@@ -7576,8 +7523,7 @@ class _SpotSaveMenu extends StatelessWidget {
                 ),
               ];
             },
-            child: _spotDetailLabeledQuickActionContent(
-              context: context,
+            child: SpotDetailQuickActionChip(
               icon: Icons.bookmark_border,
               iconColor: colorScheme.onSurface.withValues(alpha: 0.75),
               label: l10n.spotDetailQuickActionSave,
@@ -7820,8 +7766,7 @@ class _SpotSaveMenu extends StatelessWidget {
                   ],
                 ];
               },
-              child: _spotDetailLabeledQuickActionContent(
-                context: context,
+              child: SpotDetailQuickActionChip(
                 icon: icon,
                 iconColor: iconColor,
                 label: saveLabel,

--- a/lib/screens/spots/spot_list_detail_screen.dart
+++ b/lib/screens/spots/spot_list_detail_screen.dart
@@ -21,7 +21,9 @@ import '../../utils/map_bounds_utils.dart';
 import '../../services/url_service.dart';
 import '../../services/web_share_service.dart';
 import '../../services/user_profile_service.dart';
+import '../../constants/spot_detail_ui.dart';
 import '../../widgets/page_scaffold.dart';
+import '../../widgets/spot_detail_quick_action_chip.dart';
 import '../../widgets/spot_list_save_button.dart';
 import 'package:flutter/services.dart';
 import 'spot_list_advanced_organization_screen.dart';
@@ -1103,8 +1105,8 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
               child: PopupMenuButton<_ListManageMenuAction>(
                 position: PopupMenuPosition.under,
                 tooltip: _l10n.spotListDetailEditListTooltip,
-                borderRadius: BorderRadius.circular(22),
-                splashRadius: 22,
+                borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                splashRadius: 20,
                 onSelected: _onListManageMenuSelected,
                 itemBuilder: (menuContext) {
                   final theme = Theme.of(menuContext);
@@ -1167,25 +1169,12 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
                     ),
                   ];
                 },
-                child: SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .surfaceContainerHighest
-                          .withValues(alpha: 0.6),
-                      shape: BoxShape.circle,
-                    ),
-                    child: Icon(
-                      Icons.edit_outlined,
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.6),
-                      size: 24,
-                    ),
-                  ),
+                child: SpotDetailQuickActionChip(
+                  icon: Icons.edit_outlined,
+                  iconColor: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.75),
+                  label: _l10n.spotDetailQuickActionEdit,
                 ),
               ),
             ),
@@ -1196,24 +1185,22 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
             padding: const EdgeInsets.only(bottom: 16),
             child: Tooltip(
               message: _l10n.spotDetailShareTooltip,
-              child: Material(
-                color: Theme.of(
-                  context,
-                ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
-                shape: const CircleBorder(),
-                clipBehavior: Clip.antiAlias,
-                child: InkWell(
-                  onTap: _copyListToClipboard,
-                  customBorder: const CircleBorder(),
-                  child: SizedBox(
-                    width: 44,
-                    height: 44,
-                    child: Icon(
-                      Icons.share,
-                      color: Theme.of(
+              child: Semantics(
+                button: true,
+                label: _l10n.spotDetailShareTooltip,
+                child: Material(
+                  color: Colors.transparent,
+                  borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                    onTap: _copyListToClipboard,
+                    child: SpotDetailQuickActionChip(
+                      icon: Icons.share_outlined,
+                      iconColor: Theme.of(
                         context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.6),
-                      size: 24,
+                      ).colorScheme.onSurface.withValues(alpha: 0.75),
+                      label: _l10n.spotDetailQuickActionShare,
                     ),
                   ),
                 ),
@@ -1232,9 +1219,12 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
 
         return Padding(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: children,
+            ),
           ),
         );
       },

--- a/lib/widgets/spot_detail_quick_action_chip.dart
+++ b/lib/widgets/spot_detail_quick_action_chip.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../constants/spot_detail_ui.dart';
+
+/// Outlined chip with icon + short label for Save / Edit / Share quick actions.
+/// Used on spot detail and spot list detail so the action row reads as one family.
+class SpotDetailQuickActionChip extends StatelessWidget {
+  final IconData icon;
+  final Color? iconColor;
+  final String label;
+  final bool showSpinner;
+
+  const SpotDetailQuickActionChip({
+    super.key,
+    required this.icon,
+    required this.iconColor,
+    required this.label,
+    this.showSpinner = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 40),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: cs.surfaceContainerHighest.withValues(alpha: 0.45),
+          borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+          border: SpotDetailUi.outlineBorder(cs),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (showSpinner)
+              SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: cs.primary,
+                ),
+              )
+            else
+              Icon(icon, size: 20, color: iconColor),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: theme.textTheme.labelLarge,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/spot_list_save_button.dart
+++ b/lib/widgets/spot_list_save_button.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import '../constants/spot_detail_ui.dart';
 import '../l10n/app_localizations.dart';
 import '../services/auth_service.dart';
 import '../services/saved_spot_list_service.dart';
 import '../services/snackbar_service.dart';
+import 'spot_detail_quick_action_chip.dart';
 
 enum _SpotListSaveAction { login, save, unsave, viewSaved }
 
-/// Matches spot detail [Save] control: 44×44 circular bookmark + popup menu.
+/// Matches spot detail Save control: outlined chip (icon + label) + popup menu.
 class SpotListSaveButton extends StatelessWidget {
   final String listId;
 
@@ -30,27 +32,11 @@ class SpotListSaveButton extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: 16),
             child: Align(
               alignment: Alignment.centerLeft,
-              child: SizedBox(
-                width: 44,
-                height: 44,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: colorScheme.surfaceContainerHighest.withValues(
-                      alpha: 0.6,
-                    ),
-                    shape: BoxShape.circle,
-                  ),
-                  child: Center(
-                    child: SizedBox(
-                      width: 22,
-                      height: 22,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: colorScheme.primary,
-                      ),
-                    ),
-                  ),
-                ),
+              child: SpotDetailQuickActionChip(
+                icon: Icons.bookmark_border,
+                iconColor: colorScheme.onSurface.withValues(alpha: 0.38),
+                label: l10n.spotDetailLoading,
+                showSpinner: true,
               ),
             ),
           );
@@ -64,8 +50,8 @@ class SpotListSaveButton extends StatelessWidget {
               child: PopupMenuButton<_SpotListSaveAction>(
                 tooltip: l10n.spotListSaveTooltipSaveList,
                 position: PopupMenuPosition.under,
-                borderRadius: BorderRadius.circular(22),
-                splashRadius: 22,
+                borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                splashRadius: 20,
                 onSelected: (action) {
                   if (action == _SpotListSaveAction.login && context.mounted) {
                     context.go(_loginRedirect);
@@ -116,22 +102,10 @@ class SpotListSaveButton extends StatelessWidget {
                     ),
                   ];
                 },
-                child: SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: colorScheme.surfaceContainerHighest.withValues(
-                        alpha: 0.6,
-                      ),
-                      shape: BoxShape.circle,
-                    ),
-                    child: Icon(
-                      Icons.bookmark_border,
-                      color: colorScheme.onSurface.withValues(alpha: 0.6),
-                      size: 24,
-                    ),
-                  ),
+                child: SpotDetailQuickActionChip(
+                  icon: Icons.bookmark_border,
+                  iconColor: colorScheme.onSurface.withValues(alpha: 0.75),
+                  label: l10n.spotDetailQuickActionSave,
                 ),
               ),
             ),
@@ -148,18 +122,22 @@ class SpotListSaveButton extends StatelessWidget {
             IconData icon;
             Color? iconColor;
             String tooltip;
+            String chipLabel;
             if (isBusy) {
               icon = Icons.bookmark_border;
               iconColor = colorScheme.onSurface.withValues(alpha: 0.38);
               tooltip = l10n.spotDetailSaveTooltipUpdating;
+              chipLabel = l10n.spotDetailSaveTooltipUpdating;
             } else if (isSaved) {
               icon = Icons.bookmark;
               iconColor = colorScheme.primary;
               tooltip = l10n.spotListSaveTooltipSavedList;
+              chipLabel = l10n.spotListSaveTooltipSavedList;
             } else {
               icon = Icons.bookmark_border;
               iconColor = colorScheme.onSurface.withValues(alpha: 0.6);
               tooltip = l10n.spotListSaveTooltipSaveList;
+              chipLabel = l10n.spotDetailQuickActionSave;
             }
 
             Future<void> handleAction(_SpotListSaveAction action) async {
@@ -217,8 +195,8 @@ class SpotListSaveButton extends StatelessWidget {
                   enabled: !isBusy,
                   tooltip: tooltip,
                   position: PopupMenuPosition.under,
-                  borderRadius: BorderRadius.circular(22),
-                  splashRadius: 22,
+                  borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                  splashRadius: 20,
                   onSelected: handleAction,
                   itemBuilder: (menuContext) {
                     final menuTheme = Theme.of(menuContext);
@@ -286,29 +264,11 @@ class SpotListSaveButton extends StatelessWidget {
                       ),
                     ];
                   },
-                  child: SizedBox(
-                    width: 44,
-                    height: 44,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: colorScheme.surfaceContainerHighest.withValues(
-                          alpha: 0.6,
-                        ),
-                        shape: BoxShape.circle,
-                      ),
-                      child: isBusy
-                          ? Center(
-                              child: SizedBox(
-                                width: 22,
-                                height: 22,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: colorScheme.primary,
-                                ),
-                              ),
-                            )
-                          : Icon(icon, color: iconColor, size: 24),
-                    ),
+                  child: SpotDetailQuickActionChip(
+                    icon: icon,
+                    iconColor: iconColor,
+                    label: chipLabel,
+                    showSpinner: isBusy,
                   ),
                 ),
               ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Spot list detail actions (Save, Edit, Share) now use the same outlined chip shell as spot detail: icon + short label, shared border/radius from `SpotDetailUi`, and horizontal scroll on narrow layouts like spot detail.

## Changes

- New `SpotDetailQuickActionChip` widget (extracted from spot detail) for a single implementation of the quick-action visual.
- `SpotListSaveButton` uses the chip for loading, guest, and signed-in states; popup menu uses the same border radius and splash as spot detail save.
- List detail Edit and Share use the chip with `spotDetailQuickActionEdit` / `spotDetailQuickActionShare` and `share_outlined` to match spot detail.

## Testing

- `flutter test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fe9ad08-faf8-48a4-8b32-06888872da2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fe9ad08-faf8-48a4-8b32-06888872da2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

