### PR TITLE
Admin: all notifications list with pagination and delete

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -342,6 +342,13 @@
         { "fieldPath": "longitude", "order": "ASCENDING" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "notifications",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,5 +1,11 @@
 rules_version = '2';
 service cloud.firestore {
+  function requestingUserIsAdmin() {
+    return request.auth != null &&
+      exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+      get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+  }
+
   match /databases/{database}/documents {
     // Spots collection - all spots are public, authenticated users can create, admins/moderators can edit, only admins can delete any spot
     match /spots/{spotId} {
@@ -231,8 +237,10 @@ service cloud.firestore {
         // List queries must not use field checks the query cannot guarantee for every
         // matching document (see Firestore "rules are not filters"). Clients cannot
         // create docs here; only validate shape on update (toggle read / unread).
-        allow read: if request.auth != null && request.auth.uid == userId;
-        allow create, delete: if false;
+        allow read: if request.auth != null &&
+          (request.auth.uid == userId || requestingUserIsAdmin());
+        allow create: if false;
+        allow delete: if requestingUserIsAdmin();
         allow update: if request.auth != null && request.auth.uid == userId &&
           request.resource.data.read is bool &&
           notificationReadStatusPatchOnly() &&

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:parkour_spot/services/search_state_service.dart';
 import 'package:parkour_spot/services/geocoding_service.dart';
 import 'package:parkour_spot/services/jumpflix_service.dart';
 import 'package:parkour_spot/services/user_management_service.dart';
+import 'package:parkour_spot/services/admin_notifications_service.dart';
 import 'package:parkour_spot/services/snackbar_service.dart';
 import 'package:parkour_spot/services/spot_list_service.dart';
 import 'package:parkour_spot/services/saved_spot_list_service.dart';
@@ -121,6 +122,7 @@ class ParkourSpotApp extends StatelessWidget {
           },
         ),
         ChangeNotifierProvider(create: (_) => UserManagementService()),
+        ChangeNotifierProvider(create: (_) => AdminNotificationsService()),
         ChangeNotifierProvider(create: (_) => SpotService()),
         ChangeNotifierProvider(create: (_) => SyncSourceService()),
         ChangeNotifierProvider(create: (_) => ApiClientService()),

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -11,6 +11,7 @@ import '../screens/admin/sync_sources_screen.dart';
 import '../screens/admin/geocoding_admin_screen.dart';
 import '../screens/admin/spot_management_screen.dart';
 import '../screens/admin/user_management_screen.dart';
+import '../screens/admin/admin_notifications_screen.dart';
 import '../screens/admin/user_activity_metrics_screen.dart';
 import '../screens/admin/audit_log_viewer_screen.dart';
 import '../screens/admin/duplicate_images_screen.dart';
@@ -359,6 +360,10 @@ class AppRouter {
         GoRoute(
           path: '/admin/users',
           builder: (context, state) => const UserManagementScreen(),
+        ),
+        GoRoute(
+          path: '/admin/notifications',
+          builder: (context, state) => const AdminNotificationsScreen(),
         ),
         GoRoute(
           path: '/admin/user-activity-metrics',

--- a/lib/screens/admin/admin_home_screen.dart
+++ b/lib/screens/admin/admin_home_screen.dart
@@ -79,6 +79,16 @@ class AdminHomeScreen extends StatelessWidget {
             const SizedBox(height: 8),
             Card(
               child: ListTile(
+                leading: const Icon(Icons.notifications_outlined),
+                title: const Text('All notifications'),
+                subtitle: const Text('Browse every in-app notification across users (newest first)'),
+                trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+                onTap: () => context.push('/admin/notifications'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Card(
+              child: ListTile(
                 leading: const Icon(Icons.analytics),
                 title: const Text('User Activity Metrics'),
                 subtitle: const Text('Calculate and sync DAU/WAU/MAU metrics to Google Sheets'),

--- a/lib/screens/admin/admin_notifications_screen.dart
+++ b/lib/screens/admin/admin_notifications_screen.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../services/admin_notifications_service.dart';
+import '../../services/auth_service.dart';
+import '../../utils/user_notification_localization.dart';
+
+class AdminNotificationsScreen extends StatefulWidget {
+  const AdminNotificationsScreen({super.key});
+
+  @override
+  State<AdminNotificationsScreen> createState() => _AdminNotificationsScreenState();
+}
+
+class _AdminNotificationsScreenState extends State<AdminNotificationsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final service = context.read<AdminNotificationsService>();
+      if (service.entries.isEmpty && !service.isLoading) {
+        service.fetchInitial();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = context.select<AuthService, bool>((s) => s.isAdmin);
+    if (!isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('All notifications')),
+        body: const Center(child: Text('Administrator access required')),
+      );
+    }
+
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('All notifications'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            } else {
+              context.go('/admin');
+            }
+          },
+        ),
+        actions: [
+          Consumer<AdminNotificationsService>(
+            builder: (context, service, _) {
+              return IconButton(
+                tooltip: 'Refresh',
+                icon: service.isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh),
+                onPressed: service.isLoading
+                    ? null
+                    : () => service.fetchInitial(forceRefresh: true),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Consumer<AdminNotificationsService>(
+        builder: (context, service, _) {
+          if (service.isLoading && service.entries.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (service.error != null && service.entries.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+                    const SizedBox(height: 12),
+                    Text(service.error!, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    FilledButton.icon(
+                      onPressed: () => service.fetchInitial(forceRefresh: true),
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          if (service.entries.isEmpty && !service.hasMore) {
+            return RefreshIndicator(
+              onRefresh: () => service.fetchInitial(forceRefresh: true),
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 120),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.notifications_none_outlined,
+                          size: 64,
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.45),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          'No notifications in the database',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final showLoadMore = service.hasMore;
+          final itemCount = service.entries.length + (showLoadMore ? 1 : 0);
+
+          return RefreshIndicator(
+            onRefresh: () => service.fetchInitial(forceRefresh: true),
+            child: ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+              itemCount: itemCount,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                if (index >= service.entries.length) {
+                  return _AdminNotificationsLoadMoreFooter(service: service);
+                }
+                final entry = service.entries[index];
+                return _AdminNotificationCard(
+                  entry: entry,
+                  l10n: l10n,
+                  onDelete: () => _confirmDelete(context, service, entry),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    AdminNotificationsService service,
+    AdminNotificationEntry entry,
+  ) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete notification'),
+        content: const Text(
+          'Remove this notification from the recipient’s inbox? This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (ok != true || !context.mounted) return;
+
+    final success = await service.deleteNotification(entry);
+    if (!context.mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(success ? 'Notification deleted' : 'Failed to delete'),
+        backgroundColor: success ? null : Colors.red,
+      ),
+    );
+  }
+}
+
+class _AdminNotificationCard extends StatelessWidget {
+  const _AdminNotificationCard({
+    required this.entry,
+    required this.l10n,
+    required this.onDelete,
+  });
+
+  final AdminNotificationEntry entry;
+  final AppLocalizations l10n;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final n = entry.notification;
+    final copy = localizedUserNotificationCopy(n, l10n);
+    final timeLabel = _formatCreatedAt(n.createdAt);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 10, 4, 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    copy.title.isNotEmpty ? copy.title : '(no title)',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  if (copy.body != null && copy.body!.trim().isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      copy.body!,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.75),
+                          ),
+                    ),
+                  ],
+                  const SizedBox(height: 8),
+                  SelectableText(
+                    'Recipient: ${entry.recipientUserId}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${n.deeplinkKind.name} · ${n.deeplinkId}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.65),
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 4,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      Text(
+                        timeLabel,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      if (n.notificationKind != null && n.notificationKind!.isNotEmpty)
+                        Chip(
+                          label: Text(n.notificationKind!, style: const TextStyle(fontSize: 12)),
+                          visualDensity: VisualDensity.compact,
+                          padding: EdgeInsets.zero,
+                          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                      Chip(
+                        label: Text(n.read ? 'Read' : 'Unread', style: const TextStyle(fontSize: 12)),
+                        visualDensity: VisualDensity.compact,
+                        padding: EdgeInsets.zero,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              tooltip: 'Delete',
+              icon: const Icon(Icons.delete_outline),
+              onPressed: onDelete,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatCreatedAt(DateTime? createdAt) {
+    if (createdAt == null) {
+      return 'Time unknown';
+    }
+    return '${DateFormat.yMMMd().add_Hms().format(createdAt.toUtc())} UTC';
+  }
+}
+
+class _AdminNotificationsLoadMoreFooter extends StatelessWidget {
+  const _AdminNotificationsLoadMoreFooter({required this.service});
+
+  final AdminNotificationsService service;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Center(
+        child: service.isLoadingMore
+            ? const SizedBox(
+                width: 28,
+                height: 28,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : FilledButton.icon(
+                onPressed: () => service.loadMore(),
+                icon: const Icon(Icons.expand_more),
+                label: const Text('Load more'),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/services/admin_notifications_service.dart
+++ b/lib/services/admin_notifications_service.dart
@@ -1,0 +1,158 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/user_notification.dart';
+
+/// One in-app notification plus the recipient user id (Firestore path
+/// `users/{uid}/notifications/{id}`).
+class AdminNotificationEntry {
+  const AdminNotificationEntry({
+    required this.recipientUserId,
+    required this.notification,
+    required this.documentReference,
+  });
+
+  final String recipientUserId;
+  final UserNotification notification;
+  final DocumentReference<Map<String, dynamic>> documentReference;
+}
+
+/// Paginated collection-group query over all users' notification inboxes (admin only).
+class AdminNotificationsService extends ChangeNotifier {
+  AdminNotificationsService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  final List<AdminNotificationEntry> _entries = <AdminNotificationEntry>[];
+  bool _isLoading = false;
+  bool _isLoadingMore = false;
+  String? _error;
+  QueryDocumentSnapshot<Map<String, dynamic>>? _lastDocument;
+  bool _hasMore = true;
+
+  static const int _defaultPageSize = 50;
+
+  List<AdminNotificationEntry> get entries =>
+      List<AdminNotificationEntry>.unmodifiable(_entries);
+
+  bool get isLoading => _isLoading;
+
+  bool get isLoadingMore => _isLoadingMore;
+
+  bool get hasMore => _hasMore;
+
+  String? get error => _error;
+
+  /// Loads the first page (newest [createdAt] first).
+  Future<void> fetchInitial({bool forceRefresh = false, int pageSize = _defaultPageSize}) async {
+    if (_isLoading && !forceRefresh) {
+      return;
+    }
+
+    _isLoading = true;
+    _isLoadingMore = false;
+    _error = null;
+    if (forceRefresh) {
+      _entries.clear();
+      _lastDocument = null;
+      _hasMore = true;
+    }
+    notifyListeners();
+
+    try {
+      final snapshot = await _firestore
+          .collectionGroup('notifications')
+          .orderBy('createdAt', descending: true)
+          .limit(pageSize)
+          .get();
+
+      _applyPage(snapshot, pageSize, replaceExisting: true);
+    } catch (e, stackTrace) {
+      _error = 'Failed to load notifications';
+      debugPrint('AdminNotificationsService.fetchInitial error: $e');
+      debugPrint('$stackTrace');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Appends the next page using the Firestore cursor.
+  Future<void> loadMore({int pageSize = _defaultPageSize}) async {
+    if (!_hasMore || _isLoading || _isLoadingMore || _lastDocument == null) {
+      return;
+    }
+
+    _isLoadingMore = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final snapshot = await _firestore
+          .collectionGroup('notifications')
+          .orderBy('createdAt', descending: true)
+          .startAfterDocument(_lastDocument!)
+          .limit(pageSize)
+          .get();
+
+      _applyPage(snapshot, pageSize, replaceExisting: false);
+    } catch (e, stackTrace) {
+      _error = 'Failed to load more notifications';
+      debugPrint('AdminNotificationsService.loadMore error: $e');
+      debugPrint('$stackTrace');
+    } finally {
+      _isLoadingMore = false;
+      notifyListeners();
+    }
+  }
+
+  void _applyPage(
+    QuerySnapshot<Map<String, dynamic>> snapshot,
+    int pageSize, {
+    required bool replaceExisting,
+  }) {
+    final docs = snapshot.docs;
+    if (replaceExisting) {
+      _entries.clear();
+    }
+
+    for (final doc in docs) {
+      final userRef = doc.reference.parent.parent;
+      final recipientUserId = userRef?.id ?? '';
+      _entries.add(
+        AdminNotificationEntry(
+          recipientUserId: recipientUserId,
+          notification: UserNotification.fromFirestore(doc),
+          documentReference: doc.reference,
+        ),
+      );
+    }
+
+    if (replaceExisting) {
+      _lastDocument = docs.isNotEmpty ? docs.last : null;
+      _hasMore = docs.length >= pageSize;
+    } else if (docs.isEmpty) {
+      _hasMore = false;
+    } else {
+      _lastDocument = docs.last;
+      _hasMore = docs.length >= pageSize;
+    }
+  }
+
+  /// Deletes a notification document. Returns true on success.
+  Future<bool> deleteNotification(AdminNotificationEntry entry) async {
+    _error = null;
+    try {
+      await entry.documentReference.delete();
+      _entries.removeWhere((e) => e.documentReference.path == entry.documentReference.path);
+      notifyListeners();
+      return true;
+    } catch (e, st) {
+      debugPrint('AdminNotificationsService.deleteNotification: $e\n$st');
+      _error = e.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **Admin → All notifications** screen that loads in-app notification documents from every user’s `users/{uid}/notifications` subcollection via a Firestore collection-group query, ordered by `createdAt` descending (newest first). The first page loads 50 items; **Load more** fetches the next 50, matching the User Management pattern.

Admins can **delete** a notification from the list (confirmation dialog). Firestore rules were updated so admins may read any user’s notifications (for the query) and delete notification documents; regular users keep the same read/update behavior for their own inbox.

A composite index was added for `collectionGroup("notifications")` with `createdAt` DESC.

## Deploy notes

After merge, deploy Firestore rules and indexes (e.g. `firebase deploy --only firestore:rules,firestore:indexes`) so production picks up the new permissions and index.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-529dac42-2442-41e0-9f5d-13b6e5b5d7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-529dac42-2442-41e0-9f5d-13b6e5b5d7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

