### PR TITLE
Track Create Native spots and exclude from profile stats/notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -61,6 +61,9 @@ const {
   fanOutNearbyNewSpotNotifications,
 } = require("./lib/nearby-new-spot-notifications");
 const {
+  markCreateNativeOriginalSpots,
+} = require("./lib/retroactive-create-native-flag");
+const {
   fanOutNearbyCheckInNotifications,
 } = require("./lib/nearby-check-in-notifications");
 const {
@@ -1096,6 +1099,23 @@ exports.recomputeSpotRankings = onCall(
       } catch (error) {
         console.error("recomputeSpotRankings error", error);
         return {success: false, error: error.message};
+      }
+    },
+);
+
+// ========== Admin Callable: Mark retroactive Create Native originals ==========
+exports.markCreateNativeDuplicateTargets = onCall(
+    {region: "europe-west1", memory: "512MiB", timeoutSeconds: 540},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const result = await markCreateNativeOriginalSpots({db, FieldValue});
+        return {success: true, ...result};
+      } catch (error) {
+        console.error("markCreateNativeDuplicateTargets error", error);
+        throw new Error(
+            `Failed to mark Create Native duplicate targets: ${error.message}`,
+        );
       }
     },
 );

--- a/functions/index.js
+++ b/functions/index.js
@@ -61,7 +61,7 @@ const {
   fanOutNearbyNewSpotNotifications,
 } = require("./lib/nearby-new-spot-notifications");
 const {
-  markCreateNativeOriginalSpots,
+  markRetroactiveCreateNativeFlags,
 } = require("./lib/retroactive-create-native-flag");
 const {
   fanOutNearbyCheckInNotifications,
@@ -1109,7 +1109,10 @@ exports.markCreateNativeDuplicateTargets = onCall(
     async (request) => {
       try {
         await ensureAdmin(request);
-        const result = await markCreateNativeOriginalSpots({db, FieldValue});
+        const result = await markRetroactiveCreateNativeFlags({
+          db,
+          FieldValue,
+        });
         return {success: true, ...result};
       } catch (error) {
         console.error("markCreateNativeDuplicateTargets error", error);

--- a/functions/lib/nearby-new-spot-notifications.js
+++ b/functions/lib/nearby-new-spot-notifications.js
@@ -148,6 +148,9 @@ function shouldFanOutNearbyNewSpotNotifications(spotData) {
   if (!spotData || spotData.hidden === true) {
     return false;
   }
+  if (spotData.createdFromCreateNative === true) {
+    return false;
+  }
   if (spotData.spotSource != null && String(spotData.spotSource).trim() !== "") {
     return false;
   }

--- a/functions/lib/retroactive-create-native-flag.js
+++ b/functions/lib/retroactive-create-native-flag.js
@@ -1,0 +1,105 @@
+const GET_ALL_CHUNK = 200;
+const BATCH_SIZE = 500;
+
+/**
+ * Marks native original spots as created via Create Native when any duplicate
+ * points to them via duplicateOf.
+ * @param {object} options
+ * @param {object} options.db Firestore instance
+ * @param {object} options.FieldValue admin.firestore.FieldValue
+ * @return {Promise<object>}
+ */
+async function markRetroactiveCreateNativeFlags({db, FieldValue}) {
+  const duplicatesSnap = await db
+      .collection("spots")
+      .where("duplicateOf", "!=", null)
+      .select("duplicateOf")
+      .get();
+
+  const targetIds = new Set();
+  for (const doc of duplicatesSnap.docs) {
+    const duplicateOf = doc.data()?.duplicateOf;
+    if (typeof duplicateOf === "string" && duplicateOf.trim().length > 0) {
+      targetIds.add(duplicateOf.trim());
+    }
+  }
+
+  if (targetIds.size === 0) {
+    return {
+      candidateCount: 0,
+      existingTargetCount: 0,
+      updatedCount: 0,
+      alreadyMarkedCount: 0,
+      skippedNonNativeCount: 0,
+      missingTargetCount: 0,
+    };
+  }
+
+  const targetIdList = Array.from(targetIds);
+  let existingTargetCount = 0;
+  let updatedCount = 0;
+  let alreadyMarkedCount = 0;
+  let skippedNonNativeCount = 0;
+  let missingTargetCount = 0;
+
+  let batch = db.batch();
+  let ops = 0;
+  for (let i = 0; i < targetIdList.length; i += GET_ALL_CHUNK) {
+    const chunk = targetIdList.slice(i, i + GET_ALL_CHUNK);
+    const refs = chunk.map((spotId) => db.collection("spots").doc(spotId));
+    const docs = await db.getAll(...refs);
+
+    for (let j = 0; j < docs.length; j++) {
+      const spotDoc = docs[j];
+      if (!spotDoc.exists) {
+        missingTargetCount++;
+        continue;
+      }
+
+      existingTargetCount++;
+      const data = spotDoc.data() || {};
+      const rawSpotSource = data.spotSource;
+      const isNative = rawSpotSource == null ||
+          String(rawSpotSource).trim() === "";
+      if (!isNative) {
+        skippedNonNativeCount++;
+        continue;
+      }
+
+      if (data.createdFromCreateNative === true) {
+        alreadyMarkedCount++;
+        continue;
+      }
+
+      batch.update(spotDoc.ref, {
+        createdFromCreateNative: true,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      updatedCount++;
+      ops++;
+
+      if (ops >= BATCH_SIZE) {
+        await batch.commit();
+        batch = db.batch();
+        ops = 0;
+      }
+    }
+  }
+
+  if (ops > 0) {
+    await batch.commit();
+  }
+
+  return {
+    candidateCount: targetIds.size,
+    existingTargetCount,
+    updatedCount,
+    alreadyMarkedCount,
+    skippedNonNativeCount,
+    missingTargetCount,
+  };
+}
+
+module.exports = {
+  markRetroactiveCreateNativeFlags,
+};

--- a/functions/lib/retroactive-create-native-flag.js
+++ b/functions/lib/retroactive-create-native-flag.js
@@ -1,5 +1,4 @@
 const GET_ALL_CHUNK = 200;
-const BATCH_SIZE = 500;
 
 /**
  * Marks native original spots as created via Create Native when any duplicate
@@ -10,11 +9,13 @@ const BATCH_SIZE = 500;
  * @return {Promise<object>}
  */
 async function markRetroactiveCreateNativeFlags({db, FieldValue}) {
-  const duplicatesSnap = await db
+  let duplicatesQuery = db
       .collection("spots")
-      .where("duplicateOf", "!=", null)
-      .select("duplicateOf")
-      .get();
+      .where("duplicateOf", "!=", null);
+  if (typeof duplicatesQuery.select === "function") {
+    duplicatesQuery = duplicatesQuery.select("duplicateOf");
+  }
+  const duplicatesSnap = await duplicatesQuery.get();
 
   const targetIds = new Set();
   for (const doc of duplicatesSnap.docs) {
@@ -26,77 +27,77 @@ async function markRetroactiveCreateNativeFlags({db, FieldValue}) {
 
   if (targetIds.size === 0) {
     return {
-      candidateCount: 0,
-      existingTargetCount: 0,
-      updatedCount: 0,
-      alreadyMarkedCount: 0,
-      skippedNonNativeCount: 0,
-      missingTargetCount: 0,
+      duplicateTargetsFound: 0,
+      processed: 0,
+      marked: 0,
+      skippedAlreadyMarked: 0,
+      skippedImported: 0,
+      skippedMissing: 0,
+      failed: 0,
+      failedSpotIds: [],
     };
   }
 
   const targetIdList = Array.from(targetIds);
-  let existingTargetCount = 0;
-  let updatedCount = 0;
-  let alreadyMarkedCount = 0;
-  let skippedNonNativeCount = 0;
-  let missingTargetCount = 0;
+  let processed = 0;
+  let marked = 0;
+  let skippedAlreadyMarked = 0;
+  let skippedImported = 0;
+  let skippedMissing = 0;
+  let failed = 0;
+  const failedSpotIds = [];
 
-  let batch = db.batch();
-  let ops = 0;
   for (let i = 0; i < targetIdList.length; i += GET_ALL_CHUNK) {
     const chunk = targetIdList.slice(i, i + GET_ALL_CHUNK);
     const refs = chunk.map((spotId) => db.collection("spots").doc(spotId));
-    const docs = await db.getAll(...refs);
+    const docs = typeof db.getAll === "function" ?
+      await db.getAll(...refs) :
+      await Promise.all(refs.map((ref) => ref.get()));
 
     for (let j = 0; j < docs.length; j++) {
       const spotDoc = docs[j];
       if (!spotDoc.exists) {
-        missingTargetCount++;
+        skippedMissing++;
         continue;
       }
 
-      existingTargetCount++;
+      processed++;
       const data = spotDoc.data() || {};
       const rawSpotSource = data.spotSource;
       const isNative = rawSpotSource == null ||
           String(rawSpotSource).trim() === "";
       if (!isNative) {
-        skippedNonNativeCount++;
+        skippedImported++;
         continue;
       }
 
       if (data.createdFromCreateNative === true) {
-        alreadyMarkedCount++;
+        skippedAlreadyMarked++;
         continue;
       }
 
-      batch.update(spotDoc.ref, {
-        createdFromCreateNative: true,
-        updatedAt: FieldValue.serverTimestamp(),
-      });
-      updatedCount++;
-      ops++;
-
-      if (ops >= BATCH_SIZE) {
-        await batch.commit();
-        batch = db.batch();
-        ops = 0;
+      try {
+        await spotDoc.ref.update({
+          createdFromCreateNative: true,
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        marked++;
+      } catch (error) {
+        failed++;
+        failedSpotIds.push(spotDoc.id);
       }
     }
   }
 
-  if (ops > 0) {
-    await batch.commit();
-  }
-
   return {
-    candidateCount: targetIds.size,
-    existingTargetCount,
-    updatedCount,
-    alreadyMarkedCount,
-    skippedNonNativeCount,
-    missingTargetCount,
+    duplicateTargetsFound: targetIds.size,
+    processed,
+    marked,
+    skippedAlreadyMarked,
+    skippedImported,
+    skippedMissing,
+    failed,
+    failedSpotIds,
   };
 }
 

--- a/functions/test/nearby-new-spot-notifications.test.js
+++ b/functions/test/nearby-new-spot-notifications.test.js
@@ -35,6 +35,13 @@ describe("shouldFanOutNearbyNewSpotNotifications", () => {
       longitude: 1,
     })).toBe(false);
   });
+  it("returns false when spot was created from Create Native", () => {
+    expect(shouldFanOutNearbyNewSpotNotifications({
+      createdFromCreateNative: true,
+      latitude: 1,
+      longitude: 1,
+    })).toBe(false);
+  });
   it("returns false for invalid coordinates", () => {
     expect(shouldFanOutNearbyNewSpotNotifications({
       latitude: NaN,

--- a/functions/test/retroactive-create-native-flag.test.js
+++ b/functions/test/retroactive-create-native-flag.test.js
@@ -1,0 +1,141 @@
+const {
+  markRetroactiveCreateNativeFlags,
+} = require("../lib/retroactive-create-native-flag");
+
+describe("markRetroactiveCreateNativeFlags", () => {
+  function createSpotDoc(id, data = {}) {
+    const updates = [];
+    return {
+      id,
+      data: () => data,
+      ref: {
+        update: jest.fn(async (payload) => {
+          updates.push(payload);
+        }),
+      },
+      updates,
+    };
+  }
+
+  function createDuplicatesSnapshot(duplicateOfValues) {
+    return {
+      docs: duplicateOfValues.map((duplicateOf, index) => ({
+        id: `dup-${index + 1}`,
+        data: () => ({duplicateOf}),
+      })),
+    };
+  }
+
+  function createDb({
+    duplicates,
+    originalSpotDocsById,
+  }) {
+    return {
+      collection: jest.fn((name) => {
+        if (name !== "spots") {
+          throw new Error(`Unexpected collection ${name}`);
+        }
+        return {
+          where: jest.fn((field, op, value) => {
+            if (field === "duplicateOf" && op === "!=" && value === null) {
+              return {
+                get: jest.fn(async () => createDuplicatesSnapshot(duplicates)),
+              };
+            }
+            throw new Error(
+                `Unexpected where call: ${field} ${op} ${String(value)}`,
+            );
+          }),
+          doc: jest.fn((id) => ({
+            get: jest.fn(async () => {
+              const doc = originalSpotDocsById[id];
+              if (!doc) {
+                return {exists: false};
+              }
+              return {
+                exists: true,
+                id: doc.id,
+                data: doc.data,
+                ref: doc.ref,
+              };
+            }),
+          })),
+        };
+      }),
+    };
+  }
+
+  it("marks only eligible native original spots", async () => {
+    const eligible = createSpotDoc("orig-1", {
+      spotSource: null,
+      createdFromCreateNative: false,
+    });
+    const alreadyMarked = createSpotDoc("orig-2", {
+      spotSource: null,
+      createdFromCreateNative: true,
+    });
+    const imported = createSpotDoc("orig-3", {
+      spotSource: "kml",
+      createdFromCreateNative: false,
+    });
+
+    const db = createDb({
+      duplicates: ["orig-1", "orig-2", "orig-3", "orig-1"],
+      originalSpotDocsById: {
+        "orig-1": eligible,
+        "orig-2": alreadyMarked,
+        "orig-3": imported,
+      },
+    });
+    const FieldValue = {serverTimestamp: jest.fn(() => ({_serverTs: true}))};
+
+    const result = await markRetroactiveCreateNativeFlags({
+      db,
+      FieldValue,
+    });
+
+    expect(result).toEqual({
+      duplicateTargetsFound: 3,
+      processed: 3,
+      marked: 1,
+      skippedAlreadyMarked: 1,
+      skippedImported: 1,
+      skippedMissing: 0,
+      failed: 0,
+      failedSpotIds: [],
+    });
+    expect(eligible.ref.update).toHaveBeenCalledTimes(1);
+    expect(alreadyMarked.ref.update).not.toHaveBeenCalled();
+    expect(imported.ref.update).not.toHaveBeenCalled();
+  });
+
+  it("tracks missing and failed originals without aborting", async () => {
+    const failing = createSpotDoc("orig-fail", {
+      spotSource: null,
+      createdFromCreateNative: false,
+    });
+    failing.ref.update = jest.fn(async () => {
+      throw new Error("update failed");
+    });
+
+    const db = createDb({
+      duplicates: ["orig-missing", "orig-fail"],
+      originalSpotDocsById: {
+        "orig-fail": failing,
+      },
+    });
+    const FieldValue = {serverTimestamp: jest.fn(() => ({_serverTs: true}))};
+
+    const result = await markRetroactiveCreateNativeFlags({
+      db,
+      FieldValue,
+    });
+
+    expect(result.duplicateTargetsFound).toBe(2);
+    expect(result.processed).toBe(1);
+    expect(result.marked).toBe(0);
+    expect(result.skippedMissing).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.failedSpotIds).toEqual(["orig-fail"]);
+  });
+});

--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -30,7 +30,10 @@ class Spot {
   final List<String>? goodFor;
   final String? duplicateOf; // ID of the original spot if this is a duplicate
   final bool hidden; // Whether the spot is hidden from public view
-  final List<Map<String, String>>? contributors; // List of contributors who improved the spot
+  final List<Map<String, String>>?
+  contributors; // List of contributors who improved the spot
+  final bool
+  createdFromCreateNative; // Whether spot was created via "Create Native"
 
   static const Object _unset = Object();
 
@@ -65,6 +68,7 @@ class Spot {
     this.duplicateOf,
     this.hidden = false,
     this.contributors,
+    this.createdFromCreateNative = false,
   });
 
   factory Spot.fromFirestore(DocumentSnapshot doc) {
@@ -73,14 +77,17 @@ class Spot {
       final trimmed = input.trim();
       if (trimmed.isEmpty) return null;
       // If it's already a likely ID, return as-is (11 chars typical)
-      if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) && !trimmed.contains('/')) {
+      if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) &&
+          !trimmed.contains('/')) {
         return trimmed;
       }
       try {
         final uri = Uri.parse(trimmed);
         // youtu.be/<id>
         if (uri.host.contains('youtu.be')) {
-          final seg = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : null;
+          final seg = uri.pathSegments.isNotEmpty
+              ? uri.pathSegments.last
+              : null;
           if (seg != null && seg.isNotEmpty) return seg;
         }
         // youtube.com/watch?v=<id>
@@ -99,6 +106,7 @@ class Spot {
       } catch (_) {}
       return trimmed; // Fallback to raw value
     }
+
     List<String>? extractYoutubeIdsList(dynamic value) {
       if (value == null) return null;
       if (value is List) {
@@ -115,6 +123,7 @@ class Spot {
       }
       return null;
     }
+
     return Spot(
       id: doc.id,
       name: data['name'] ?? '',
@@ -127,9 +136,7 @@ class Spot {
       imageUrls: data['imageUrls'] != null
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl']] : null),
-      youtubeVideoIds: extractYoutubeIdsList(
-        data['youtubeVideoIds'],
-      ),
+      youtubeVideoIds: extractYoutubeIdsList(data['youtubeVideoIds']),
       folderName: data['folderName'],
       createdBy: data['createdBy'],
       createdByName: data['createdByName'],
@@ -141,21 +148,34 @@ class Spot {
       spotSourceRemovedAt: data['spotSourceRemovedAt'] is Timestamp
           ? (data['spotSourceRemovedAt'] as Timestamp).toDate()
           : null,
-      averageRating: data['averageRating'] != null ? (data['averageRating'] as num).toDouble() : null,
+      averageRating: data['averageRating'] != null
+          ? (data['averageRating'] as num).toDouble()
+          : null,
       ratingCount: data['ratingCount'],
-      wilsonLowerBound: data['wilsonLowerBound'] != null ? (data['wilsonLowerBound'] as num).toDouble() : null,
-      ranking: data['ranking'] != null ? (data['ranking'] as num).toDouble() : null,
+      wilsonLowerBound: data['wilsonLowerBound'] != null
+          ? (data['wilsonLowerBound'] as num).toDouble()
+          : null,
+      ranking: data['ranking'] != null
+          ? (data['ranking'] as num).toDouble()
+          : null,
       spotAccess: data['spotAccess'],
-      spotFeatures: data['spotFeatures'] != null ? List<String>.from(data['spotFeatures']) : null,
-      spotFacilities: data['spotFacilities'] != null ? Map<String, String>.from(data['spotFacilities']) : null,
-      goodFor: data['goodFor'] != null ? List<String>.from(data['goodFor']) : null,
+      spotFeatures: data['spotFeatures'] != null
+          ? List<String>.from(data['spotFeatures'])
+          : null,
+      spotFacilities: data['spotFacilities'] != null
+          ? Map<String, String>.from(data['spotFacilities'])
+          : null,
+      goodFor: data['goodFor'] != null
+          ? List<String>.from(data['goodFor'])
+          : null,
       duplicateOf: data['duplicateOf'],
       hidden: data['hidden'] == true,
       contributors: data['contributors'] != null
           ? (data['contributors'] as List)
-              .map((e) => Map<String, String>.from(e as Map))
-              .toList()
+                .map((e) => Map<String, String>.from(e as Map))
+                .toList()
           : null,
+      createdFromCreateNative: data['createdFromCreateNative'] == true,
     );
   }
 
@@ -163,13 +183,16 @@ class Spot {
     String? extractYoutubeId(String input) {
       final trimmed = input.trim();
       if (trimmed.isEmpty) return null;
-      if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) && !trimmed.contains('/')) {
+      if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) &&
+          !trimmed.contains('/')) {
         return trimmed;
       }
       try {
         final uri = Uri.parse(trimmed);
         if (uri.host.contains('youtu.be')) {
-          final seg = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : null;
+          final seg = uri.pathSegments.isNotEmpty
+              ? uri.pathSegments.last
+              : null;
           if (seg != null && seg.isNotEmpty) return seg;
         }
         final vParam = uri.queryParameters['v'];
@@ -185,6 +208,7 @@ class Spot {
       } catch (_) {}
       return trimmed;
     }
+
     List<String>? extractYoutubeIdsList(dynamic value) {
       if (value == null) return null;
       if (value is List) {
@@ -201,6 +225,7 @@ class Spot {
       }
       return null;
     }
+
     DateTime? parseDate(dynamic v) {
       if (v == null) return null;
       if (v is Timestamp) return v.toDate();
@@ -226,9 +251,7 @@ class Spot {
       imageUrls: data['imageUrls'] is List
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl'] as String] : null),
-      youtubeVideoIds: extractYoutubeIdsList(
-        data['youtubeVideoIds'],
-      ),
+      youtubeVideoIds: extractYoutubeIdsList(data['youtubeVideoIds']),
       folderName: data['folderName'] as String?,
       createdBy: data['createdBy'] as String?,
       createdByName: data['createdByName'] as String?,
@@ -239,20 +262,29 @@ class Spot {
       spotSourceRemoved: data['spotSourceRemoved'] == true,
       spotSourceRemovedAt: parseDate(data['spotSourceRemovedAt']),
       averageRating: (data['averageRating'] as num?)?.toDouble(),
-      ratingCount: (data['ratingCount'] is int) ? data['ratingCount'] as int : (data['ratingCount'] as num?)?.toInt(),
+      ratingCount: (data['ratingCount'] is int)
+          ? data['ratingCount'] as int
+          : (data['ratingCount'] as num?)?.toInt(),
       wilsonLowerBound: (data['wilsonLowerBound'] as num?)?.toDouble(),
       ranking: (data['ranking'] as num?)?.toDouble(),
       spotAccess: data['spotAccess'] as String?,
-      spotFeatures: data['spotFeatures'] is List ? List<String>.from(data['spotFeatures']) : null,
-      spotFacilities: data['spotFacilities'] is Map ? Map<String, String>.from(data['spotFacilities']) : null,
-      goodFor: data['goodFor'] is List ? List<String>.from(data['goodFor']) : null,
+      spotFeatures: data['spotFeatures'] is List
+          ? List<String>.from(data['spotFeatures'])
+          : null,
+      spotFacilities: data['spotFacilities'] is Map
+          ? Map<String, String>.from(data['spotFacilities'])
+          : null,
+      goodFor: data['goodFor'] is List
+          ? List<String>.from(data['goodFor'])
+          : null,
       duplicateOf: data['duplicateOf'] as String?,
       hidden: data['hidden'] == true,
       contributors: data['contributors'] is List
           ? (data['contributors'] as List)
-              .map((e) => Map<String, String>.from(e as Map))
-              .toList()
+                .map((e) => Map<String, String>.from(e as Map))
+                .toList()
           : null,
+      createdFromCreateNative: data['createdFromCreateNative'] == true,
     );
   }
 
@@ -278,7 +310,8 @@ class Spot {
       'spotSource': spotSource,
       'spotSourceName': spotSourceName,
       'spotSourceRemoved': spotSourceRemoved,
-      if (spotSourceRemovedAt != null) 'spotSourceRemovedAt': spotSourceRemovedAt,
+      if (spotSourceRemovedAt != null)
+        'spotSourceRemovedAt': spotSourceRemovedAt,
       if (averageRating != null) 'averageRating': averageRating,
       if (ratingCount != null) 'ratingCount': ratingCount,
       if (wilsonLowerBound != null) 'wilsonLowerBound': wilsonLowerBound,
@@ -290,6 +323,7 @@ class Spot {
       'duplicateOf': duplicateOf,
       'hidden': hidden,
       if (contributors != null) 'contributors': contributors,
+      'createdFromCreateNative': createdFromCreateNative,
     };
   }
 
@@ -324,6 +358,7 @@ class Spot {
     Object? duplicateOf = _unset,
     bool? hidden,
     List<Map<String, String>>? contributors,
+    bool? createdFromCreateNative,
   }) {
     return Spot(
       id: id ?? this.id,
@@ -335,7 +370,9 @@ class Spot {
       city: city ?? this.city,
       countryCode: countryCode ?? this.countryCode,
       imageUrls: imageUrls ?? this.imageUrls,
-      youtubeVideoIds: identical(youtubeVideoIds, _unset) ? this.youtubeVideoIds : youtubeVideoIds as List<String>?,
+      youtubeVideoIds: identical(youtubeVideoIds, _unset)
+          ? this.youtubeVideoIds
+          : youtubeVideoIds as List<String>?,
       folderName: folderName ?? this.folderName,
       createdBy: createdBy ?? this.createdBy,
       createdByName: createdByName ?? this.createdByName,
@@ -355,12 +392,15 @@ class Spot {
       spotFeatures: spotFeatures ?? this.spotFeatures,
       spotFacilities: spotFacilities ?? this.spotFacilities,
       goodFor: goodFor ?? this.goodFor,
-      duplicateOf: identical(duplicateOf, _unset) ? this.duplicateOf : duplicateOf as String?,
+      duplicateOf: identical(duplicateOf, _unset)
+          ? this.duplicateOf
+          : duplicateOf as String?,
       hidden: hidden ?? this.hidden,
       contributors: contributors ?? this.contributors,
+      createdFromCreateNative:
+          createdFromCreateNative ?? this.createdFromCreateNative,
     );
   }
-
 
   @override
   String toString() {

--- a/lib/screens/admin/admin_home_screen.dart
+++ b/lib/screens/admin/admin_home_screen.dart
@@ -250,6 +250,75 @@ class AdminHomeScreen extends StatelessWidget {
           const SizedBox(height: 8),
           Card(
             child: ListTile(
+              leading: const Icon(Icons.merge_type),
+              title: const Text('Mark Create Native Originals'),
+              subtitle: const Text(
+                'Set createdFromCreateNative=true for native spots targeted by duplicateOf',
+              ),
+              onTap: () async {
+                final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('Mark Create Native Originals'),
+                    content: const Text(
+                      'This scans spots with duplicateOf set and marks their native original spot '
+                      'with createdFromCreateNative=true when appropriate. Continue?',
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(ctx).pop(false),
+                        child: const Text('Cancel'),
+                      ),
+                      ElevatedButton(
+                        onPressed: () => Navigator.of(ctx).pop(true),
+                        child: const Text('Run'),
+                      ),
+                    ],
+                  ),
+                );
+
+                if (confirmed != true) return;
+
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Marking Create Native originals...'),
+                  ),
+                );
+
+                try {
+                  final spotService = Provider.of<SpotService>(
+                    context,
+                    listen: false,
+                  );
+                  final result = await spotService
+                      .markCreateNativeDuplicateTargets();
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        'Done. duplicate targets ${result['duplicateTargetsFound']}, '
+                        'processed ${result['processed']}, '
+                        'marked ${result['marked']}, '
+                        'already marked ${result['skippedAlreadyMarked']}, '
+                        'skipped imported ${result['skippedImported']}, '
+                        'missing ${result['skippedMissing']}, '
+                        'failed ${result['failed']}',
+                      ),
+                    ),
+                  );
+                } catch (e) {
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(SnackBar(content: Text('Error: $e')));
+                }
+              },
+            ),
+          ),
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
               leading: const Icon(Icons.map),
               title: const Text('Generate Sitemaps'),
               subtitle: const Text(

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -725,14 +725,14 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
       }).toList();
 
       if (filteredContributors.isNotEmpty) {
-        textSpans.add(
-          TextSpan(
-            text: willHaveUpdatedDate
-                ? l10n.spotDetailImprovedByAfterComma
-                : l10n.spotDetailImprovedByAfterAnd,
-            style: textStyle,
-          ),
-        );
+        final improvedByPrefix = hasPreviousContent
+            ? (willHaveUpdatedDate
+                  ? l10n.spotDetailImprovedByAfterComma
+                  : l10n.spotDetailImprovedByAfterAnd)
+            : _trimLeadingContributorPrefix(
+                l10n.spotDetailImprovedByAfterComma,
+              );
+        textSpans.add(TextSpan(text: improvedByPrefix, style: textStyle));
 
         // Add each contributor name as a clickable link
         for (int i = 0; i < filteredContributors.length; i++) {
@@ -835,6 +835,10 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
 
   String _formatRelativeDate(DateTime date, AppLocalizations l10n) {
     return formatRelativeDateInDays(date, l10n);
+  }
+
+  String _trimLeadingContributorPrefix(String value) {
+    return value.replaceFirst(RegExp(r'^[\s,]+'), '');
   }
 
   void _copySpotToClipboard() async {

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -336,10 +336,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
 
   Future<void> _handleEditTrainingPlan(SpotTrainingPlan p) async {
     final svc = Provider.of<SpotTrainingPlanService>(context, listen: false);
-    final result = await showSpotTrainingPlanDialog(
-      context,
-      existingPlan: p,
-    );
+    final result = await showSpotTrainingPlanDialog(context, existingPlan: p);
     if (result == null || !mounted) return;
     if (result is SpotTrainingPlanDialogOpenCheckIn) {
       await _runCheckInFromTrainingPlan(result.plan);
@@ -372,7 +369,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
     }
   }
 
-  Future<void> _joinTrainingPlanFromCommunity(SpotTrainingPlan sourcePlan) async {
+  Future<void> _joinTrainingPlanFromCommunity(
+    SpotTrainingPlan sourcePlan,
+  ) async {
     final spotId = _spot.id;
     if (spotId == null) return;
     final svc = Provider.of<SpotTrainingPlanService>(context, listen: false);
@@ -619,6 +618,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
     final textStyle = theme.textTheme.bodyLarge?.copyWith(
       color: theme.colorScheme.onSurfaceVariant,
     );
+    final bool hideCreatorAttribution = _spot.createdFromCreateNative;
     bool hasPreviousContent = false;
 
     // Check if there will be an updated date part (to determine if we should use commas)
@@ -629,7 +629,8 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
         (_spot.updatedAt != null && _spot.createdAt == null);
 
     // Created by
-    if (_spot.createdBy != null || _spot.createdByName != null) {
+    if (!hideCreatorAttribution &&
+        (_spot.createdBy != null || _spot.createdByName != null)) {
       final createdBy = _spot.createdByName ?? _spot.createdBy ?? '';
       final createdById = _spot.createdBy;
 
@@ -712,8 +713,8 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
     // Contributors (filter out the createdBy user)
     bool hasContributors = false;
     if (_spot.contributors != null && _spot.contributors!.isNotEmpty) {
-      final createdByName = _spot.createdByName;
-      final createdBy = _spot.createdBy;
+      final createdByName = hideCreatorAttribution ? null : _spot.createdByName;
+      final createdBy = hideCreatorAttribution ? null : _spot.createdBy;
 
       // Filter out contributors that match the createdBy user
       final filteredContributors = _spot.contributors!.where((c) {
@@ -1046,8 +1047,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                   onPressed: () {
                                     _submitRatingDirectly(
                                       index + 1.0,
-                                      refreshModal: () =>
-                                          setModalState(() {}),
+                                      refreshModal: () => setModalState(() {}),
                                     );
                                   },
                                   icon: Icon(
@@ -1096,10 +1096,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
         labelWidget: Text.rich(
           TextSpan(
             children: [
-              TextSpan(
-                text: avg.toStringAsFixed(1),
-                style: baseLabel,
-              ),
+              TextSpan(text: avg.toStringAsFixed(1), style: baseLabel),
               TextSpan(
                 text: ' ($count)',
                 style: baseLabel?.copyWith(
@@ -2130,8 +2127,8 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                               builder: (context, constraints) {
                                 final compactQuickActions =
                                     constraints.maxWidth <
-                                        SpotDetailUi
-                                            .quickActionsCompactLayoutMaxWidth;
+                                    SpotDetailUi
+                                        .quickActionsCompactLayoutMaxWidth;
                                 return SingleChildScrollView(
                                   scrollDirection: Axis.horizontal,
                                   child: Row(
@@ -2146,31 +2143,28 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                       const SizedBox(width: 8),
                                       _SpotSaveMenu(
                                         spotId: _spot.id!,
-                                        onAddToCustomList:
-                                            _showAddToListDialog,
+                                        onAddToCustomList: _showAddToListDialog,
                                         stripBottomPadding: true,
                                         compactQuickActions:
                                             compactQuickActions,
                                       ),
                                       const SizedBox(width: 8),
                                       Tooltip(
-                                        message:
-                                            _l10n.spotDetailRatingTooltip,
+                                        message: _l10n.spotDetailRatingTooltip,
                                         child: Semantics(
                                           button: true,
                                           label: _l10n.spotDetailRatingTooltip,
                                           child: Material(
                                             color: Colors.transparent,
-                                            borderRadius:
-                                                BorderRadius.circular(
+                                            borderRadius: BorderRadius.circular(
                                               SpotDetailUi.surfaceRadius,
                                             ),
                                             clipBehavior: Clip.antiAlias,
                                             child: InkWell(
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                SpotDetailUi.surfaceRadius,
-                                              ),
+                                                    SpotDetailUi.surfaceRadius,
+                                                  ),
                                               onTap: _showSpotRatingSheet,
                                               child:
                                                   _spotDetailRatingQuickChip(),
@@ -2186,16 +2180,15 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                           label: _l10n.spotDetailShareTooltip,
                                           child: Material(
                                             color: Colors.transparent,
-                                            borderRadius:
-                                                BorderRadius.circular(
+                                            borderRadius: BorderRadius.circular(
                                               SpotDetailUi.surfaceRadius,
                                             ),
                                             clipBehavior: Clip.antiAlias,
                                             child: InkWell(
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                SpotDetailUi.surfaceRadius,
-                                              ),
+                                                    SpotDetailUi.surfaceRadius,
+                                                  ),
                                               onTap: _copySpotToClipboard,
                                               child: SpotDetailQuickActionChip(
                                                 icon: Icons.share_outlined,
@@ -2623,8 +2616,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                         ),
 
                         // Merged Created by / Source / Contributors section
-                        if (_spot.createdBy != null ||
-                            _spot.createdByName != null ||
+                        if ((!_spot.createdFromCreateNative &&
+                                (_spot.createdBy != null ||
+                                    _spot.createdByName != null)) ||
                             _spot.spotSource != null ||
                             (_spot.contributors != null &&
                                 _spot.contributors!.isNotEmpty)) ...[
@@ -8524,7 +8518,8 @@ class _SpotRatingUserRatingLoader extends StatefulWidget {
       _SpotRatingUserRatingLoaderState();
 }
 
-class _SpotRatingUserRatingLoaderState extends State<_SpotRatingUserRatingLoader> {
+class _SpotRatingUserRatingLoaderState
+    extends State<_SpotRatingUserRatingLoader> {
   late final Future<double?> _future;
 
   @override

--- a/lib/services/spot_service.dart
+++ b/lib/services/spot_service.dart
@@ -1120,6 +1120,24 @@ class SpotService extends ChangeNotifier {
     }
   }
 
+  Future<Map<String, dynamic>> markCreateNativeDuplicateTargets() async {
+    try {
+      final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
+      final callable = functions.httpsCallable(
+        'markCreateNativeDuplicateTargets',
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
+      );
+      final result = await callable.call();
+      final data = result.data as Map<String, dynamic>;
+      return data;
+    } catch (e) {
+      debugPrint(
+        'Error marking Create Native original spots retroactively: $e',
+      );
+      rethrow;
+    }
+  }
+
   /// Admin: Trigger sitemap generation (countries, unlocated spots, lists, users).
   Future<void> generateSitemaps() async {
     final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');

--- a/lib/services/spot_service.dart
+++ b/lib/services/spot_service.dart
@@ -15,7 +15,7 @@ class SpotService extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseStorage _storage = FirebaseStorage.instance;
   final AuditLogService _auditLogService = AuditLogService();
-  
+
   bool _isLoading = false;
   String? _error;
 
@@ -70,7 +70,11 @@ class SpotService extends ChangeNotifier {
   }
 
   // Create a native spot from an existing spot (copies name, description, location, photos, youtube link)
-  Future<String?> createNativeSpotFromExisting(Spot sourceSpot, String createdBy, String createdByName) async {
+  Future<String?> createNativeSpotFromExisting(
+    Spot sourceSpot,
+    String createdBy,
+    String createdByName,
+  ) async {
     try {
       _isLoading = true;
       notifyListeners();
@@ -100,11 +104,14 @@ class SpotService extends ChangeNotifier {
         goodFor: sourceSpot.goodFor,
         duplicateOf: null, // New native spot, not a duplicate
         hidden: false, // New spot, not hidden
+        createdFromCreateNative: true,
         // spotSource is null (native spot)
       );
 
-      final docRef = await _firestore.collection('spots').add(nativeSpot.toFirestore());
-      
+      final docRef = await _firestore
+          .collection('spots')
+          .add(nativeSpot.toFirestore());
+
       _isLoading = false;
       notifyListeners();
       return docRef.id; // Return the spot ID
@@ -118,13 +125,19 @@ class SpotService extends ChangeNotifier {
   }
 
   // Create a new spot
-  Future<String?> createSpot(Spot spot, {File? imageFile, Uint8List? imageBytes, List<File>? imageFiles, List<Uint8List>? imageBytesList}) async {
+  Future<String?> createSpot(
+    Spot spot, {
+    File? imageFile,
+    Uint8List? imageBytes,
+    List<File>? imageFiles,
+    List<Uint8List>? imageBytesList,
+  }) async {
     try {
       _isLoading = true;
       notifyListeners();
 
       List<String>? imageUrls;
-      
+
       // Handle single image uploads
       if (imageFile != null) {
         final imageUrl = await _uploadImage(imageFile);
@@ -133,7 +146,7 @@ class SpotService extends ChangeNotifier {
         final imageUrl = await _uploadImageBytes(imageBytes);
         imageUrls = [imageUrl];
       }
-      
+
       // Handle multiple image uploads
       if (imageFiles != null && imageFiles.isNotEmpty) {
         imageUrls = await _uploadImages(imageFiles);
@@ -147,11 +160,14 @@ class SpotService extends ChangeNotifier {
         updatedAt: DateTime.now(),
         ranking: spot.ranking ?? Random().nextDouble(),
         duplicateOf: null, // New spot, not a duplicate
-        hidden: spot.hidden, // Preserve hidden field (defaults to false for new spots)
+        hidden: spot
+            .hidden, // Preserve hidden field (defaults to false for new spots)
       );
 
-      final docRef = await _firestore.collection('spots').add(spotWithImages.toFirestore());
-      
+      final docRef = await _firestore
+          .collection('spots')
+          .add(spotWithImages.toFirestore());
+
       return docRef.id; // Return the spot ID
     } catch (e) {
       _error = 'Failed to create spot: $e';
@@ -165,17 +181,15 @@ class SpotService extends ChangeNotifier {
 
   // Update an existing spot with comprehensive image management
   Future<bool> updateSpot(
-    Spot spot, 
-    {
-      List<File>? newImageFiles,
-      List<Uint8List>? newImageBytesList,
-      List<String>? imagesToDelete,
-      String? userId,
-      String? userName,
-      String? reportId,
-      String? notes,
-    }
-  ) async {
+    Spot spot, {
+    List<File>? newImageFiles,
+    List<Uint8List>? newImageBytesList,
+    List<String>? imagesToDelete,
+    String? userId,
+    String? userName,
+    String? reportId,
+    String? notes,
+  }) async {
     try {
       _isLoading = true;
       notifyListeners();
@@ -212,8 +226,11 @@ class SpotService extends ChangeNotifier {
         hidden: spot.hidden, // Preserve existing hidden field
       );
 
-      await _firestore.collection('spots').doc(spot.id).update(updatedSpot.toFirestore(isUpdate: true));
-      
+      await _firestore
+          .collection('spots')
+          .doc(spot.id)
+          .update(updatedSpot.toFirestore(isUpdate: true));
+
       // Log audit trail if user info is provided (moderator edit)
       if (userId != null && userName != null && oldSpot != null) {
         final changes = _computeSpotChanges(oldSpot, updatedSpot);
@@ -228,7 +245,7 @@ class SpotService extends ChangeNotifier {
           );
         }
       }
-      
+
       _isLoading = false;
       notifyListeners();
       return true;
@@ -273,7 +290,9 @@ class SpotService extends ChangeNotifier {
         updatedSpot = updatedSpot.copyWith(name: updates['name'] as String?);
       }
       if (updates.containsKey('description')) {
-        updatedSpot = updatedSpot.copyWith(description: updates['description'] as String?);
+        updatedSpot = updatedSpot.copyWith(
+          description: updates['description'] as String?,
+        );
       }
       if (updates.containsKey('latitude') && updates.containsKey('longitude')) {
         updatedSpot = updatedSpot.copyWith(
@@ -299,7 +318,9 @@ class SpotService extends ChangeNotifier {
         );
       }
       if (updates.containsKey('spotAccess')) {
-        updatedSpot = updatedSpot.copyWith(spotAccess: updates['spotAccess'] as String?);
+        updatedSpot = updatedSpot.copyWith(
+          spotAccess: updates['spotAccess'] as String?,
+        );
       }
       if (updates.containsKey('spotFacilities')) {
         updatedSpot = updatedSpot.copyWith(
@@ -309,11 +330,16 @@ class SpotService extends ChangeNotifier {
         );
       }
 
-      List<Map<String, String>> contributors = List.from(updatedSpot.contributors ?? []);
+      List<Map<String, String>> contributors = List.from(
+        updatedSpot.contributors ?? [],
+      );
       if (reporterUserId != null && reporterUserName != null) {
         final exists = contributors.any((c) => c['userId'] == reporterUserId);
         if (!exists) {
-          contributors.add({'userId': reporterUserId, 'userName': reporterUserName});
+          contributors.add({
+            'userId': reporterUserId,
+            'userName': reporterUserName,
+          });
         }
       }
 
@@ -322,7 +348,10 @@ class SpotService extends ChangeNotifier {
         updatedAt: DateTime.now(),
       );
 
-      await _firestore.collection('spots').doc(spot.id).update(updatedSpot.toFirestore(isUpdate: true));
+      await _firestore
+          .collection('spots')
+          .doc(spot.id)
+          .update(updatedSpot.toFirestore(isUpdate: true));
 
       final changes = _computeSpotChanges(oldSpot, updatedSpot);
       if (changes.isNotEmpty) {
@@ -390,10 +419,7 @@ class SpotService extends ChangeNotifier {
 
     // Compare each field
     if (!valuesEqual(oldSpot.name, newSpot.name)) {
-      changes['name'] = {
-        'from': oldSpot.name,
-        'to': newSpot.name,
-      };
+      changes['name'] = {'from': oldSpot.name, 'to': newSpot.name};
     }
 
     if (!valuesEqual(oldSpot.description, newSpot.description)) {
@@ -403,7 +429,8 @@ class SpotService extends ChangeNotifier {
       };
     }
 
-    if (oldSpot.latitude != newSpot.latitude || oldSpot.longitude != newSpot.longitude) {
+    if (oldSpot.latitude != newSpot.latitude ||
+        oldSpot.longitude != newSpot.longitude) {
       changes['location'] = {
         'from': {'latitude': oldSpot.latitude, 'longitude': oldSpot.longitude},
         'to': {'latitude': newSpot.latitude, 'longitude': newSpot.longitude},
@@ -411,17 +438,11 @@ class SpotService extends ChangeNotifier {
     }
 
     if (!valuesEqual(oldSpot.address, newSpot.address)) {
-      changes['address'] = {
-        'from': oldSpot.address,
-        'to': newSpot.address,
-      };
+      changes['address'] = {'from': oldSpot.address, 'to': newSpot.address};
     }
 
     if (!valuesEqual(oldSpot.city, newSpot.city)) {
-      changes['city'] = {
-        'from': oldSpot.city,
-        'to': newSpot.city,
-      };
+      changes['city'] = {'from': oldSpot.city, 'to': newSpot.city};
     }
 
     if (!valuesEqual(oldSpot.countryCode, newSpot.countryCode)) {
@@ -502,7 +523,7 @@ class SpotService extends ChangeNotifier {
       notifyListeners();
 
       await _firestore.collection('spots').doc(spotId).delete();
-      
+
       return true;
     } catch (e) {
       _error = 'Failed to delete spot: $e';
@@ -514,14 +535,14 @@ class SpotService extends ChangeNotifier {
     }
   }
 
-
   // Upload single image to Firebase Storage
   Future<String> _uploadImage(File imageFile) async {
     try {
       final bytes = await imageFile.readAsBytes();
       final prepared = await prepareImageForUpload(bytes);
       final ext = _extensionForContentType(prepared.contentType);
-      final fileName = 'spots/${DateTime.now().millisecondsSinceEpoch}_web_image$ext';
+      final fileName =
+          'spots/${DateTime.now().millisecondsSinceEpoch}_web_image$ext';
       final ref = _storage.ref().child(fileName);
 
       final uploadTask = ref.putData(
@@ -542,7 +563,8 @@ class SpotService extends ChangeNotifier {
     try {
       final prepared = await prepareImageForUpload(imageBytes);
       final ext = _extensionForContentType(prepared.contentType);
-      final fileName = 'spots/${DateTime.now().millisecondsSinceEpoch}_web_image$ext';
+      final fileName =
+          'spots/${DateTime.now().millisecondsSinceEpoch}_web_image$ext';
       final ref = _storage.ref().child(fileName);
 
       final uploadTask = ref.putData(
@@ -584,7 +606,9 @@ class SpotService extends ChangeNotifier {
   }
 
   // Upload multiple image bytes to Firebase Storage (for web)
-  Future<List<String>> _uploadImagesBytes(List<Uint8List> imageBytesList) async {
+  Future<List<String>> _uploadImagesBytes(
+    List<Uint8List> imageBytesList,
+  ) async {
     final List<String> imageUrls = [];
     for (final imageBytes in imageBytesList) {
       final imageUrl = await _uploadImageBytes(imageBytes);
@@ -654,9 +678,12 @@ class SpotService extends ChangeNotifier {
     required String? userName,
     String? reportId,
     String? notes,
-    String? targetSpotId, // Optional: if spot is duplicate, add to original spot instead
-    String? approvedByUserId, // Optional: userId of the approver (for audit log)
-    String? approvedByUserName, // Optional: userName of the approver (for audit log)
+    String?
+    targetSpotId, // Optional: if spot is duplicate, add to original spot instead
+    String?
+    approvedByUserId, // Optional: userId of the approver (for audit log)
+    String?
+    approvedByUserName, // Optional: userName of the approver (for audit log)
     void Function(int current, int total)? onProgress,
   }) async {
     try {
@@ -665,7 +692,7 @@ class SpotService extends ChangeNotifier {
 
       // Determine target spot (use targetSpotId if provided, otherwise use spotId)
       final finalSpotId = targetSpotId ?? spotId;
-      
+
       // Get the target spot
       final targetSpot = await getSpotById(finalSpotId);
       if (targetSpot == null) {
@@ -689,11 +716,12 @@ class SpotService extends ChangeNotifier {
           // Extract the file path from the URL
           final uri = Uri.parse(photoUrl);
           String? filePath;
-          
+
           // Handle Firebase Storage URL formats
           if (uri.pathSegments.contains('o')) {
             // Format: /v0/b/bucket/o/suggestions%2Ffilename.jpg
-            final encodedPath = uri.pathSegments[uri.pathSegments.indexOf('o') + 1];
+            final encodedPath =
+                uri.pathSegments[uri.pathSegments.indexOf('o') + 1];
             filePath = Uri.decodeComponent(encodedPath);
           } else if (uri.host.contains('storage.googleapis.com')) {
             // Format: https://storage.googleapis.com/bucket/suggestions/filename.jpg
@@ -702,20 +730,20 @@ class SpotService extends ChangeNotifier {
               filePath = uri.pathSegments.sublist(pathIndex).join('/');
             }
           }
-          
+
           if (filePath == null || !filePath.startsWith('suggestions/')) {
             debugPrint('Invalid photo URL format: $photoUrl');
             continue;
           }
-          
+
           // Create new path in /spots/ (use .jpg since we resize to JPEG)
           final suggestedPath = filePath.replaceFirst('suggestions/', 'spots/');
           final baseName = suggestedPath.split('.').first;
           final newPath = '$baseName.jpg';
-          
+
           final sourceRef = _storage.ref().child(filePath);
           final destRef = _storage.ref().child(newPath);
-          
+
           // Fetch via HTTP (bypasses getData's 10MB limit), then resize to avoid
           // timeout/memory issues with very large images (e.g. 13MB phone photos).
           final response = await http.get(Uri.parse(photoUrl));
@@ -724,13 +752,15 @@ class SpotService extends ChangeNotifier {
             continue;
           }
           final rawBytes = Uint8List.fromList(response.bodyBytes);
-          await Future<void>.delayed(Duration.zero); // Let UI update before CPU-heavy resize
+          await Future<void>.delayed(
+            Duration.zero,
+          ); // Let UI update before CPU-heavy resize
           final resizedBytes = resizeImageForSpotUpload(rawBytes);
           if (resizedBytes == null || resizedBytes.isEmpty) {
             debugPrint('Failed to resize photo: $photoUrl');
             continue;
           }
-          
+
           await destRef.putData(
             resizedBytes,
             SettableMetadata(contentType: 'image/jpeg'),
@@ -743,7 +773,7 @@ class SpotService extends ChangeNotifier {
           // Continue with other photos even if one fails
         }
       }
-      
+
       if (finalPhotoUrls.isEmpty) {
         _error = 'Failed to move any photos';
         _isLoading = false;
@@ -760,15 +790,16 @@ class SpotService extends ChangeNotifier {
       }
 
       // Update contributors list
-      List<Map<String, String>> updatedContributors = List.from(targetSpot.contributors ?? []);
+      List<Map<String, String>> updatedContributors = List.from(
+        targetSpot.contributors ?? [],
+      );
       if (userId != null && userName != null) {
         // Check if contributor already exists
-        final contributorExists = updatedContributors.any((c) => c['userId'] == userId);
+        final contributorExists = updatedContributors.any(
+          (c) => c['userId'] == userId,
+        );
         if (!contributorExists) {
-          updatedContributors.add({
-            'userId': userId,
-            'userName': userName,
-          });
+          updatedContributors.add({'userId': userId, 'userName': userName});
         }
       }
 
@@ -779,8 +810,11 @@ class SpotService extends ChangeNotifier {
         updatedAt: DateTime.now(),
       );
 
-      await _firestore.collection('spots').doc(finalSpotId).update(updatedSpot.toFirestore(isUpdate: true));
-      
+      await _firestore
+          .collection('spots')
+          .doc(finalSpotId)
+          .update(updatedSpot.toFirestore(isUpdate: true));
+
       // Log audit trail (use approver info if provided, otherwise use contributor info)
       final auditUserId = approvedByUserId ?? userId;
       final auditUserName = approvedByUserName ?? userName;
@@ -791,11 +825,12 @@ class SpotService extends ChangeNotifier {
           userId: auditUserId,
           userName: auditUserName,
           reportId: reportId,
-          originalPhotoUrls: photoUrls, // Keep track of original URLs from suggestions
+          originalPhotoUrls:
+              photoUrls, // Keep track of original URLs from suggestions
           notes: notes,
         );
       }
-      
+
       _isLoading = false;
       notifyListeners();
       return finalPhotoUrls; // Return the new URLs from /spots/
@@ -812,16 +847,17 @@ class SpotService extends ChangeNotifier {
   Future<List<String>> movePhotosToRejected(List<String> photoUrls) async {
     try {
       final List<String> rejectedUrls = [];
-      
+
       for (final photoUrl in photoUrls) {
         try {
           // Extract the file path from the URL
           final uri = Uri.parse(photoUrl);
           String? filePath;
-          
+
           // Handle Firebase Storage URL formats
           if (uri.pathSegments.contains('o')) {
-            final encodedPath = uri.pathSegments[uri.pathSegments.indexOf('o') + 1];
+            final encodedPath =
+                uri.pathSegments[uri.pathSegments.indexOf('o') + 1];
             filePath = Uri.decodeComponent(encodedPath);
           } else if (uri.host.contains('storage.googleapis.com')) {
             final pathIndex = uri.pathSegments.indexOf('suggestions');
@@ -829,32 +865,32 @@ class SpotService extends ChangeNotifier {
               filePath = uri.pathSegments.sublist(pathIndex).join('/');
             }
           }
-          
+
           if (filePath != null && filePath.startsWith('suggestions/')) {
             // Create new path in /rejected/
             final newPath = filePath.replaceFirst('suggestions/', 'rejected/');
-            
+
             // Get references
             final sourceRef = _storage.ref().child(filePath);
             final destRef = _storage.ref().child(newPath);
-            
+
             // Copy the file
             final data = await sourceRef.getData();
             if (data != null) {
               // Get content type from metadata
               final metadata = await sourceRef.getMetadata();
               final contentType = metadata.contentType ?? 'image/jpeg';
-              
+
               // Upload to rejected location
               await destRef.putData(
                 data,
                 SettableMetadata(contentType: contentType),
               );
-              
+
               // Get the new URL
               final newUrl = await destRef.getDownloadURL();
               rejectedUrls.add(newUrl);
-              
+
               // Delete the original from /suggestions/
               await sourceRef.delete();
             }
@@ -864,7 +900,7 @@ class SpotService extends ChangeNotifier {
           // Continue with other photos even if one fails
         }
       }
-      
+
       return rejectedUrls;
     } catch (e) {
       debugPrint('Error moving suggested photos to rejected: $e');
@@ -873,19 +909,22 @@ class SpotService extends ChangeNotifier {
   }
 
   // Move photos from /rejected/ back to /suggestions/ path (used when undoing rejection)
-  Future<List<String>> movePhotosFromRejectedToSuggestions(List<String> rejectedPhotoUrls) async {
+  Future<List<String>> movePhotosFromRejectedToSuggestions(
+    List<String> rejectedPhotoUrls,
+  ) async {
     try {
       final List<String> suggestionUrls = [];
-      
+
       for (final photoUrl in rejectedPhotoUrls) {
         try {
           // Extract the file path from the URL
           final uri = Uri.parse(photoUrl);
           String? filePath;
-          
+
           // Handle Firebase Storage URL formats
           if (uri.pathSegments.contains('o')) {
-            final encodedPath = uri.pathSegments[uri.pathSegments.indexOf('o') + 1];
+            final encodedPath =
+                uri.pathSegments[uri.pathSegments.indexOf('o') + 1];
             filePath = Uri.decodeComponent(encodedPath);
           } else if (uri.host.contains('storage.googleapis.com')) {
             final pathIndex = uri.pathSegments.indexOf('rejected');
@@ -893,42 +932,44 @@ class SpotService extends ChangeNotifier {
               filePath = uri.pathSegments.sublist(pathIndex).join('/');
             }
           }
-          
+
           if (filePath != null && filePath.startsWith('rejected/')) {
             // Create new path in /suggestions/
             final newPath = filePath.replaceFirst('rejected/', 'suggestions/');
-            
+
             // Get references
             final sourceRef = _storage.ref().child(filePath);
             final destRef = _storage.ref().child(newPath);
-            
+
             // Copy the file
             final data = await sourceRef.getData();
             if (data != null) {
               // Get content type from metadata
               final metadata = await sourceRef.getMetadata();
               final contentType = metadata.contentType ?? 'image/jpeg';
-              
+
               // Upload to suggestions location
               await destRef.putData(
                 data,
                 SettableMetadata(contentType: contentType),
               );
-              
+
               // Get the new URL
               final newUrl = await destRef.getDownloadURL();
               suggestionUrls.add(newUrl);
-              
+
               // Delete the original from /rejected/
               await sourceRef.delete();
             }
           }
         } catch (e) {
-          debugPrint('Error moving rejected photo back to suggestions $photoUrl: $e');
+          debugPrint(
+            'Error moving rejected photo back to suggestions $photoUrl: $e',
+          );
           // Continue with other photos even if one fails
         }
       }
-      
+
       return suggestionUrls;
     } catch (e) {
       debugPrint('Error moving rejected photos back to suggestions: $e');
@@ -944,14 +985,14 @@ class SpotService extends ChangeNotifier {
         debugPrint('User ID is required for rating');
         return false;
       }
-      
+
       // Check if user already rated this spot
       final existingRatingDoc = await _firestore
           .collection('ratings')
           .where('spotId', isEqualTo: spotId)
           .where('userId', isEqualTo: userId)
           .get();
-      
+
       if (existingRatingDoc.docs.isNotEmpty) {
         // Update existing rating
         final ratingDoc = existingRatingDoc.docs.first;
@@ -969,7 +1010,7 @@ class SpotService extends ChangeNotifier {
           'updatedAt': FieldValue.serverTimestamp(),
         });
       }
-      
+
       return true;
     } catch (e) {
       debugPrint('Error rating spot: $e');
@@ -985,7 +1026,7 @@ class SpotService extends ChangeNotifier {
           .where('spotId', isEqualTo: spotId)
           .where('userId', isEqualTo: userId)
           .get();
-      
+
       if (ratingDoc.docs.isNotEmpty) {
         return ratingDoc.docs.first.data()['rating'] as double?;
       }
@@ -1003,7 +1044,7 @@ class SpotService extends ChangeNotifier {
           .collection('ratings')
           .where('spotId', isEqualTo: spotId)
           .get();
-      
+
       return ratingsSnapshot.docs
           .map((doc) => Rating.fromFirestore(doc))
           .toList();
@@ -1022,7 +1063,7 @@ class SpotService extends ChangeNotifier {
         final data = doc.data() as Map<String, dynamic>;
         final avg = (data['averageRating'] ?? 0).toDouble();
         final count = (data['ratingCount'] ?? 0) as int;
-        
+
         return {
           'averageRating': avg,
           'ratingCount': count,
@@ -1052,9 +1093,7 @@ class SpotService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'recomputeAllRatedSpots',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
       final result = await callable.call();
       final data = result.data as Map<String, dynamic>;
@@ -1070,9 +1109,7 @@ class SpotService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'recomputeSpotRankings',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
       final result = await callable.call();
       final data = result.data as Map<String, dynamic>;
@@ -1088,9 +1125,7 @@ class SpotService extends ChangeNotifier {
     final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
     final callable = functions.httpsCallable(
       'generateSitemaps',
-      options: HttpsCallableOptions(
-        timeout: const Duration(minutes: 9),
-      ),
+      options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
     );
     final result = await callable.call();
     final data = result.data as Map<String, dynamic>?;
@@ -1107,9 +1142,12 @@ class SpotService extends ChangeNotifier {
     double maxLng, {
     int limit = 100,
     String? filterArea, // "amenities" | "source" | null (null = source)
-    String? spotSource, // when source: null = all, "" = native, string = specific source
-    List<String>? folders, // when source: list of folder names (null = all folders)
-    List<String>? spotAccess, // when amenities: ["public", "restricted", "paid"] for OR query, empty = any
+    String?
+    spotSource, // when source: null = all, "" = native, string = specific source
+    List<String>?
+    folders, // when source: list of folder names (null = all folders)
+    List<String>?
+    spotAccess, // when amenities: ["public", "restricted", "paid"] for OR query, empty = any
     bool? spotFacilitiesCovered, // when amenities: true = "yes"
     bool? spotFacilitiesLighting, // when amenities: true = "yes"
     bool? spotFacilitiesWaterTap, // when amenities: true = "yes"
@@ -1133,15 +1171,24 @@ class SpotService extends ChangeNotifier {
       }
       if (filterArea == 'amenities') {
         if (spotAccess != null && spotAccess.isNotEmpty) {
-          requestData['spotAccess'] = spotAccess.length == 1 ? spotAccess.first : spotAccess;
+          requestData['spotAccess'] = spotAccess.length == 1
+              ? spotAccess.first
+              : spotAccess;
         }
-        if (spotFacilitiesCovered == true) requestData['spotFacilitiesCovered'] = 'yes';
-        if (spotFacilitiesLighting == true) requestData['spotFacilitiesLighting'] = 'yes';
-        if (spotFacilitiesWaterTap == true) requestData['spotFacilitiesWaterTap'] = 'yes';
-        if (spotFacilitiesToilet == true) requestData['spotFacilitiesToilet'] = 'yes';
-        if (spotFacilitiesParking == true) requestData['spotFacilitiesParking'] = 'yes';
-        if (goodFor != null && goodFor.isNotEmpty) requestData['goodFor'] = goodFor.take(10).toList();
-        if (spotFeatures != null && spotFeatures.isNotEmpty) requestData['spotFeatures'] = spotFeatures.take(10).toList();
+        if (spotFacilitiesCovered == true)
+          requestData['spotFacilitiesCovered'] = 'yes';
+        if (spotFacilitiesLighting == true)
+          requestData['spotFacilitiesLighting'] = 'yes';
+        if (spotFacilitiesWaterTap == true)
+          requestData['spotFacilitiesWaterTap'] = 'yes';
+        if (spotFacilitiesToilet == true)
+          requestData['spotFacilitiesToilet'] = 'yes';
+        if (spotFacilitiesParking == true)
+          requestData['spotFacilitiesParking'] = 'yes';
+        if (goodFor != null && goodFor.isNotEmpty)
+          requestData['goodFor'] = goodFor.take(10).toList();
+        if (spotFeatures != null && spotFeatures.isNotEmpty)
+          requestData['spotFeatures'] = spotFeatures.take(10).toList();
       } else {
         if (spotSource != null) {
           requestData['spotSource'] = spotSource;
@@ -1154,10 +1201,15 @@ class SpotService extends ChangeNotifier {
 
       final responseData = result.data as Map<String, dynamic>?;
       if (responseData == null || responseData['success'] != true) {
-        throw Exception(responseData != null && responseData['error'] is String ? responseData['error'] : 'Unknown error');
+        throw Exception(
+          responseData != null && responseData['error'] is String
+              ? responseData['error']
+              : 'Unknown error',
+        );
       }
 
-      final List<dynamic> items = (responseData['spots'] as List<dynamic>? ?? <dynamic>[]);
+      final List<dynamic> items =
+          (responseData['spots'] as List<dynamic>? ?? <dynamic>[]);
       final spots = items
           .whereType<Map<String, dynamic>>()
           .map((m) => Spot.fromMap(m))
@@ -1165,13 +1217,21 @@ class SpotService extends ChangeNotifier {
 
       return {
         'spots': spots,
-        'totalCount': (responseData['totalCount'] as num?)?.toInt() ?? spots.length,
-        'shownCount': (responseData['shownCount'] as num?)?.toInt() ?? spots.length,
-        'averageWilson': (responseData['averageWilson'] as num?)?.toDouble() ?? 0.0,
+        'totalCount':
+            (responseData['totalCount'] as num?)?.toInt() ?? spots.length,
+        'shownCount':
+            (responseData['shownCount'] as num?)?.toInt() ?? spots.length,
+        'averageWilson':
+            (responseData['averageWilson'] as num?)?.toDouble() ?? 0.0,
       };
     } catch (e) {
       debugPrint('Error getting top ranked spots in bounds: $e');
-      return {'spots': <Spot>[], 'totalCount': 0, 'shownCount': 0, 'averageWilson': 0.0};
+      return {
+        'spots': <Spot>[],
+        'totalCount': 0,
+        'shownCount': 0,
+        'averageWilson': 0.0,
+      };
     }
   }
 
@@ -1203,12 +1263,14 @@ class SpotService extends ChangeNotifier {
           .orderBy('updatedAt', descending: true);
 
       final querySnapshot = await query.get();
-      
+
       final spots = querySnapshot.docs
           .map((doc) => Spot.fromFirestore(doc))
           .toList();
 
-      debugPrint('✅ Found ${spots.length} spots for source $sourceId last updated before ${timestamp.day}/${timestamp.month}/${timestamp.year}');
+      debugPrint(
+        '✅ Found ${spots.length} spots for source $sourceId last updated before ${timestamp.day}/${timestamp.month}/${timestamp.year}',
+      );
 
       return spots;
     } catch (e) {
@@ -1231,7 +1293,9 @@ class SpotService extends ChangeNotifier {
 
       debugPrint('🔍 Searching for removed spots');
       if (sourceId != null) {
-        debugPrint('📦 Source filter: ${sourceId.isEmpty ? "Native spots (no source)" : sourceId}');
+        debugPrint(
+          '📦 Source filter: ${sourceId.isEmpty ? "Native spots (no source)" : sourceId}',
+        );
       } else {
         debugPrint('📦 Source filter: All sources');
       }
@@ -1256,7 +1320,7 @@ class SpotService extends ChangeNotifier {
       query = query.orderBy('spotSourceRemovedAt', descending: true);
 
       final querySnapshot = await query.get();
-      
+
       final spots = querySnapshot.docs
           .map((doc) => Spot.fromFirestore(doc))
           .toList();
@@ -1294,10 +1358,7 @@ class SpotService extends ChangeNotifier {
         }
       }
 
-      return {
-        'deleted': deletedCount,
-        'failed': failedCount,
-      };
+      return {'deleted': deletedCount, 'failed': failedCount};
     } catch (e) {
       _error = 'Failed to delete spots: $e';
       debugPrint('Error deleting spots: $e');
@@ -1317,7 +1378,10 @@ class SpotService extends ChangeNotifier {
     try {
       Query queryRef = _firestore
           .collection('spots')
-          .where('duplicateOf', isNull: true); // Exclude spots that are already duplicates
+          .where(
+            'duplicateOf',
+            isNull: true,
+          ); // Exclude spots that are already duplicates
 
       final querySnapshot = await queryRef.limit(limit).get();
 
@@ -1331,9 +1395,13 @@ class SpotService extends ChangeNotifier {
         final queryLower = query.toLowerCase();
         spots.retainWhere((spot) {
           final nameMatch = spot.name.toLowerCase().contains(queryLower);
-          final descriptionMatch = spot.description.toLowerCase().contains(queryLower);
-          final addressMatch = spot.address?.toLowerCase().contains(queryLower) ?? false;
-          final cityMatch = spot.city?.toLowerCase().contains(queryLower) ?? false;
+          final descriptionMatch = spot.description.toLowerCase().contains(
+            queryLower,
+          );
+          final addressMatch =
+              spot.address?.toLowerCase().contains(queryLower) ?? false;
+          final cityMatch =
+              spot.city?.toLowerCase().contains(queryLower) ?? false;
           return nameMatch || descriptionMatch || addressMatch || cityMatch;
         });
       }
@@ -1393,7 +1461,8 @@ class SpotService extends ChangeNotifier {
       // Prevent marking a spot as duplicate if other spots are already marked as duplicates of it
       final existingDuplicates = await getDuplicatesOfSpot(spotId);
       if (existingDuplicates.isNotEmpty) {
-        _error = 'Cannot mark this spot as a duplicate because other spots are already marked as duplicates of it';
+        _error =
+            'Cannot mark this spot as a duplicate because other spots are already marked as duplicates of it';
         _isLoading = false;
         notifyListeners();
         return false;
@@ -1401,7 +1470,8 @@ class SpotService extends ChangeNotifier {
 
       // Prevent circular references (check if original is already marked as duplicate)
       if (originalSpot.duplicateOf != null) {
-        _error = 'Cannot mark as duplicate of a spot that is already a duplicate';
+        _error =
+            'Cannot mark as duplicate of a spot that is already a duplicate';
         _isLoading = false;
         notifyListeners();
         return false;
@@ -1409,7 +1479,8 @@ class SpotService extends ChangeNotifier {
 
       // Ensure the original spot is a native parkour.spot spot (not from external source)
       if (originalSpot.spotSource != null) {
-        _error = 'Original spot must be a native parkour.spot spot, not from an external source';
+        _error =
+            'Original spot must be a native parkour.spot spot, not from an external source';
         _isLoading = false;
         notifyListeners();
         return false;
@@ -1420,12 +1491,14 @@ class SpotService extends ChangeNotifier {
       bool needsOriginalUpdate = false;
 
       // Merge photos if requested
-      if (transferPhotos && duplicateSpot.imageUrls != null && duplicateSpot.imageUrls!.isNotEmpty) {
+      if (transferPhotos &&
+          duplicateSpot.imageUrls != null &&
+          duplicateSpot.imageUrls!.isNotEmpty) {
         final existingPhotos = List<String>.from(originalSpot.imageUrls ?? []);
         final newPhotos = duplicateSpot.imageUrls!
             .where((url) => !existingPhotos.contains(url))
             .toList();
-        
+
         if (newPhotos.isNotEmpty) {
           originalSpotUpdates['imageUrls'] = [...existingPhotos, ...newPhotos];
           needsOriginalUpdate = true;
@@ -1433,14 +1506,21 @@ class SpotService extends ChangeNotifier {
       }
 
       // Merge YouTube links if requested
-      if (transferYoutubeLinks && duplicateSpot.youtubeVideoIds != null && duplicateSpot.youtubeVideoIds!.isNotEmpty) {
-        final existingYoutubeLinks = List<String>.from(originalSpot.youtubeVideoIds ?? []);
+      if (transferYoutubeLinks &&
+          duplicateSpot.youtubeVideoIds != null &&
+          duplicateSpot.youtubeVideoIds!.isNotEmpty) {
+        final existingYoutubeLinks = List<String>.from(
+          originalSpot.youtubeVideoIds ?? [],
+        );
         final newYoutubeLinks = duplicateSpot.youtubeVideoIds!
             .where((id) => !existingYoutubeLinks.contains(id))
             .toList();
-        
+
         if (newYoutubeLinks.isNotEmpty) {
-          originalSpotUpdates['youtubeVideoIds'] = [...existingYoutubeLinks, ...newYoutubeLinks];
+          originalSpotUpdates['youtubeVideoIds'] = [
+            ...existingYoutubeLinks,
+            ...newYoutubeLinks,
+          ];
           needsOriginalUpdate = true;
         }
       }
@@ -1465,7 +1545,8 @@ class SpotService extends ChangeNotifier {
           originalSpotUpdates['longitude'] = duplicateSpot.longitude;
           hasLocationData = true;
         }
-        if (duplicateSpot.address != null && duplicateSpot.address!.isNotEmpty) {
+        if (duplicateSpot.address != null &&
+            duplicateSpot.address!.isNotEmpty) {
           originalSpotUpdates['address'] = duplicateSpot.address;
           hasLocationData = true;
         }
@@ -1473,7 +1554,8 @@ class SpotService extends ChangeNotifier {
           originalSpotUpdates['city'] = duplicateSpot.city;
           hasLocationData = true;
         }
-        if (duplicateSpot.countryCode != null && duplicateSpot.countryCode!.isNotEmpty) {
+        if (duplicateSpot.countryCode != null &&
+            duplicateSpot.countryCode!.isNotEmpty) {
           originalSpotUpdates['countryCode'] = duplicateSpot.countryCode;
           hasLocationData = true;
         }
@@ -1485,19 +1567,23 @@ class SpotService extends ChangeNotifier {
       // Overwrite spot attributes if requested and duplicate has attributes
       if (overwriteSpotAttributes) {
         bool hasAttributes = false;
-        if (duplicateSpot.spotAccess != null && duplicateSpot.spotAccess!.isNotEmpty) {
+        if (duplicateSpot.spotAccess != null &&
+            duplicateSpot.spotAccess!.isNotEmpty) {
           originalSpotUpdates['spotAccess'] = duplicateSpot.spotAccess;
           hasAttributes = true;
         }
-        if (duplicateSpot.spotFeatures != null && duplicateSpot.spotFeatures!.isNotEmpty) {
+        if (duplicateSpot.spotFeatures != null &&
+            duplicateSpot.spotFeatures!.isNotEmpty) {
           originalSpotUpdates['spotFeatures'] = duplicateSpot.spotFeatures;
           hasAttributes = true;
         }
-        if (duplicateSpot.spotFacilities != null && duplicateSpot.spotFacilities!.isNotEmpty) {
+        if (duplicateSpot.spotFacilities != null &&
+            duplicateSpot.spotFacilities!.isNotEmpty) {
           originalSpotUpdates['spotFacilities'] = duplicateSpot.spotFacilities;
           hasAttributes = true;
         }
-        if (duplicateSpot.goodFor != null && duplicateSpot.goodFor!.isNotEmpty) {
+        if (duplicateSpot.goodFor != null &&
+            duplicateSpot.goodFor!.isNotEmpty) {
           originalSpotUpdates['goodFor'] = duplicateSpot.goodFor;
           hasAttributes = true;
         }
@@ -1509,7 +1595,10 @@ class SpotService extends ChangeNotifier {
       // Update the original spot if needed
       if (needsOriginalUpdate) {
         originalSpotUpdates['updatedAt'] = FieldValue.serverTimestamp();
-        await _firestore.collection('spots').doc(originalSpotId).update(originalSpotUpdates);
+        await _firestore
+            .collection('spots')
+            .doc(originalSpotId)
+            .update(originalSpotUpdates);
       }
 
       // Update the spot to mark it as duplicate
@@ -1556,9 +1645,7 @@ class SpotService extends ChangeNotifier {
           .where('duplicateOf', isEqualTo: spotId)
           .get();
 
-      return querySnapshot.docs
-          .map((doc) => Spot.fromFirestore(doc))
-          .toList();
+      return querySnapshot.docs.map((doc) => Spot.fromFirestore(doc)).toList();
     } catch (e) {
       debugPrint('Error getting duplicates of spot: $e');
       return [];
@@ -1717,7 +1804,12 @@ class SpotService extends ChangeNotifier {
         }
 
         if (missingUrls.isNotEmpty) {
-          results.add(SpotWithMissingResizedImages(spot: spot, missingImageUrls: missingUrls));
+          results.add(
+            SpotWithMissingResizedImages(
+              spot: spot,
+              missingImageUrls: missingUrls,
+            ),
+          );
         }
       }
 
@@ -1777,9 +1869,7 @@ class SpotService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'triggerResizeForMissingImages',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
 
       final result = await callable.call();
@@ -1814,9 +1904,7 @@ class SpotService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'findDuplicateSpots',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
 
       final result = await callable.call({
@@ -1826,9 +1914,11 @@ class SpotService extends ChangeNotifier {
 
       final responseData = result.data as Map<String, dynamic>?;
       if (responseData == null || responseData['success'] != true) {
-        throw Exception(responseData != null && responseData['error'] is String
-            ? responseData['error']
-            : 'Unknown error');
+        throw Exception(
+          responseData != null && responseData['error'] is String
+              ? responseData['error']
+              : 'Unknown error',
+        );
       }
 
       _isLoading = false;

--- a/lib/services/user_management_service.dart
+++ b/lib/services/user_management_service.dart
@@ -25,7 +25,7 @@ class UserStats {
 /// Service responsible for loading admin-facing user information and actions.
 class UserManagementService extends ChangeNotifier {
   UserManagementService({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+    : _firestore = firestore ?? FirebaseFirestore.instance;
 
   final FirebaseFirestore _firestore;
 
@@ -85,10 +85,12 @@ class UserManagementService extends ChangeNotifier {
   bool isLoadingStats(String userId) => _loadingStatsFor.contains(userId);
 
   /// Whether the service is currently updating moderator status for the user.
-  bool isUpdatingModerator(String userId) => _updatingModeratorFor.contains(userId);
+  bool isUpdatingModerator(String userId) =>
+      _updatingModeratorFor.contains(userId);
 
   /// Whether the service is currently updating feature access for the user.
-  bool isUpdatingFeatureAccess(String userId) => _updatingFeatureAccessFor.contains(userId);
+  bool isUpdatingFeatureAccess(String userId) =>
+      _updatingFeatureAccessFor.contains(userId);
 
   /// Whether the service is currently calculating user activity metrics.
   bool get isCalculatingMetrics => _calculatingMetrics;
@@ -224,10 +226,7 @@ class UserManagementService extends ChangeNotifier {
     for (final doc in docs) {
       final data = doc.data();
       _users.add(
-        app_user.User.fromMap(<String, dynamic>{
-          'id': doc.id,
-          ...data,
-        }),
+        app_user.User.fromMap(<String, dynamic>{'id': doc.id, ...data}),
       );
     }
     if (replaceExisting) {
@@ -242,7 +241,10 @@ class UserManagementService extends ChangeNotifier {
   }
 
   /// Ensures statistics for the provided user are loaded and cached.
-  Future<UserStats?> loadUserStats(String userId, {bool forceRefresh = false}) async {
+  Future<UserStats?> loadUserStats(
+    String userId, {
+    bool forceRefresh = false,
+  }) async {
     if (!forceRefresh && _statsCache.containsKey(userId)) {
       return _statsCache[userId];
     }
@@ -256,14 +258,27 @@ class UserManagementService extends ChangeNotifier {
 
     try {
       final int reportedCount = await _countDocuments(
-        _firestore.collection('spotReports').where('reporterUserId', isEqualTo: userId),
+        _firestore
+            .collection('spotReports')
+            .where('reporterUserId', isEqualTo: userId),
       );
       final int ratingsCount = await _countDocuments(
         _firestore.collection('ratings').where('userId', isEqualTo: userId),
       );
-      final int spotsCreatedCount = await _countDocuments(
+      final int totalSpotsCreatedCount = await _countDocuments(
         _firestore.collection('spots').where('createdBy', isEqualTo: userId),
       );
+      final int createNativeSpotsCreatedCount = await _countDocuments(
+        _firestore
+            .collection('spots')
+            .where('createdBy', isEqualTo: userId)
+            .where('createdFromCreateNative', isEqualTo: true),
+      );
+      final int spotsCreatedCount =
+          (totalSpotsCreatedCount - createNativeSpotsCreatedCount).clamp(
+            0,
+            1 << 30,
+          );
 
       final stats = UserStats(
         spotReports: reportedCount,
@@ -313,13 +328,17 @@ class UserManagementService extends ChangeNotifier {
   }
 
   /// Updates feature access for a user and updates internal cache.
-  /// 
+  ///
   /// [featureName] is the name of the feature (e.g., "spotLists").
   /// [hasAccess] indicates whether the user should have access to the feature.
-  /// 
+  ///
   /// This method merges the new feature access with existing feature access,
   /// so other features are not affected.
-  Future<bool> updateFeatureAccess(String userId, String featureName, bool hasAccess) async {
+  Future<bool> updateFeatureAccess(
+    String userId,
+    String featureName,
+    bool hasAccess,
+  ) async {
     if (_updatingFeatureAccessFor.contains(userId)) {
       return false;
     }
@@ -331,16 +350,20 @@ class UserManagementService extends ChangeNotifier {
       // Get current user to preserve existing feature access
       final userIndex = _users.indexWhere((u) => u.id == userId);
       Map<String, bool>? currentFeatureAccess;
-      
+
       if (userIndex != -1) {
-        currentFeatureAccess = Map<String, bool>.from(_users[userIndex].featureAccess ?? {});
+        currentFeatureAccess = Map<String, bool>.from(
+          _users[userIndex].featureAccess ?? {},
+        );
       } else {
         // If user not in cache, fetch from Firestore
         final userDoc = await _firestore.collection('users').doc(userId).get();
         if (userDoc.exists) {
           final data = userDoc.data();
           if (data != null && data['featureAccess'] != null) {
-            currentFeatureAccess = Map<String, bool>.from(data['featureAccess']);
+            currentFeatureAccess = Map<String, bool>.from(
+              data['featureAccess'],
+            );
           }
         }
         currentFeatureAccess ??= <String, bool>{};
@@ -356,7 +379,9 @@ class UserManagementService extends ChangeNotifier {
 
       // Update local cache
       if (userIndex != -1) {
-        _users[userIndex] = _users[userIndex].copyWith(featureAccess: currentFeatureAccess);
+        _users[userIndex] = _users[userIndex].copyWith(
+          featureAccess: currentFeatureAccess,
+        );
       }
 
       return true;
@@ -385,9 +410,7 @@ class UserManagementService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'testCalculateUserActivityMetrics',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
 
       final result = await callable.call();
@@ -397,7 +420,9 @@ class UserManagementService extends ChangeNotifier {
       return data;
     } catch (e, stackTrace) {
       _metricsError = 'Failed to calculate metrics: $e';
-      debugPrint('UserManagementService.calculateUserActivityMetrics error: $e');
+      debugPrint(
+        'UserManagementService.calculateUserActivityMetrics error: $e',
+      );
       debugPrint('$stackTrace');
       return null;
     } finally {
@@ -407,7 +432,7 @@ class UserManagementService extends ChangeNotifier {
   }
 
   /// Syncs user.createdAt from Firebase Auth creation time.
-  /// 
+  ///
   /// [dryRun] if true, previews changes without updating.
   /// [limit] optional limit on number of users to process (for testing).
   Future<Map<String, dynamic>?> syncUserCreatedAtFromAuth({
@@ -426,9 +451,7 @@ class UserManagementService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'syncUserCreatedAtFromAuth',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
 
       final result = await callable.call({
@@ -438,12 +461,12 @@ class UserManagementService extends ChangeNotifier {
       final data = result.data as Map<String, dynamic>?;
 
       _lastSyncCreatedAtResult = data;
-      
+
       // Refresh users list if sync was successful and not a dry run
       if (data?['success'] == true && !dryRun) {
         await fetchUsers(forceRefresh: true);
       }
-      
+
       return data;
     } catch (e, stackTrace) {
       _syncCreatedAtError = 'Failed to sync user createdAt: $e';
@@ -478,9 +501,7 @@ class UserManagementService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'copyGoogleAvatarsToStorage',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 15),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 15)),
       );
 
       final result = await callable.call({
@@ -522,9 +543,7 @@ class UserManagementService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'makeProfilePicturesPublic',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 5),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 5)),
       );
 
       final result = await callable.call();
@@ -540,8 +559,7 @@ class UserManagementService extends ChangeNotifier {
     } catch (e, stackTrace) {
       _makeProfilePicturesPublicError =
           'Failed to make profile pictures public: $e';
-      debugPrint(
-          'UserManagementService.makeProfilePicturesPublic error: $e');
+      debugPrint('UserManagementService.makeProfilePicturesPublic error: $e');
       debugPrint('$stackTrace');
       return null;
     } finally {
@@ -570,9 +588,7 @@ class UserManagementService extends ChangeNotifier {
       final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
       final callable = functions.httpsCallable(
         'syncSpotDisplayNames',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
 
       final result = await callable.call({'dryRun': dryRun});

--- a/lib/services/user_profile_service.dart
+++ b/lib/services/user_profile_service.dart
@@ -4,7 +4,7 @@ import '../models/user.dart' as app_user;
 
 class UserProfileService extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-  
+
   bool _isLoading = false;
   String? _error;
 
@@ -15,7 +15,10 @@ class UserProfileService extends ChangeNotifier {
   /// Returns null if user not found or profile is private (unless currentUserId matches)
   /// Note: Email is excluded from public profiles unless viewing own profile
   /// [currentUserId] - Optional current user ID to allow viewing own private profile
-  Future<app_user.User?> getUserProfile(String userIdOrUsername, {String? currentUserId}) async {
+  Future<app_user.User?> getUserProfile(
+    String userIdOrUsername, {
+    String? currentUserId,
+  }) async {
     try {
       _isLoading = true;
       _error = null;
@@ -41,7 +44,7 @@ class UserProfileService extends ChangeNotifier {
             .where('username', isEqualTo: userIdOrUsername.toLowerCase())
             .limit(1)
             .get();
-        
+
         if (querySnapshot.docs.isNotEmpty) {
           doc = querySnapshot.docs.first;
           resolvedUserId = doc.id;
@@ -55,11 +58,12 @@ class UserProfileService extends ChangeNotifier {
       }
 
       final data = doc.data() as Map<String, dynamic>;
-      
+
       // Check if profile is public
       final isPublicProfile = data['isPublicProfile'] ?? true;
-      final isOwnProfile = currentUserId != null && resolvedUserId == currentUserId;
-      
+      final isOwnProfile =
+          currentUserId != null && resolvedUserId == currentUserId;
+
       // Allow viewing own profile even if private
       if (!isPublicProfile && !isOwnProfile) {
         _isLoading = false;
@@ -72,7 +76,9 @@ class UserProfileService extends ChangeNotifier {
       final user = app_user.User.fromMap({
         'id': doc.id,
         ...data,
-        'email': isOwnProfile ? (data['email'] ?? '') : '', // Include email only for own profile
+        'email': isOwnProfile
+            ? (data['email'] ?? '')
+            : '', // Include email only for own profile
       });
 
       _isLoading = false;
@@ -137,13 +143,15 @@ class UserProfileService extends ChangeNotifier {
 
       // Validate username length (max 27 to prevent conflicts with 28-character user IDs)
       if (trimmedUsername.length >= 28) {
-        _error = 'Username must be 27 characters or less to avoid conflicts with user IDs';
+        _error =
+            'Username must be 27 characters or less to avoid conflicts with user IDs';
         _isLoading = false;
         notifyListeners();
         return false;
       }
       if (!RegExp(r'^[a-zA-Z0-9_-]{3,27}$').hasMatch(trimmedUsername)) {
-        _error = 'Username must be 3-27 characters and contain only letters, numbers, underscores, and hyphens';
+        _error =
+            'Username must be 3-27 characters and contain only letters, numbers, underscores, and hyphens';
         _isLoading = false;
         notifyListeners();
         return false;
@@ -155,7 +163,10 @@ class UserProfileService extends ChangeNotifier {
       final isAvailable = await checkUsernameAvailability(normalizedUsername);
       if (!isAvailable) {
         // Check if it's the current user's username
-        final currentUserDoc = await _firestore.collection('users').doc(userId).get();
+        final currentUserDoc = await _firestore
+            .collection('users')
+            .doc(userId)
+            .get();
         if (currentUserDoc.exists) {
           final currentData = currentUserDoc.data() as Map<String, dynamic>;
           final currentUsername = currentData['username'] as String?;
@@ -166,7 +177,7 @@ class UserProfileService extends ChangeNotifier {
             return true;
           }
         }
-        
+
         _error = 'Username is already taken';
         _isLoading = false;
         notifyListeners();
@@ -218,17 +229,22 @@ class UserProfileService extends ChangeNotifier {
   /// Returns a map with 'spotsCreated' and 'ratings' counts
   Future<Map<String, int>?> getUserStats(String userId) async {
     try {
-      final int spotsCreatedCount = await _countDocuments(
+      final int totalSpotsCreatedCount = await _countDocuments(
         _firestore.collection('spots').where('createdBy', isEqualTo: userId),
       );
+      final int createNativeSpotsCount = await _countDocuments(
+        _firestore
+            .collection('spots')
+            .where('createdBy', isEqualTo: userId)
+            .where('createdFromCreateNative', isEqualTo: true),
+      );
+      final int spotsCreatedCount =
+          (totalSpotsCreatedCount - createNativeSpotsCount).clamp(0, 1 << 30);
       final int ratingsCount = await _countDocuments(
         _firestore.collection('ratings').where('userId', isEqualTo: userId),
       );
 
-      return {
-        'spotsCreated': spotsCreatedCount,
-        'ratings': ratingsCount,
-      };
+      return {'spotsCreated': spotsCreatedCount, 'ratings': ratingsCount};
     } catch (e) {
       debugPrint('Error getting user stats: $e');
       return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `createdFromCreateNative` to the `Spot` model and persist it in Firestore payloads.
- set `createdFromCreateNative: true` when creating a spot via the Create Native flow.
- exclude Create Native spots from profile/admin “spots created” stats while keeping backward compatibility for legacy spots without the field.
- hide creator attribution on Create Native spots in spot detail metadata while still showing improvers/contributors.
- adjust contributor-only metadata formatting so native spots start cleanly with `improved by` (no leading comma).
- skip nearby new-spot notification fan-out for spots marked `createdFromCreateNative`.
- add an admin callable + admin UI action to retroactively mark native original spots referenced by `duplicateOf` with `createdFromCreateNative=true`.
- add/update function unit tests for notification eligibility and retroactive flagging behavior.

## Testing
- `npm test -- retroactive-create-native-flag.test.js nearby-new-spot-notifications.test.js` (pass)
- `flutter test` (pass)
- Emulator callable E2E validation (pass): sign in via Auth emulator, call `markCreateNativeDuplicateTargets`, verify spot document flags updated as expected.

[create_native_spot_attribution_final.mp4](https://cursor.com/agents/bc-f86dd75f-350e-4531-b10d-344bf5524cdd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_native_spot_attribution_final.mp4)
[Native spot metadata hides creator](https://cursor.com/agents/bc-f86dd75f-350e-4531-b10d-344bf5524cdd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnative_spot_metadata_hidden_creator.webp)
[Regular spot metadata shows creator](https://cursor.com/agents/bc-f86dd75f-350e-4531-b10d-344bf5524cdd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fregular_spot_metadata_shows_creator.webp)
[admin_callable_validation.log](https://cursor.com/agents/bc-f86dd75f-350e-4531-b10d-344bf5524cdd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_callable_validation.log)
[flutter_test_admin_feature.log](https://cursor.com/agents/bc-f86dd75f-350e-4531-b10d-344bf5524cdd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fflutter_test_admin_feature.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f86dd75f-350e-4531-b10d-344bf5524cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f86dd75f-350e-4531-b10d-344bf5524cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

