### PR TITLE
Fix map add-spot flow to stay in tab navigation

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
 import 'package:go_router/go_router.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart' as gmaps;
 import 'package:provider/provider.dart';
 import 'package:web/web.dart' as web;
 import 'package:sealed_countries/sealed_countries.dart';
@@ -279,7 +279,7 @@ class AppRouter {
             final lat = latParam != null ? double.tryParse(latParam) : null;
             final lng = lngParam != null ? double.tryParse(lngParam) : null;
             final initialAddSpotLocation = (lat != null && lng != null)
-                ? LatLng(lat, lng)
+                ? gmaps.LatLng(lat, lng)
                 : null;
 
             return ExploreScreen(

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
 import 'package:go_router/go_router.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:web/web.dart' as web;
 import 'package:sealed_countries/sealed_countries.dart';
@@ -273,11 +274,19 @@ class AppRouter {
 
             // Parse listId query parameter
             final listId = state.uri.queryParameters['listId'];
+            final latParam = state.uri.queryParameters['lat'];
+            final lngParam = state.uri.queryParameters['lng'];
+            final lat = latParam != null ? double.tryParse(latParam) : null;
+            final lng = lngParam != null ? double.tryParse(lngParam) : null;
+            final initialAddSpotLocation = (lat != null && lng != null)
+                ? LatLng(lat, lng)
+                : null;
 
             return ExploreScreen(
               initialTab: initialTab,
               initialLocationQuery: locationQuery,
               initialListId: listId,
+              initialAddSpotLocation: initialAddSpotLocation,
             );
           },
         ),

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:web/web.dart' as web;
@@ -30,8 +31,15 @@ class ExploreScreen extends StatefulWidget {
   final int initialTab;
   final String? initialLocationQuery;
   final String? initialListId;
-  
-  const ExploreScreen({super.key, this.initialTab = 0, this.initialLocationQuery, this.initialListId});
+  final LatLng? initialAddSpotLocation;
+
+  const ExploreScreen({
+    super.key,
+    this.initialTab = 0,
+    this.initialLocationQuery,
+    this.initialListId,
+    this.initialAddSpotLocation,
+  });
 
   @override
   State<ExploreScreen> createState() => _ExploreScreenState();
@@ -40,7 +48,9 @@ class ExploreScreen extends StatefulWidget {
 class _ExploreScreenState extends State<ExploreScreen> {
   int _currentIndex = 0;
   late PageController _pageController;
-  final GlobalKey<SearchScreenState> _searchKey = GlobalKey<SearchScreenState>();
+  final GlobalKey<SearchScreenState> _searchKey =
+      GlobalKey<SearchScreenState>();
+
   /// Cached for web meta reset in [dispose] (cannot use [BuildContext] there).
   String? _cachedMetaDefaultTitle;
   String? _cachedMetaDefaultDescription;
@@ -50,7 +60,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
     super.initState();
     _currentIndex = widget.initialTab;
     _pageController = PageController(initialPage: _currentIndex);
-    
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
@@ -119,7 +129,8 @@ class _ExploreScreenState extends State<ExploreScreen> {
     // Reset document title and meta description when leaving the page
     if (kIsWeb && widget.initialLocationQuery != null) {
       final title = _cachedMetaDefaultTitle ?? 'Parkour·Spot';
-      final description = _cachedMetaDefaultDescription ??
+      final description =
+          _cachedMetaDefaultDescription ??
           'Discover, map, and share the best parkour spots worldwide with community photos, ratings, and local tips for your next training session.';
       web.document.title = title;
       _updateMetaDescription(description);
@@ -136,41 +147,44 @@ class _ExploreScreenState extends State<ExploreScreen> {
 
     final l10n = AppLocalizations.of(context)!;
     final locationQuery = widget.initialLocationQuery!;
-    
+
     // Extract country code from current URL to determine if "the" article is needed
     final countryCode = _extractCountryCodeFromUrl();
-    
+
     // Check if this is a city+country format (e.g., "Amsterdam, Netherlands")
     // or just a country (e.g., "Netherlands" or "the Netherlands")
     final parts = locationQuery.split(',').map((s) => s.trim()).toList();
-    
+
     String title;
     String description;
-    
+
     if (parts.length >= 2) {
       // City + Country format: "City, Country"
       // For city pages, don't add "the" article (matching cloud function behavior)
       final city = parts[0];
-      final country = parts.sublist(1).join(', '); // Handle countries with commas
+      final country = parts
+          .sublist(1)
+          .join(', '); // Handle countries with commas
       title = l10n.exploreMetaTitleCityCountry(city, country);
       description = l10n.exploreMetaDescriptionCityCountry(city, country);
     } else {
       // Country only format: "Country" or "the Country"
       // For country pages, add "the" article if needed (matching cloud function behavior)
       var country = parts[0];
-      
+
       // If country code is available and needs "the" article, add it
-      if (countryCode != null && _countriesWithArticle.contains(countryCode.toUpperCase())) {
+      if (countryCode != null &&
+          _countriesWithArticle.contains(countryCode.toUpperCase())) {
         // Check if "the" is not already present
         if (!country.toLowerCase().startsWith('the ')) {
           country = 'the $country';
         }
       }
-      
+
       title = l10n.exploreMetaTitleCountry(country);
       description = l10n.exploreMetaDescriptionCountry(country);
     }
-    
+
     web.document.title = title;
     _updateMetaDescription(description);
     _updateMetaTitle(title);
@@ -180,34 +194,37 @@ class _ExploreScreenState extends State<ExploreScreen> {
   /// Returns null if country code cannot be determined
   String? _extractCountryCodeFromUrl() {
     if (!kIsWeb) return null;
-    
+
     try {
       final uri = Uri.parse(web.window.location.href);
       final pathSegments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
-      
+
       // For country-only pages: /gb -> pathSegments = ['gb']
       // For city pages: /gb/london -> pathSegments = ['gb', 'london']
       // For spot pages: /gb/london/spot-id -> pathSegments = ['gb', 'london', 'spot-id']
-      
+
       if (pathSegments.isNotEmpty) {
         final firstSegment = pathSegments[0];
         // Validate it's a 2-letter country code
-        if (firstSegment.length == 2 && RegExp(r'^[a-zA-Z]{2}$').hasMatch(firstSegment)) {
+        if (firstSegment.length == 2 &&
+            RegExp(r'^[a-zA-Z]{2}$').hasMatch(firstSegment)) {
           return firstSegment.toUpperCase();
         }
       }
     } catch (e) {
       // If URL parsing fails, return null
     }
-    
+
     return null;
   }
 
   void _updateMetaDescription(String description) {
     if (!kIsWeb) return;
-    
+
     // Find or create the meta description tag
-    final metaDescription = web.document.querySelector('meta[name="description"]');
+    final metaDescription = web.document.querySelector(
+      'meta[name="description"]',
+    );
     if (metaDescription != null) {
       metaDescription.setAttribute('content', description);
     } else {
@@ -217,14 +234,18 @@ class _ExploreScreenState extends State<ExploreScreen> {
       meta.content = description;
       web.document.head?.appendChild(meta);
     }
-    
+
     // Also update Open Graph and Twitter meta tags
-    final ogDescription = web.document.querySelector('meta[property="og:description"]');
+    final ogDescription = web.document.querySelector(
+      'meta[property="og:description"]',
+    );
     if (ogDescription != null) {
       ogDescription.setAttribute('content', description);
     }
-    
-    final twitterDescription = web.document.querySelector('meta[name="twitter:description"]');
+
+    final twitterDescription = web.document.querySelector(
+      'meta[name="twitter:description"]',
+    );
     if (twitterDescription != null) {
       twitterDescription.setAttribute('content', description);
     }
@@ -232,14 +253,16 @@ class _ExploreScreenState extends State<ExploreScreen> {
 
   void _updateMetaTitle(String title) {
     if (!kIsWeb) return;
-    
+
     // Update Open Graph and Twitter title tags
     final ogTitle = web.document.querySelector('meta[property="og:title"]');
     if (ogTitle != null) {
       ogTitle.setAttribute('content', title);
     }
-    
-    final twitterTitle = web.document.querySelector('meta[name="twitter:title"]');
+
+    final twitterTitle = web.document.querySelector(
+      'meta[name="twitter:title"]',
+    );
     if (twitterTitle != null) {
       twitterTitle.setAttribute('content', title);
     }
@@ -273,7 +296,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeInOut,
     );
-    
+
     // Update URL to reflect current tab (but don't navigate away)
     _updateUrlForTab(index);
   }
@@ -293,12 +316,15 @@ class _ExploreScreenState extends State<ExploreScreen> {
         final uri = GoRouterState.of(context).uri;
         final listId = uri.queryParameters['listId'];
         final locateSpotId = uri.queryParameters['locateSpotId'];
-        final hasMapParams = (listId?.isNotEmpty ?? false) || (locateSpotId?.isNotEmpty ?? false);
+        final hasMapParams =
+            (listId?.isNotEmpty ?? false) ||
+            (locateSpotId?.isNotEmpty ?? false);
         if (hasMapParams) {
           final params = <String, String>{};
           if (listId != null) params['listId'] = listId;
           if (locateSpotId != null) params['locateSpotId'] = locateSpotId;
-          newPath = '/explore?${params.entries.map((e) => '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}').join('&')}';
+          newPath =
+              '/explore?${params.entries.map((e) => '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}').join('&')}';
         } else {
           newPath = '/explore';
         }
@@ -328,10 +354,10 @@ class _ExploreScreenState extends State<ExploreScreen> {
       ),
       // Require profile loaded before Add spot (prevents email-as-createdByName race)
       authService.isProfileReady
-          ? const AddSpotScreen()
+          ? AddSpotScreen(initialLocation: widget.initialAddSpotLocation)
           : authService.isAuthenticated
-              ? _buildProfileLoadingScreen(authService)
-              : _buildLoginPromptScreen(Icons.add_location),
+          ? _buildProfileLoadingScreen(authService)
+          : _buildLoginPromptScreen(Icons.add_location),
       // Profile tab is always accessible
       const ProfileScreen(),
     ];
@@ -364,10 +390,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
                   error,
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.9),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.9),
                   ),
                 ),
               ),
@@ -381,7 +406,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
                   }
                 },
                 icon: const Icon(Icons.refresh),
-                label: Text(kIsWeb ? l10n.profileRefreshPage : l10n.profileRetry),
+                label: Text(
+                  kIsWeb ? l10n.profileRefreshPage : l10n.profileRetry,
+                ),
               ),
             ] else ...[
               SizedBox(
@@ -396,10 +423,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
               Text(
                 l10n.exploreLoadingProfile,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.7),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.7),
                 ),
               ),
             ],
@@ -436,23 +462,27 @@ class _ExploreScreenState extends State<ExploreScreen> {
                         Icon(
                           icon,
                           size: 48,
-                          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.6),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.primary.withValues(alpha: 0.6),
                         ),
                         const SizedBox(height: 16),
                         Text(
                           l10n.exploreSignInToAddSpot,
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
-                          ),
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.w600),
                           textAlign: TextAlign.center,
                         ),
                         const SizedBox(height: 8),
                         Text(
                           l10n.exploreAddSpotSubtitle,
                           textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
-                          ),
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurface.withValues(alpha: 0.7),
+                              ),
                         ),
                         const SizedBox(height: 16),
                         Center(
@@ -460,7 +490,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
                             constraints: const BoxConstraints(maxWidth: 400),
                             child: CustomButton(
                               onPressed: () {
-                                context.go('/login?redirectTo=${Uri.encodeComponent('/explore?tab=add')}');
+                                context.go(
+                                  '/login?redirectTo=${Uri.encodeComponent('/explore?tab=add')}',
+                                );
                               },
                               text: l10n.profileSignInButton,
                               width: double.infinity,
@@ -473,21 +505,31 @@ class _ExploreScreenState extends State<ExploreScreen> {
                           children: [
                             Expanded(
                               child: Divider(
-                                color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.outline.withValues(alpha: 0.3),
                               ),
                             ),
                             Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 16),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                              ),
                               child: Text(
                                 l10n.profileOrDivider,
-                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
-                                ),
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurface
+                                          .withValues(alpha: 0.6),
+                                    ),
                               ),
                             ),
                             Expanded(
                               child: Divider(
-                                color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.3),
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.outline.withValues(alpha: 0.3),
                               ),
                             ),
                           ],
@@ -498,7 +540,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
                             constraints: const BoxConstraints(maxWidth: 400),
                             child: CustomButton(
                               onPressed: () {
-                                context.go('/login?mode=signup&redirectTo=${Uri.encodeComponent('/explore?tab=add')}');
+                                context.go(
+                                  '/login?mode=signup&redirectTo=${Uri.encodeComponent('/explore?tab=add')}',
+                                );
                               },
                               text: l10n.profileCreateAccount,
                               width: double.infinity,
@@ -527,11 +571,7 @@ class _ExploreScreenState extends State<ExploreScreen> {
     const icon = Icon(Icons.person);
     if (unreadCount <= 0) return icon;
     final scheme = Theme.of(context).colorScheme;
-    return Badge(
-      smallSize: 8,
-      backgroundColor: scheme.error,
-      child: icon,
-    );
+    return Badge(smallSize: 8, backgroundColor: scheme.error, child: icon);
   }
 
   @override
@@ -540,10 +580,11 @@ class _ExploreScreenState extends State<ExploreScreen> {
       // On Explore tab (mobile): don't resize when keyboard opens - the bottom sheet
       // and search bar would be pushed around. Let the keyboard overlay instead.
       // On Add Spot/Account: keep default resize so text fields scroll into view.
-      resizeToAvoidBottomInset: !(_currentIndex == 0 && MobileDetectionService.isMobileDevice),
+      resizeToAvoidBottomInset:
+          !(_currentIndex == 0 && MobileDetectionService.isMobileDevice),
       body: PageView(
         controller: _pageController,
-        physics: _currentIndex == 0 
+        physics: _currentIndex == 0
             ? const NeverScrollableScrollPhysics() // Disable swiping on Explore tab (map gestures)
             : const PageScrollPhysics(), // Enable swiping on other tabs
         onPageChanged: (index) {
@@ -579,10 +620,9 @@ class _ExploreScreenState extends State<ExploreScreen> {
                   currentIndex: _currentIndex,
                   onTap: _onTabTapped,
                   selectedItemColor: Theme.of(context).colorScheme.primary,
-                  unselectedItemColor: Theme.of(context)
-                      .colorScheme
-                      .onSurface
-                      .withValues(alpha: 0.6),
+                  unselectedItemColor: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.6),
                   backgroundColor: Theme.of(context).colorScheme.surface,
                   elevation: 8,
                   items: [
@@ -608,4 +648,3 @@ class _ExploreScreenState extends State<ExploreScreen> {
     );
   }
 }
-

--- a/lib/screens/spots/add_spot_screen.dart
+++ b/lib/screens/spots/add_spot_screen.dart
@@ -26,18 +26,19 @@ import '../../l10n/app_localizations.dart';
 
 class AddSpotScreen extends StatefulWidget {
   final LatLng? initialLocation;
-  
+
   const AddSpotScreen({super.key, this.initialLocation});
 
   @override
   State<AddSpotScreen> createState() => _AddSpotScreenState();
 }
 
-class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin {
+class _AddSpotScreenState extends State<AddSpotScreen>
+    with MapRecenteringMixin {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
   final _descriptionController = TextEditingController();
-  
+
   final List<Uint8List?> _selectedImageBytes = [];
   Position? _currentPosition;
   LatLng? _pickedLocation;
@@ -50,7 +51,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
   bool _isSatelliteView = false;
   bool _isLocationPermissionDenied = false;
   SearchStateService? _searchStateServiceRef;
-  
+
   // Spot attributes
   String? _selectedAccess;
   final Set<String> _selectedFeatures = <String>{};
@@ -60,7 +61,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
   @override
   void initState() {
     super.initState();
-    
+
     // If initial location is provided, use it; otherwise get current location
     if (widget.initialLocation != null) {
       setState(() {
@@ -68,24 +69,36 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       });
       // Geocode the initial location
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _geocodeLocation(widget.initialLocation!.latitude, widget.initialLocation!.longitude);
+        _geocodeLocation(
+          widget.initialLocation!.latitude,
+          widget.initialLocation!.longitude,
+        );
       });
     } else {
       // Set default location so map is always visible, even if permission is denied
       setState(() {
-        _pickedLocation = const LatLng(AppConfig.defaultMapCenterLat, AppConfig.defaultMapCenterLng);
+        _pickedLocation = const LatLng(
+          AppConfig.defaultMapCenterLat,
+          AppConfig.defaultMapCenterLng,
+        );
       });
       // Geocode the default location
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _geocodeLocation(AppConfig.defaultMapCenterLat, AppConfig.defaultMapCenterLng);
+        _geocodeLocation(
+          AppConfig.defaultMapCenterLat,
+          AppConfig.defaultMapCenterLng,
+        );
       });
       // Try to get current location, but don't block if permission is denied
       _getCurrentLocation();
     }
-    
+
     // Initialize satellite view from SearchStateService
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _searchStateServiceRef = Provider.of<SearchStateService>(context, listen: false);
+      _searchStateServiceRef = Provider.of<SearchStateService>(
+        context,
+        listen: false,
+      );
       _searchStateServiceRef!.addListener(_onSearchStateChanged);
       setState(() {
         _isSatelliteView = _searchStateServiceRef!.isSatellite;
@@ -97,7 +110,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
     if (!mounted) return;
     final searchState = _searchStateServiceRef;
     if (searchState == null) return;
-    
+
     setState(() {
       _isSatelliteView = searchState.isSatellite;
     });
@@ -108,9 +121,33 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
     super.didChangeDependencies();
     // Center map on location after the map controller is created
     if (_currentPosition != null || _pickedLocation != null) {
-      final target = _pickedLocation ?? LatLng(_currentPosition!.latitude, _currentPosition!.longitude);
+      final target =
+          _pickedLocation ??
+          LatLng(_currentPosition!.latitude, _currentPosition!.longitude);
       centerMapAfterBuild(target);
     }
+  }
+
+  @override
+  void didUpdateWidget(covariant AddSpotScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newLocation = widget.initialLocation;
+    final oldLocation = oldWidget.initialLocation;
+    if (newLocation == null) return;
+
+    final locationChanged =
+        oldLocation == null ||
+        oldLocation.latitude != newLocation.latitude ||
+        oldLocation.longitude != newLocation.longitude;
+    if (!locationChanged) return;
+
+    setState(() {
+      _pickedLocation = newLocation;
+      // Ensure map centers on the explicit location and not stale device location.
+      _currentPosition = null;
+    });
+    centerMapOnLocationWithDelay(newLocation);
+    _geocodeLocation(newLocation.latitude, newLocation.longitude);
   }
 
   @override
@@ -131,9 +168,11 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       context: context,
       showErrorMessages: true,
     );
-    
-    final isPermissionGranted = LocationPermissionUtils.isPermissionGranted(permission);
-    
+
+    final isPermissionGranted = LocationPermissionUtils.isPermissionGranted(
+      permission,
+    );
+
     if (mounted) {
       setState(() {
         _isLocationPermissionDenied = !isPermissionGranted;
@@ -145,10 +184,16 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
         // If permission denied, ensure we still have a default location for the map
         if (_pickedLocation == null && _currentPosition == null) {
           setState(() {
-            _pickedLocation = const LatLng(AppConfig.defaultMapCenterLat, AppConfig.defaultMapCenterLng);
+            _pickedLocation = const LatLng(
+              AppConfig.defaultMapCenterLat,
+              AppConfig.defaultMapCenterLng,
+            );
           });
           // Geocode the default location
-          _geocodeLocation(AppConfig.defaultMapCenterLat, AppConfig.defaultMapCenterLng);
+          _geocodeLocation(
+            AppConfig.defaultMapCenterLat,
+            AppConfig.defaultMapCenterLng,
+          );
         }
         setState(() {
           _isGettingLocation = false;
@@ -172,7 +217,9 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
           _isLocationPermissionDenied = false;
         });
         // Center the map on the new current location with a small delay to ensure controller is ready
-        centerMapOnLocationWithDelay(LatLng(position.latitude, position.longitude));
+        centerMapOnLocationWithDelay(
+          LatLng(position.latitude, position.longitude),
+        );
         // Geocode the coordinates to get address
         _geocodeCurrentLocation();
       }
@@ -180,7 +227,9 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(AppLocalizations.of(context)!.exploreLocationError('$e')),
+            content: Text(
+              AppLocalizations.of(context)!.exploreLocationError('$e'),
+            ),
             backgroundColor: Colors.red,
           ),
         );
@@ -214,10 +263,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
           } on ImagePreparationException catch (e) {
             if (mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(e.message),
-                  backgroundColor: Colors.red,
-                ),
+                SnackBar(content: Text(e.message), backgroundColor: Colors.red),
               );
             }
           }
@@ -259,10 +305,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
     } on ImagePreparationException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.message),
-            backgroundColor: Colors.red,
-          ),
+          SnackBar(content: Text(e.message), backgroundColor: Colors.red),
         );
       }
     } catch (e) {
@@ -292,15 +335,18 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
     });
   }
 
-
   Future<void> _pickLocationOnMap() async {
     final result = await Navigator.push<LatLng>(
       context,
       MaterialPageRoute(
         builder: (context) => LocationPickerScreen(
-          initialLocation: _pickedLocation ?? 
-              (_currentPosition != null 
-                  ? LatLng(_currentPosition!.latitude, _currentPosition!.longitude)
+          initialLocation:
+              _pickedLocation ??
+              (_currentPosition != null
+                  ? LatLng(
+                      _currentPosition!.latitude,
+                      _currentPosition!.longitude,
+                    )
                   : null),
           showUsageTip: true,
         ),
@@ -322,18 +368,27 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
 
   Future<void> _geocodeCurrentLocation() async {
     if (_currentPosition == null) return;
-      await _geocodeLocation(_currentPosition!.latitude, _currentPosition!.longitude);
+    await _geocodeLocation(
+      _currentPosition!.latitude,
+      _currentPosition!.longitude,
+    );
   }
 
   Future<void> _geocodeLocation(double latitude, double longitude) async {
     try {
-    setState(() {
-      _isGeocoding = true;
-    });
+      setState(() {
+        _isGeocoding = true;
+      });
 
-      final geocodingService = Provider.of<GeocodingService>(context, listen: false);
-      final result = await geocodingService.geocodeCoordinatesDetails(latitude, longitude);
-      
+      final geocodingService = Provider.of<GeocodingService>(
+        context,
+        listen: false,
+      );
+      final result = await geocodingService.geocodeCoordinatesDetails(
+        latitude,
+        longitude,
+      );
+
       if (mounted) {
         setState(() {
           _currentAddress = result['address'];
@@ -342,7 +397,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
         });
       }
     } catch (e) {
-        debugPrint('Error geocoding location: $e');
+      debugPrint('Error geocoding location: $e');
     } finally {
       if (mounted) {
         setState(() {
@@ -354,7 +409,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
 
   Future<void> _submitForm() async {
     if (!_formKey.currentState!.validate()) return;
-    
+
     // Check if at least one photo is uploaded
     if (_selectedImageBytes.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -365,7 +420,7 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       );
       return;
     }
-    
+
     if (_currentPosition == null && _pickedLocation == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -389,7 +444,8 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       }
 
       // Create spot - resolve createdByName (prefer profile displayName, then Auth displayName, then email)
-      final displayName = authService.userProfile?.displayName ??
+      final displayName =
+          authService.userProfile?.displayName ??
           authService.currentUser?.displayName;
       final email = authService.currentUser?.email;
       final uid = authService.currentUser?.uid;
@@ -404,13 +460,17 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
         countryCode: _currentCountryCode,
         createdBy: authService.currentUser?.uid,
         createdByName: createdByName,
-      averageRating: 0.0,
-      ratingCount: 0,
-      wilsonLowerBound: 0.0,
-      ranking: Random().nextDouble(),
-      spotAccess: _selectedAccess,
-        spotFeatures: _selectedFeatures.isNotEmpty ? _selectedFeatures.toList() : null,
-        spotFacilities: _selectedFacilities.isNotEmpty ? _selectedFacilities : null,
+        averageRating: 0.0,
+        ratingCount: 0,
+        wilsonLowerBound: 0.0,
+        ranking: Random().nextDouble(),
+        spotAccess: _selectedAccess,
+        spotFeatures: _selectedFeatures.isNotEmpty
+            ? _selectedFeatures.toList()
+            : null,
+        spotFacilities: _selectedFacilities.isNotEmpty
+            ? _selectedFacilities
+            : null,
         goodFor: _selectedGoodFor.isNotEmpty ? _selectedGoodFor.toList() : null,
         duplicateOf: null, // New spot, not a duplicate
         hidden: false, // New spot, not hidden
@@ -419,7 +479,10 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       final spotId = await spotService.createSpot(
         spot,
         imageFiles: null,
-        imageBytesList: _selectedImageBytes.where((bytes) => bytes != null).cast<Uint8List>().toList(),
+        imageBytesList: _selectedImageBytes
+            .where((bytes) => bytes != null)
+            .cast<Uint8List>()
+            .toList(),
       );
 
       if (spotId != null && mounted) {
@@ -433,14 +496,14 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
           _selectedFacilities.clear();
           _selectedGoodFor.clear();
         });
-        
+
         // Navigate to the newly created spot detail page
         if (context.mounted) {
           // Use locale and city-based URL format
           final navigationUrl = UrlService.generateNavigationUrl(
-            spotId, 
-            countryCode: _currentCountryCode, 
-            city: _currentCity
+            spotId,
+            countryCode: _currentCountryCode,
+            city: _currentCity,
           );
           // Use go so back from the new spot doesn't return to the add form
           context.go(navigationUrl);
@@ -450,7 +513,9 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(AppLocalizations.of(context)!.addSpotCreateError('$e')),
+            content: Text(
+              AppLocalizations.of(context)!.addSpotCreateError('$e'),
+            ),
             backgroundColor: Colors.red,
           ),
         );
@@ -485,131 +550,145 @@ class _AddSpotScreenState extends State<AddSpotScreen> with MapRecenteringMixin 
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-              // Location Section
-              SpotLocationSection(
-                currentLocation: _pickedLocation != null 
-                    ? LatLng(_pickedLocation!.latitude, _pickedLocation!.longitude)
-                    : (_currentPosition != null 
-                        ? LatLng(_currentPosition!.latitude, _currentPosition!.longitude) 
-                        : null),
-                address: _currentAddress,
-                countryCode: _currentCountryCode,
-                isGettingLocation: _isGettingLocation,
-                isGeocoding: _isGeocoding,
-                isSatelliteView: _isSatelliteView,
-                isLocationPermissionDenied: _isLocationPermissionDenied,
-                onRefreshLocation: _getCurrentLocation,
-                onPickOnMap: _pickLocationOnMap,
-                onToggleSatellite: (value) {
-                                    setState(() {
-                                      _isSatelliteView = value;
-                                    });
-                                    final searchState = Provider.of<SearchStateService>(context, listen: false);
-                                    searchState.setSatellite(value);
-                                  },
-                onMapCreated: onMapCreated,
-              ),
-              
-              const SizedBox(height: 16),
-              
-              // Image Section
-              SpotImageSection(
-                selectedImageBytes: _selectedImageBytes,
-                existingImageUrls: const <String>[],
-                onPickFromGallery: _pickImagesFromGallery,
-                onTakePhoto: _takePhoto,
-                onRemoveSelectedAt: _removeImageAt,
-                onRemoveExistingAt: (index) {}, // Not used in add mode
-                onReorderSelected: _reorderSelectedImage,
-              ),
-              
-              const SizedBox(height: 16),
-              
-              // Name Field
-              CustomTextField(
-                controller: _nameController,
-                labelText: l10n.addSpotNameLabel,
-                prefixIcon: Icons.location_on,
-                textCapitalization: TextCapitalization.words,
-                validator: (value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return l10n.addSpotNameRequired;
-                  }
-                  return null;
-                },
-              ),
-              
-              const SizedBox(height: 16),
-              
-              // Description Field
-              CustomTextField(
-                controller: _descriptionController,
-                labelText: l10n.addSpotDescriptionLabel,
-                prefixIcon: Icons.description,
-                maxLines: 3,
-                textCapitalization: TextCapitalization.sentences,
-                validator: (value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return l10n.addSpotDescriptionRequired;
-                  }
-                  if (value.trim().length < 10) {
-                    return l10n.addSpotDescriptionMinLength;
-                  }
-                  return null;
-                },
-              ),
-              
-              const SizedBox(height: 16),
-              
-              // Attributes Section
-              SpotAttributesSection(
-                selectedAccess: _selectedAccess,
-                selectedFeatures: _selectedFeatures,
-                selectedFacilities: _selectedFacilities,
-                selectedGoodFor: _selectedGoodFor,
-                onAccessChanged: (value) {
-                  setState(() {
-                    _selectedAccess = value;
-                  });
-                },
-                onToggleFeature: (key, selected) {
-        setState(() {
-                    if (selected) {
-                      _selectedFeatures.add(key);
-          } else {
-                      _selectedFeatures.remove(key);
-          }
-        });
-      },
-                onFacilityChanged: (key, value) {
-              setState(() {
-                    _selectedFacilities[key] = value;
-              });
-            },
-                onToggleGoodFor: (key, selected) {
-        setState(() {
-                    if (selected) {
-                      _selectedGoodFor.add(key);
-          } else {
-                      _selectedGoodFor.remove(key);
-          }
-        });
-        },
-              ),
-              
-              const SizedBox(height: 24),
-              
-              // Submit Button
-              CustomButton(
-                onPressed: _isLoading || 
-                           (_currentPosition == null && _pickedLocation == null) || 
-                           _selectedImageBytes.isEmpty 
-                           ? null : _submitForm,
-                text: _isLoading ? l10n.addSpotCreating : l10n.addSpotCreateButton,
-                isLoading: _isLoading,
-                icon: Icons.add_location,
-            ),
-          ],
+                  // Location Section
+                  SpotLocationSection(
+                    currentLocation: _pickedLocation != null
+                        ? LatLng(
+                            _pickedLocation!.latitude,
+                            _pickedLocation!.longitude,
+                          )
+                        : (_currentPosition != null
+                              ? LatLng(
+                                  _currentPosition!.latitude,
+                                  _currentPosition!.longitude,
+                                )
+                              : null),
+                    address: _currentAddress,
+                    countryCode: _currentCountryCode,
+                    isGettingLocation: _isGettingLocation,
+                    isGeocoding: _isGeocoding,
+                    isSatelliteView: _isSatelliteView,
+                    isLocationPermissionDenied: _isLocationPermissionDenied,
+                    onRefreshLocation: _getCurrentLocation,
+                    onPickOnMap: _pickLocationOnMap,
+                    onToggleSatellite: (value) {
+                      setState(() {
+                        _isSatelliteView = value;
+                      });
+                      final searchState = Provider.of<SearchStateService>(
+                        context,
+                        listen: false,
+                      );
+                      searchState.setSatellite(value);
+                    },
+                    onMapCreated: onMapCreated,
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Image Section
+                  SpotImageSection(
+                    selectedImageBytes: _selectedImageBytes,
+                    existingImageUrls: const <String>[],
+                    onPickFromGallery: _pickImagesFromGallery,
+                    onTakePhoto: _takePhoto,
+                    onRemoveSelectedAt: _removeImageAt,
+                    onRemoveExistingAt: (index) {}, // Not used in add mode
+                    onReorderSelected: _reorderSelectedImage,
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Name Field
+                  CustomTextField(
+                    controller: _nameController,
+                    labelText: l10n.addSpotNameLabel,
+                    prefixIcon: Icons.location_on,
+                    textCapitalization: TextCapitalization.words,
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return l10n.addSpotNameRequired;
+                      }
+                      return null;
+                    },
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Description Field
+                  CustomTextField(
+                    controller: _descriptionController,
+                    labelText: l10n.addSpotDescriptionLabel,
+                    prefixIcon: Icons.description,
+                    maxLines: 3,
+                    textCapitalization: TextCapitalization.sentences,
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return l10n.addSpotDescriptionRequired;
+                      }
+                      if (value.trim().length < 10) {
+                        return l10n.addSpotDescriptionMinLength;
+                      }
+                      return null;
+                    },
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Attributes Section
+                  SpotAttributesSection(
+                    selectedAccess: _selectedAccess,
+                    selectedFeatures: _selectedFeatures,
+                    selectedFacilities: _selectedFacilities,
+                    selectedGoodFor: _selectedGoodFor,
+                    onAccessChanged: (value) {
+                      setState(() {
+                        _selectedAccess = value;
+                      });
+                    },
+                    onToggleFeature: (key, selected) {
+                      setState(() {
+                        if (selected) {
+                          _selectedFeatures.add(key);
+                        } else {
+                          _selectedFeatures.remove(key);
+                        }
+                      });
+                    },
+                    onFacilityChanged: (key, value) {
+                      setState(() {
+                        _selectedFacilities[key] = value;
+                      });
+                    },
+                    onToggleGoodFor: (key, selected) {
+                      setState(() {
+                        if (selected) {
+                          _selectedGoodFor.add(key);
+                        } else {
+                          _selectedGoodFor.remove(key);
+                        }
+                      });
+                    },
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // Submit Button
+                  CustomButton(
+                    onPressed:
+                        _isLoading ||
+                            (_currentPosition == null &&
+                                _pickedLocation == null) ||
+                            _selectedImageBytes.isEmpty
+                        ? null
+                        : _submitForm,
+                    text: _isLoading
+                        ? l10n.addSpotCreating
+                        : l10n.addSpotCreateButton,
+                    isLoading: _isLoading,
+                    icon: Icons.add_location,
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -27,7 +27,6 @@ import '../../utils/map_bounds_utils.dart';
 import '../../utils/location_permission_utils.dart';
 import '../../constants/spot_attributes.dart';
 import '../../l10n/app_localizations.dart';
-import 'add_spot_screen.dart';
 
 /// Stateful overlay for autocomplete suggestions; manages ScrollController lifecycle.
 class _AutocompleteOverlayContent extends StatefulWidget {
@@ -3612,6 +3611,16 @@ class SearchScreenState extends State<SearchScreen>
                                               onPressed: () {
                                                 final location =
                                                     _longPressedLocation!;
+                                                final addSpotUri = Uri(
+                                                  path: '/explore',
+                                                  queryParameters: {
+                                                    'tab': 'add',
+                                                    'lat': location.latitude
+                                                        .toString(),
+                                                    'lng': location.longitude
+                                                        .toString(),
+                                                  },
+                                                );
                                                 final authService =
                                                     Provider.of<AuthService>(
                                                       context,
@@ -3631,7 +3640,7 @@ class SearchScreenState extends State<SearchScreen>
                                                 if (!authService
                                                     .isAuthenticated) {
                                                   context.go(
-                                                    '/login?redirectTo=${Uri.encodeComponent('/explore?tab=add')}',
+                                                    '/login?redirectTo=${Uri.encodeComponent(addSpotUri.toString())}',
                                                   );
                                                 } else if (!authService
                                                     .isProfileReady) {
@@ -3647,16 +3656,9 @@ class SearchScreenState extends State<SearchScreen>
                                                     ),
                                                   );
                                                 } else {
-                                                  // Navigate to add spot screen with the location
-                                                  Navigator.push(
-                                                    context,
-                                                    MaterialPageRoute(
-                                                      builder: (context) =>
-                                                          AddSpotScreen(
-                                                            initialLocation:
-                                                                location,
-                                                          ),
-                                                    ),
+                                                  // Navigate to Add Spot tab (preserves bottom navigation).
+                                                  context.go(
+                                                    addSpotUri.toString(),
                                                   );
                                                 }
                                               },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route Explore map long-press/right-click "Create Spot" to `/explore?tab=add&lat=...&lng=...` instead of pushing a standalone `AddSpotScreen`
- parse `lat/lng` in the explore route and pass the resulting location into `ExploreScreen` and `AddSpotScreen`
- update `AddSpotScreen` to react when `initialLocation` changes so the map and reverse-geocoded address stay in sync when re-entering the Add tab
- resolve `LatLng` type collision in `app_router.dart` by namespacing `google_maps_flutter` import

## Problem
Creating a spot from the Explore map opened `AddSpotScreen` with `Navigator.push`, which bypassed the tab shell and removed bottom navigation.

## Validation
- `flutter analyze lib/router/app_router.dart lib/screens/explore_screen.dart lib/screens/spots/add_spot_screen.dart lib/screens/spots/search_screen.dart` (no errors; two pre-existing info diagnostics in `search_screen.dart`)
- `flutter test` (pass)

## Manual verification note
I attempted end-to-end GUI verification in this environment, but the `computerUse` subagent hit a provider-side artifact limit (`maximum of 100 images/documents`) before a clean recorded pass could be captured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b3f6dc2-721d-4b28-83d8-fbbe240b112d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b3f6dc2-721d-4b28-83d8-fbbe240b112d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

