### PR TITLE
Add admin events model and initial management UI

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -28,15 +28,47 @@ service cloud.firestore {
 
     // Parkour events (admin-managed). Each event links to one or more spots.
     match /events/{eventId} {
+      function eventWebsiteOk(data) {
+        return !('websiteUrl' in data) ||
+          (data.websiteUrl is string &&
+            data.websiteUrl.size() > 0 &&
+            data.websiteUrl.size() <= 2048 &&
+            data.websiteUrl.matches('^https?://.+$'));
+      }
+
+      function eventImagesOk(data) {
+        return !('imageUrls' in data) ||
+          (data.imageUrls is list && data.imageUrls.size() <= 20);
+      }
+
+      function eventLocationOk(data) {
+        return (
+          !('latitude' in data) &&
+          !('longitude' in data) &&
+          !('address' in data)
+        ) || (
+          data.latitude is number &&
+          data.longitude is number &&
+          data.latitude >= -90 && data.latitude <= 90 &&
+          data.longitude >= -180 && data.longitude <= 180 &&
+          data.address is string &&
+          data.address.size() > 0 &&
+          data.address.size() <= 500
+        );
+      }
+
       function eventCommonShape(data) {
         return data.title is string &&
           data.title.size() > 0 &&
           data.title.size() <= 200 &&
           (!('description' in data) ||
             (data.description is string && data.description.size() <= 2000)) &&
+          eventImagesOk(data) &&
+          eventWebsiteOk(data) &&
           data.startAt is timestamp &&
           (!('endAt' in data) ||
             (data.endAt is timestamp && data.endAt >= data.startAt)) &&
+          eventLocationOk(data) &&
           data.spotIds is list &&
           data.spotIds.size() > 0 &&
           data.spotIds.size() <= 50;

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,6 +26,45 @@ service cloud.firestore {
         get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
     }
 
+    // Parkour events (admin-managed). Each event links to one or more spots.
+    match /events/{eventId} {
+      function eventCommonShape(data) {
+        return data.title is string &&
+          data.title.size() > 0 &&
+          data.title.size() <= 200 &&
+          (!('description' in data) ||
+            (data.description is string && data.description.size() <= 2000)) &&
+          data.startAt is timestamp &&
+          (!('endAt' in data) ||
+            (data.endAt is timestamp && data.endAt >= data.startAt)) &&
+          data.spotIds is list &&
+          data.spotIds.size() > 0 &&
+          data.spotIds.size() <= 50;
+      }
+
+      function eventCreateShape() {
+        return request.auth != null &&
+          request.resource.data.createdBy is string &&
+          request.resource.data.createdBy == request.auth.uid &&
+          request.resource.data.createdAt is timestamp &&
+          request.resource.data.updatedAt is timestamp &&
+          eventCommonShape(request.resource.data);
+      }
+
+      function eventUpdateShape() {
+        return request.auth != null &&
+          request.resource.data.createdBy == resource.data.createdBy &&
+          request.resource.data.createdAt == resource.data.createdAt &&
+          request.resource.data.updatedAt is timestamp &&
+          eventCommonShape(request.resource.data);
+      }
+
+      allow read: if requestingUserIsAdmin();
+      allow create: if requestingUserIsAdmin() && eventCreateShape();
+      allow update: if requestingUserIsAdmin() && eventUpdateShape();
+      allow delete: if requestingUserIsAdmin();
+    }
+
     // Spot check-ins (one document per check-in event; query by userId and/or spotId)
     match /spotCheckIns/{checkInId} {
       function spotCheckInCommentOk(data) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -91,7 +91,7 @@ service cloud.firestore {
           eventCommonShape(request.resource.data);
       }
 
-      allow read: if requestingUserIsAdmin();
+      allow read: if true;
       allow create: if requestingUserIsAdmin() && eventCreateShape();
       allow update: if requestingUserIsAdmin() && eventUpdateShape();
       allow delete: if requestingUserIsAdmin();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:parkour_spot/services/geocoding_service.dart';
 import 'package:parkour_spot/services/jumpflix_service.dart';
 import 'package:parkour_spot/services/user_management_service.dart';
 import 'package:parkour_spot/services/admin_notifications_service.dart';
+import 'package:parkour_spot/services/admin_events_service.dart';
 import 'package:parkour_spot/services/admin_push_subscriptions_service.dart';
 import 'package:parkour_spot/services/snackbar_service.dart';
 import 'package:parkour_spot/services/spot_list_service.dart';
@@ -183,6 +184,7 @@ class ParkourSpotApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(create: (_) => UserManagementService()),
         ChangeNotifierProvider(create: (_) => AdminNotificationsService()),
+        ChangeNotifierProvider(create: (_) => AdminEventsService()),
         ChangeNotifierProvider(create: (_) => AdminPushSubscriptionsService()),
         ChangeNotifierProvider(create: (_) => SpotService()),
         ChangeNotifierProvider(create: (_) => SyncSourceService()),

--- a/lib/models/parkour_event.dart
+++ b/lib/models/parkour_event.dart
@@ -4,8 +4,13 @@ class ParkourEvent {
   final String? id;
   final String title;
   final String? description;
+  final List<String> imageUrls;
+  final String? websiteUrl;
   final DateTime startAt;
   final DateTime? endAt;
+  final double? latitude;
+  final double? longitude;
+  final String? address;
   final List<String> spotIds;
   final String? createdBy;
   final DateTime? createdAt;
@@ -15,8 +20,13 @@ class ParkourEvent {
     this.id,
     required this.title,
     this.description,
+    this.imageUrls = const <String>[],
+    this.websiteUrl,
     required this.startAt,
     this.endAt,
+    this.latitude,
+    this.longitude,
+    this.address,
     required this.spotIds,
     this.createdBy,
     this.createdAt,
@@ -29,10 +39,17 @@ class ParkourEvent {
       id: doc.id,
       title: (data['title'] ?? '') as String,
       description: data['description'] as String?,
+      imageUrls: data['imageUrls'] is List
+          ? List<String>.from(data['imageUrls'])
+          : const <String>[],
+      websiteUrl: data['websiteUrl'] as String?,
       startAt: (data['startAt'] as Timestamp).toDate(),
       endAt: data['endAt'] is Timestamp
           ? (data['endAt'] as Timestamp).toDate()
           : null,
+      latitude: (data['latitude'] as num?)?.toDouble(),
+      longitude: (data['longitude'] as num?)?.toDouble(),
+      address: data['address'] as String?,
       spotIds: data['spotIds'] is List
           ? List<String>.from(data['spotIds'])
           : const <String>[],
@@ -59,8 +76,15 @@ class ParkourEvent {
       id: data['id'] as String?,
       title: (data['title'] ?? '') as String,
       description: data['description'] as String?,
+      imageUrls: data['imageUrls'] is List
+          ? List<String>.from(data['imageUrls'])
+          : const <String>[],
+      websiteUrl: data['websiteUrl'] as String?,
       startAt: parseDate(data['startAt']) ?? DateTime.now().toUtc(),
       endAt: parseDate(data['endAt']),
+      latitude: (data['latitude'] as num?)?.toDouble(),
+      longitude: (data['longitude'] as num?)?.toDouble(),
+      address: data['address'] as String?,
       spotIds: data['spotIds'] is List
           ? List<String>.from(data['spotIds'])
           : const <String>[],
@@ -75,8 +99,15 @@ class ParkourEvent {
       'title': title,
       if (description != null && description!.trim().isNotEmpty)
         'description': description!.trim(),
+      if (imageUrls.isNotEmpty) 'imageUrls': imageUrls,
+      if (websiteUrl != null && websiteUrl!.trim().isNotEmpty)
+        'websiteUrl': websiteUrl!.trim(),
       'startAt': startAt.toUtc(),
       if (endAt != null) 'endAt': endAt!.toUtc(),
+      if (latitude != null) 'latitude': latitude,
+      if (longitude != null) 'longitude': longitude,
+      if (address != null && address!.trim().isNotEmpty)
+        'address': address!.trim(),
       'spotIds': spotIds,
       if (createdBy != null) 'createdBy': createdBy,
       if (createdAt != null) 'createdAt': createdAt!.toUtc(),
@@ -88,8 +119,13 @@ class ParkourEvent {
     String? id,
     String? title,
     String? description,
+    List<String>? imageUrls,
+    Object? websiteUrl = _unset,
     DateTime? startAt,
     Object? endAt = _unset,
+    Object? latitude = _unset,
+    Object? longitude = _unset,
+    Object? address = _unset,
     List<String>? spotIds,
     Object? createdBy = _unset,
     Object? createdAt = _unset,
@@ -99,8 +135,19 @@ class ParkourEvent {
       id: id ?? this.id,
       title: title ?? this.title,
       description: description ?? this.description,
+      imageUrls: imageUrls ?? this.imageUrls,
+      websiteUrl: identical(websiteUrl, _unset)
+          ? this.websiteUrl
+          : websiteUrl as String?,
       startAt: startAt ?? this.startAt,
       endAt: identical(endAt, _unset) ? this.endAt : endAt as DateTime?,
+      latitude: identical(latitude, _unset)
+          ? this.latitude
+          : latitude as double?,
+      longitude: identical(longitude, _unset)
+          ? this.longitude
+          : longitude as double?,
+      address: identical(address, _unset) ? this.address : address as String?,
       spotIds: spotIds ?? this.spotIds,
       createdBy: identical(createdBy, _unset)
           ? this.createdBy

--- a/lib/models/parkour_event.dart
+++ b/lib/models/parkour_event.dart
@@ -1,0 +1,118 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class ParkourEvent {
+  final String? id;
+  final String title;
+  final String? description;
+  final DateTime startAt;
+  final DateTime? endAt;
+  final List<String> spotIds;
+  final String? createdBy;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  ParkourEvent({
+    this.id,
+    required this.title,
+    this.description,
+    required this.startAt,
+    this.endAt,
+    required this.spotIds,
+    this.createdBy,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory ParkourEvent.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return ParkourEvent(
+      id: doc.id,
+      title: (data['title'] ?? '') as String,
+      description: data['description'] as String?,
+      startAt: (data['startAt'] as Timestamp).toDate(),
+      endAt: data['endAt'] is Timestamp
+          ? (data['endAt'] as Timestamp).toDate()
+          : null,
+      spotIds: data['spotIds'] is List
+          ? List<String>.from(data['spotIds'])
+          : const <String>[],
+      createdBy: data['createdBy'] as String?,
+      createdAt: data['createdAt'] is Timestamp
+          ? (data['createdAt'] as Timestamp).toDate()
+          : null,
+      updatedAt: data['updatedAt'] is Timestamp
+          ? (data['updatedAt'] as Timestamp).toDate()
+          : null,
+    );
+  }
+
+  factory ParkourEvent.fromMap(Map<String, dynamic> data) {
+    DateTime? parseDate(dynamic value) {
+      if (value == null) return null;
+      if (value is Timestamp) return value.toDate();
+      if (value is DateTime) return value;
+      if (value is String) return DateTime.tryParse(value);
+      return null;
+    }
+
+    return ParkourEvent(
+      id: data['id'] as String?,
+      title: (data['title'] ?? '') as String,
+      description: data['description'] as String?,
+      startAt: parseDate(data['startAt']) ?? DateTime.now().toUtc(),
+      endAt: parseDate(data['endAt']),
+      spotIds: data['spotIds'] is List
+          ? List<String>.from(data['spotIds'])
+          : const <String>[],
+      createdBy: data['createdBy'] as String?,
+      createdAt: parseDate(data['createdAt']),
+      updatedAt: parseDate(data['updatedAt']),
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'title': title,
+      if (description != null && description!.trim().isNotEmpty)
+        'description': description!.trim(),
+      'startAt': startAt.toUtc(),
+      if (endAt != null) 'endAt': endAt!.toUtc(),
+      'spotIds': spotIds,
+      if (createdBy != null) 'createdBy': createdBy,
+      if (createdAt != null) 'createdAt': createdAt!.toUtc(),
+      if (updatedAt != null) 'updatedAt': updatedAt!.toUtc(),
+    };
+  }
+
+  ParkourEvent copyWith({
+    String? id,
+    String? title,
+    String? description,
+    DateTime? startAt,
+    Object? endAt = _unset,
+    List<String>? spotIds,
+    Object? createdBy = _unset,
+    Object? createdAt = _unset,
+    Object? updatedAt = _unset,
+  }) {
+    return ParkourEvent(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      startAt: startAt ?? this.startAt,
+      endAt: identical(endAt, _unset) ? this.endAt : endAt as DateTime?,
+      spotIds: spotIds ?? this.spotIds,
+      createdBy: identical(createdBy, _unset)
+          ? this.createdBy
+          : createdBy as String?,
+      createdAt: identical(createdAt, _unset)
+          ? this.createdAt
+          : createdAt as DateTime?,
+      updatedAt: identical(updatedAt, _unset)
+          ? this.updatedAt
+          : updatedAt as DateTime?,
+    );
+  }
+
+  static const Object _unset = Object();
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -27,6 +27,7 @@ import '../screens/admin/api_clients_screen.dart';
 import '../screens/moderator/moderator_tools_screen.dart';
 import '../screens/moderator/spot_report_queue_screen.dart';
 import '../screens/spots/spot_detail_screen.dart';
+import '../screens/events/event_detail_screen.dart';
 import '../l10n/app_localizations.dart';
 import '../screens/spots/edit_spot_screen.dart';
 import '../screens/spots/spot_list_detail_screen.dart';
@@ -36,7 +37,9 @@ import '../screens/profile/my_check_ins_screen.dart';
 import '../screens/profile/account_settings_screen.dart';
 import '../screens/profile/notifications_screen.dart';
 import '../screens/profile/public_profile_screen.dart';
+import '../models/parkour_event.dart';
 import '../models/spot.dart';
+import '../services/admin_events_service.dart';
 import '../services/spot_service.dart';
 import '../services/auth_service.dart';
 import '../analytics/web_analytics.dart';
@@ -413,6 +416,13 @@ class AppRouter {
           builder: (context, state) => const ApiClientsScreen(),
         ),
         GoRoute(
+          path: '/event/:eventId',
+          builder: (context, state) {
+            final eventId = state.pathParameters['eventId']!;
+            return EventDetailRoute(eventId: eventId);
+          },
+        ),
+        GoRoute(
           path: '/moderator',
           builder: (context, state) => const ModeratorToolsScreen(),
           routes: [
@@ -653,6 +663,101 @@ class AppRouter {
 
     // If lookup fails, return null
     return null;
+  }
+}
+
+class EventDetailRoute extends StatefulWidget {
+  final String eventId;
+
+  const EventDetailRoute({super.key, required this.eventId});
+
+  @override
+  State<EventDetailRoute> createState() => _EventDetailRouteState();
+}
+
+class _EventDetailRouteState extends State<EventDetailRoute> {
+  Future<ParkourEvent?>? _eventFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _eventFuture = Provider.of<AdminEventsService>(
+      context,
+      listen: false,
+    ).getEventById(widget.eventId);
+  }
+
+  @override
+  void didUpdateWidget(covariant EventDetailRoute oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.eventId != widget.eventId) {
+      _eventFuture = Provider.of<AdminEventsService>(
+        context,
+        listen: false,
+      ).getEventById(widget.eventId);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<ParkourEvent?>(
+      future: _eventFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (snapshot.hasError) {
+          return Scaffold(
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error, size: 64, color: Colors.red),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Error loading event',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Please try again later',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        if (!snapshot.hasData || snapshot.data == null) {
+          return Scaffold(
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.event_busy_outlined, size: 64),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Event not found',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton(
+                    onPressed: () => context.go('/explore'),
+                    child: const Text('Go to Explore'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return EventDetailScreen(event: snapshot.data!);
+      },
+    );
   }
 }
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -13,6 +13,7 @@ import '../screens/admin/geocoding_admin_screen.dart';
 import '../screens/admin/spot_management_screen.dart';
 import '../screens/admin/user_management_screen.dart';
 import '../screens/admin/admin_notifications_screen.dart';
+import '../screens/admin/admin_events_screen.dart';
 import '../screens/admin/admin_push_subscriptions_screen.dart';
 import '../screens/admin/user_activity_metrics_screen.dart';
 import '../screens/admin/audit_log_viewer_screen.dart';
@@ -378,6 +379,10 @@ class AppRouter {
         GoRoute(
           path: '/admin/notifications',
           builder: (context, state) => const AdminNotificationsScreen(),
+        ),
+        GoRoute(
+          path: '/admin/events',
+          builder: (context, state) => const AdminEventsScreen(),
         ),
         GoRoute(
           path: '/admin/push-subscriptions',
@@ -769,17 +774,18 @@ class EditSpotRoute extends StatelessWidget {
   const EditSpotRoute({super.key, required this.spotId, this.spot});
 
   @override
-  Widget build(BuildContext context) => _EditSpotRouteContent(
-    spotId: spotId,
-    providedSpot: spot,
-  );
+  Widget build(BuildContext context) =>
+      _EditSpotRouteContent(spotId: spotId, providedSpot: spot);
 }
 
 class _EditSpotRouteContent extends StatefulWidget {
   final String spotId;
   final Spot? providedSpot;
 
-  const _EditSpotRouteContent({required this.spotId, required this.providedSpot});
+  const _EditSpotRouteContent({
+    required this.spotId,
+    required this.providedSpot,
+  });
 
   @override
   State<_EditSpotRouteContent> createState() => _EditSpotRouteContentState();
@@ -894,10 +900,7 @@ class _EditSpotRouteContentState extends State<_EditSpotRouteContent> {
             }
 
             final spot = snapshot.data!;
-            return EditSpotScreen(
-              key: ValueKey('edit-${spot.id}'),
-              spot: spot,
-            );
+            return EditSpotScreen(key: ValueKey('edit-${spot.id}'), spot: spot);
           },
         );
       },

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -316,7 +316,7 @@ class _EventCard extends StatelessWidget {
             if (hasWebsite) ...[
               const SizedBox(height: 10),
               InkWell(
-                onTap: () => _openWebsite(websiteUrl!),
+                onTap: () => _openWebsite(websiteUrl),
                 child: Text(
                   websiteUrl,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -623,6 +623,7 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   }
 
   Future<void> _submit() async {
+    final eventsService = context.read<AdminEventsService>();
     if (!_formKey.currentState!.validate()) return;
     if (_linkedSpots.isEmpty) {
       setState(() {
@@ -649,9 +650,9 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
 
     try {
       if (_selectedImageBytes.isNotEmpty) {
-        uploadedImageUrls = await context
-            .read<AdminEventsService>()
-            .uploadEventImages(_selectedImageBytes);
+        uploadedImageUrls = await eventsService.uploadEventImages(
+          _selectedImageBytes,
+        );
       }
     } catch (e) {
       if (!mounted) return;
@@ -685,7 +686,7 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
     }
 
     setState(() {
-      _formError = context.read<AdminEventsService>().error ?? 'Create failed';
+      _formError = eventsService.error ?? 'Create failed';
     });
   }
 

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -218,7 +218,7 @@ class _EventCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final startLabel = _formatUtc(event.startAt);
-    final endLabel = event.endAt == null ? null : _formatUtc(event.endAt);
+    final endLabel = event.endAt == null ? null : _formatUtc(event.endAt!);
 
     return Card(
       child: Padding(

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -335,6 +335,15 @@ class _EventCard extends StatelessWidget {
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ],
+            if (event.id != null)
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  onPressed: () => context.push('/event/${event.id}'),
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('Open event page'),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -356,6 +356,17 @@ class _EventCard extends StatelessWidget {
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ],
+              if (event.id != null) ...[
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton.tonalIcon(
+                    onPressed: openEventPage,
+                    icon: const Icon(Icons.open_in_new),
+                    label: const Text('Open event page'),
+                  ),
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -1,13 +1,19 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../models/parkour_event.dart';
 import '../../models/spot.dart';
 import '../../services/admin_events_service.dart';
 import '../../services/auth_service.dart';
+import '../../services/geocoding_service.dart';
 import '../../services/spot_service.dart';
+import '../../utils/image_preparation.dart';
 import '../../widgets/spot_selection_dialog.dart';
 
 class AdminEventsScreen extends StatefulWidget {
@@ -55,8 +61,13 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
             ({
               required String title,
               String? description,
+              List<String>? imageUrls,
+              String? websiteUrl,
               required DateTime startAt,
               DateTime? endAt,
+              double? latitude,
+              double? longitude,
+              String? address,
               required List<String> spotIds,
             }) async {
               final authService = context.read<AuthService>();
@@ -64,8 +75,13 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
               return context.read<AdminEventsService>().createEvent(
                 title: title,
                 description: description,
+                imageUrls: imageUrls,
+                websiteUrl: websiteUrl,
                 startAt: startAt,
                 endAt: endAt,
+                latitude: latitude,
+                longitude: longitude,
+                address: address,
                 spotIds: spotIds,
                 createdBy: createdBy,
               );
@@ -219,6 +235,9 @@ class _EventCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final startLabel = _formatUtc(event.startAt);
     final endLabel = event.endAt == null ? null : _formatUtc(event.endAt!);
+    final websiteUrl = event.websiteUrl?.trim();
+    final hasWebsite = websiteUrl != null && websiteUrl.isNotEmpty;
+    final hasLocation = event.latitude != null && event.longitude != null;
 
     return Card(
       child: Padding(
@@ -264,6 +283,58 @@ class _EventCard extends StatelessWidget {
               'Spot IDs: ${event.spotIds.join(', ')}',
               style: Theme.of(context).textTheme.bodySmall,
             ),
+            if (event.imageUrls.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              SizedBox(
+                height: 72,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: event.imageUrls.length,
+                  separatorBuilder: (_, _) => const SizedBox(width: 8),
+                  itemBuilder: (context, index) {
+                    return ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Image.network(
+                        event.imageUrls[index],
+                        width: 72,
+                        height: 72,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, _, _) => Container(
+                          width: 72,
+                          height: 72,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.surfaceContainerHighest,
+                          child: const Icon(Icons.broken_image_outlined),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+            if (hasWebsite) ...[
+              const SizedBox(height: 10),
+              InkWell(
+                onTap: () => _openWebsite(websiteUrl!),
+                child: Text(
+                  websiteUrl,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ),
+            ],
+            if (hasLocation) ...[
+              const SizedBox(height: 10),
+              Text(
+                event.address?.trim().isNotEmpty == true
+                    ? event.address!
+                    : '${event.latitude!.toStringAsFixed(5)}, ${event.longitude!.toStringAsFixed(5)}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
           ],
         ),
       ),
@@ -272,6 +343,12 @@ class _EventCard extends StatelessWidget {
 
   String _formatUtc(DateTime value) {
     return '${DateFormat.yMMMd().add_Hm().format(value.toUtc())} UTC';
+  }
+
+  Future<void> _openWebsite(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 }
 
@@ -307,8 +384,13 @@ class _CreateEventDialog extends StatefulWidget {
   final Future<bool> Function({
     required String title,
     String? description,
+    List<String>? imageUrls,
+    String? websiteUrl,
     required DateTime startAt,
     DateTime? endAt,
+    double? latitude,
+    double? longitude,
+    String? address,
     required List<String> spotIds,
   })
   onCreate;
@@ -321,17 +403,30 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _titleController = TextEditingController();
   final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _websiteController = TextEditingController();
+  final TextEditingController _latitudeController = TextEditingController();
+  final TextEditingController _longitudeController = TextEditingController();
+  final TextEditingController _addressController = TextEditingController();
+  final TextEditingController _newImageUrlController = TextEditingController();
 
   DateTime _startAt = DateTime.now().toUtc().add(const Duration(hours: 1));
   DateTime? _endAt;
   bool _isSubmitting = false;
+  bool _isGeocoding = false;
   String? _formError;
   final List<Spot> _linkedSpots = <Spot>[];
+  final List<Uint8List> _selectedImageBytes = <Uint8List>[];
+  final List<String> _imageUrls = <String>[];
 
   @override
   void dispose() {
     _titleController.dispose();
     _descriptionController.dispose();
+    _websiteController.dispose();
+    _latitudeController.dispose();
+    _longitudeController.dispose();
+    _addressController.dispose();
+    _newImageUrlController.dispose();
     super.dispose();
   }
 
@@ -379,6 +474,154 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
     });
   }
 
+  Future<void> _pickImagesFromGallery() async {
+    try {
+      final picker = ImagePicker();
+      final pickedFiles = await picker.pickMultiImage(
+        maxWidth: 2048,
+        maxHeight: 2048,
+        imageQuality: 85,
+      );
+      if (pickedFiles.isEmpty) return;
+
+      var addedCount = 0;
+      for (final pickedFile in pickedFiles) {
+        final bytes = await pickedFile.readAsBytes();
+        final prepared = await prepareImageForUpload(bytes);
+        _selectedImageBytes.add(prepared.bytes);
+        addedCount++;
+      }
+
+      if (!mounted || addedCount == 0) return;
+      setState(() {
+        _formError = null;
+      });
+    } on ImagePreparationException catch (e) {
+      setState(() {
+        _formError = e.message;
+      });
+    } catch (e) {
+      setState(() {
+        _formError = 'Failed to pick images: $e';
+      });
+    }
+  }
+
+  void _removeSelectedImageAt(int index) {
+    setState(() {
+      _selectedImageBytes.removeAt(index);
+    });
+  }
+
+  void _addImageUrl() {
+    final value = _newImageUrlController.text.trim();
+    if (value.isEmpty) return;
+    final uri = Uri.tryParse(value);
+    final valid =
+        uri != null &&
+        (uri.scheme == 'http' || uri.scheme == 'https') &&
+        uri.host.isNotEmpty;
+    if (!valid) {
+      setState(() {
+        _formError = 'Image URL must be a valid http(s) link';
+      });
+      return;
+    }
+    if (_imageUrls.contains(value)) {
+      _newImageUrlController.clear();
+      return;
+    }
+    setState(() {
+      _imageUrls.add(value);
+      _newImageUrlController.clear();
+      _formError = null;
+    });
+  }
+
+  void _removeImageUrlAt(int index) {
+    setState(() {
+      _imageUrls.removeAt(index);
+    });
+  }
+
+  Future<bool> _tryGeocodeCoordinatesIfNeeded({bool force = false}) async {
+    final latRaw = _latitudeController.text.trim();
+    final lngRaw = _longitudeController.text.trim();
+    final hasLatitudeText = latRaw.isNotEmpty;
+    final hasLongitudeText = lngRaw.isNotEmpty;
+    final hasAddress = _addressController.text.trim().isNotEmpty;
+
+    if (!hasLatitudeText && !hasLongitudeText) {
+      return true;
+    }
+    if (hasLatitudeText != hasLongitudeText) {
+      setState(() {
+        _formError = 'Both latitude and longitude are required';
+      });
+      return false;
+    }
+    final latitude = double.tryParse(latRaw);
+    final longitude = double.tryParse(lngRaw);
+    if (latitude == null || longitude == null) {
+      setState(() {
+        _formError = 'Latitude and longitude must be valid numbers';
+      });
+      return false;
+    }
+    if (latitude < -90 || latitude > 90) {
+      setState(() {
+        _formError = 'Latitude must be between -90 and 90';
+      });
+      return false;
+    }
+    if (longitude < -180 || longitude > 180) {
+      setState(() {
+        _formError = 'Longitude must be between -180 and 180';
+      });
+      return false;
+    }
+    if (hasAddress && !force) {
+      return true;
+    }
+
+    setState(() {
+      _isGeocoding = true;
+      _formError = null;
+    });
+    try {
+      final geocoding = context.read<GeocodingService>();
+      final details = await geocoding.geocodeCoordinatesDetails(
+        latitude,
+        longitude,
+      );
+      final resolvedAddress = details['address']?.trim();
+      if (!mounted) return false;
+      if (resolvedAddress == null || resolvedAddress.isEmpty) {
+        setState(() {
+          _formError = 'Unable to geocode these coordinates';
+        });
+        return false;
+      }
+      _addressController.text = resolvedAddress;
+      setState(() {
+        _formError = null;
+      });
+      return true;
+    } catch (e) {
+      if (!mounted) return false;
+      setState(() {
+        _formError = 'Failed to geocode coordinates: $e';
+      });
+      return false;
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGeocoding = false;
+        });
+      }
+    }
+  }
+
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
     if (_linkedSpots.isEmpty) {
@@ -394,16 +637,41 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       return;
     }
 
+    final geocoded = await _tryGeocodeCoordinatesIfNeeded();
+    if (!geocoded) return;
+
+    List<String> uploadedImageUrls = <String>[];
+
     setState(() {
       _isSubmitting = true;
       _formError = null;
     });
 
+    try {
+      if (_selectedImageBytes.isNotEmpty) {
+        uploadedImageUrls = await context
+            .read<AdminEventsService>()
+            .uploadEventImages(_selectedImageBytes);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isSubmitting = false;
+        _formError = 'Failed to upload images: $e';
+      });
+      return;
+    }
+
     final success = await widget.onCreate(
       title: _titleController.text.trim(),
       description: _descriptionController.text.trim(),
+      imageUrls: [..._imageUrls, ...uploadedImageUrls],
+      websiteUrl: _websiteController.text.trim(),
       startAt: _startAt,
       endAt: _endAt,
+      latitude: double.tryParse(_latitudeController.text.trim()),
+      longitude: double.tryParse(_longitudeController.text.trim()),
+      address: _addressController.text.trim(),
       spotIds: _linkedSpots.map((spot) => spot.id!).toList(),
     );
     if (!mounted) return;
@@ -456,6 +724,187 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
                   ),
                   minLines: 2,
                   maxLines: 4,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _websiteController,
+                  decoration: const InputDecoration(
+                    labelText: 'Website URL (optional)',
+                    border: OutlineInputBorder(),
+                    hintText: 'https://example.com/event',
+                  ),
+                  keyboardType: TextInputType.url,
+                  validator: (value) {
+                    final trimmed = value?.trim() ?? '';
+                    if (trimmed.isEmpty) return null;
+                    final uri = Uri.tryParse(trimmed);
+                    final valid =
+                        uri != null &&
+                        (uri.scheme == 'http' || uri.scheme == 'https') &&
+                        uri.host.isNotEmpty;
+                    if (!valid) return 'Enter a valid http(s) URL';
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Event images',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    FilledButton.icon(
+                      onPressed: _isSubmitting ? null : _pickImagesFromGallery,
+                      icon: const Icon(Icons.photo_library_outlined),
+                      label: const Text('Upload image(s)'),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _newImageUrlController,
+                        decoration: const InputDecoration(
+                          labelText: 'Add image URL',
+                          border: OutlineInputBorder(),
+                          isDense: true,
+                        ),
+                        keyboardType: TextInputType.url,
+                        onFieldSubmitted: (_) => _addImageUrl(),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    IconButton(
+                      onPressed: _isSubmitting ? null : _addImageUrl,
+                      icon: const Icon(Icons.add_link),
+                      tooltip: 'Add image URL',
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (_selectedImageBytes.isNotEmpty)
+                  SizedBox(
+                    height: 84,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: _selectedImageBytes.length,
+                      separatorBuilder: (_, _) => const SizedBox(width: 8),
+                      itemBuilder: (context, index) {
+                        return Stack(
+                          children: [
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Image.memory(
+                                _selectedImageBytes[index],
+                                width: 84,
+                                height: 84,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                            Positioned(
+                              top: 2,
+                              right: 2,
+                              child: InkWell(
+                                onTap: _isSubmitting
+                                    ? null
+                                    : () => _removeSelectedImageAt(index),
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: Colors.black54,
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  padding: const EdgeInsets.all(2),
+                                  child: const Icon(
+                                    Icons.close,
+                                    size: 14,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                if (_imageUrls.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 6,
+                    children: _imageUrls
+                        .asMap()
+                        .entries
+                        .map(
+                          (entry) => Chip(
+                            label: Text('URL ${entry.key + 1}'),
+                            onDeleted: _isSubmitting
+                                ? null
+                                : () => _removeImageUrlAt(entry.key),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ],
+                const SizedBox(height: 16),
+                Text(
+                  'Event location',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _latitudeController,
+                        decoration: const InputDecoration(
+                          labelText: 'Latitude',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                          signed: true,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _longitudeController,
+                        decoration: const InputDecoration(
+                          labelText: 'Longitude',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                          signed: true,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    FilledButton.tonalIcon(
+                      onPressed: (_isSubmitting || _isGeocoding)
+                          ? null
+                          : () => _tryGeocodeCoordinatesIfNeeded(force: true),
+                      icon: _isGeocoding
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.pin_drop_outlined),
+                      label: const Text('Geocode'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _addressController,
+                  decoration: const InputDecoration(
+                    labelText: 'Address (auto-filled from coordinates)',
+                    border: OutlineInputBorder(),
+                  ),
+                  minLines: 2,
+                  maxLines: 3,
                 ),
                 const SizedBox(height: 16),
                 _DateField(

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -238,113 +238,126 @@ class _EventCard extends StatelessWidget {
     final websiteUrl = event.websiteUrl?.trim();
     final hasWebsite = websiteUrl != null && websiteUrl.isNotEmpty;
     final hasLocation = event.latitude != null && event.longitude != null;
+    final openEventPage = event.id == null
+        ? null
+        : () => context.push('/event/${event.id}');
 
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(12, 12, 12, 10),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(event.title, style: Theme.of(context).textTheme.titleMedium),
-            if (event.description != null &&
-                event.description!.trim().isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.only(top: 6),
-                child: Text(event.description!),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: openEventPage,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      event.title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  if (event.id != null)
+                    IconButton(
+                      onPressed: openEventPage,
+                      tooltip: 'Open event page',
+                      icon: const Icon(Icons.open_in_new),
+                    ),
+                ],
               ),
-            const SizedBox(height: 10),
-            Wrap(
-              spacing: 8,
-              runSpacing: 6,
-              children: [
-                Chip(
-                  avatar: const Icon(Icons.schedule, size: 16),
-                  label: Text(startLabel),
-                  visualDensity: VisualDensity.compact,
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              if (event.description != null &&
+                  event.description!.trim().isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 6),
+                  child: Text(event.description!),
                 ),
-                if (endLabel != null)
+              const SizedBox(height: 10),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                children: [
                   Chip(
-                    avatar: const Icon(Icons.hourglass_bottom, size: 16),
-                    label: Text(endLabel),
+                    avatar: const Icon(Icons.schedule, size: 16),
+                    label: Text(startLabel),
                     visualDensity: VisualDensity.compact,
                     materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
-                Chip(
-                  avatar: const Icon(Icons.place_outlined, size: 16),
-                  label: Text('${event.spotIds.length} linked spot(s)'),
-                  visualDensity: VisualDensity.compact,
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            SelectableText(
-              'Spot IDs: ${event.spotIds.join(', ')}',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            if (event.imageUrls.isNotEmpty) ...[
-              const SizedBox(height: 10),
-              SizedBox(
-                height: 72,
-                child: ListView.separated(
-                  scrollDirection: Axis.horizontal,
-                  itemCount: event.imageUrls.length,
-                  separatorBuilder: (_, _) => const SizedBox(width: 8),
-                  itemBuilder: (context, index) {
-                    return ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Image.network(
-                        event.imageUrls[index],
-                        width: 72,
-                        height: 72,
-                        fit: BoxFit.cover,
-                        errorBuilder: (_, _, _) => Container(
-                          width: 72,
-                          height: 72,
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.surfaceContainerHighest,
-                          child: const Icon(Icons.broken_image_outlined),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ),
-            ],
-            if (hasWebsite) ...[
-              const SizedBox(height: 10),
-              InkWell(
-                onTap: () => _openWebsite(websiteUrl),
-                child: Text(
-                  websiteUrl,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
-                    decoration: TextDecoration.underline,
+                  if (endLabel != null)
+                    Chip(
+                      avatar: const Icon(Icons.hourglass_bottom, size: 16),
+                      label: Text(endLabel),
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                  Chip(
+                    avatar: const Icon(Icons.place_outlined, size: 16),
+                    label: Text('${event.spotIds.length} linked spot(s)'),
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
-                ),
+                ],
               ),
-            ],
-            if (hasLocation) ...[
               const SizedBox(height: 10),
-              Text(
-                event.address?.trim().isNotEmpty == true
-                    ? event.address!
-                    : '${event.latitude!.toStringAsFixed(5)}, ${event.longitude!.toStringAsFixed(5)}',
+              SelectableText(
+                'Spot IDs: ${event.spotIds.join(', ')}',
                 style: Theme.of(context).textTheme.bodySmall,
               ),
-            ],
-            if (event.id != null)
-              Align(
-                alignment: Alignment.centerRight,
-                child: TextButton.icon(
-                  onPressed: () => context.push('/event/${event.id}'),
-                  icon: const Icon(Icons.open_in_new),
-                  label: const Text('Open event page'),
+              if (event.imageUrls.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                SizedBox(
+                  height: 72,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: event.imageUrls.length,
+                    separatorBuilder: (_, _) => const SizedBox(width: 8),
+                    itemBuilder: (context, index) {
+                      return ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.network(
+                          event.imageUrls[index],
+                          width: 72,
+                          height: 72,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, _, _) => Container(
+                            width: 72,
+                            height: 72,
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            child: const Icon(Icons.broken_image_outlined),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
                 ),
-              ),
-          ],
+              ],
+              if (hasWebsite) ...[
+                const SizedBox(height: 10),
+                InkWell(
+                  onTap: () => _openWebsite(websiteUrl),
+                  child: Text(
+                    websiteUrl,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                ),
+              ],
+              if (hasLocation) ...[
+                const SizedBox(height: 10),
+                Text(
+                  event.address?.trim().isNotEmpty == true
+                      ? event.address!
+                      : '${event.latitude!.toStringAsFixed(5)}, ${event.longitude!.toStringAsFixed(5)}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -1,0 +1,624 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/parkour_event.dart';
+import '../../models/spot.dart';
+import '../../services/admin_events_service.dart';
+import '../../services/auth_service.dart';
+import '../../services/spot_service.dart';
+import '../../widgets/spot_selection_dialog.dart';
+
+class AdminEventsScreen extends StatefulWidget {
+  const AdminEventsScreen({super.key});
+
+  @override
+  State<AdminEventsScreen> createState() => _AdminEventsScreenState();
+}
+
+class _AdminEventsScreenState extends State<AdminEventsScreen> {
+  late final AuthService _authService;
+  bool _scheduledInitialFetch = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _authService = context.read<AuthService>();
+    _authService.addListener(_tryFetchForAdmin);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _tryFetchForAdmin());
+  }
+
+  @override
+  void dispose() {
+    _authService.removeListener(_tryFetchForAdmin);
+    super.dispose();
+  }
+
+  void _tryFetchForAdmin() {
+    if (!mounted) return;
+    if (!_authService.isAdmin || !_authService.isProfileReady) return;
+    if (_scheduledInitialFetch) return;
+
+    final service = context.read<AdminEventsService>();
+    if (service.events.isNotEmpty || service.isLoading) return;
+
+    _scheduledInitialFetch = true;
+    service.fetchEvents();
+  }
+
+  Future<void> _openCreateDialog() async {
+    final created = await showDialog<bool>(
+      context: context,
+      builder: (_) => _CreateEventDialog(
+        onCreate:
+            ({
+              required String title,
+              String? description,
+              required DateTime startAt,
+              DateTime? endAt,
+              required List<String> spotIds,
+            }) async {
+              final authService = context.read<AuthService>();
+              final createdBy = authService.currentUser?.uid ?? 'unknown';
+              return context.read<AdminEventsService>().createEvent(
+                title: title,
+                description: description,
+                startAt: startAt,
+                endAt: endAt,
+                spotIds: spotIds,
+                createdBy: createdBy,
+              );
+            },
+      ),
+    );
+
+    if (!mounted || created == null) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(created ? 'Event created' : 'Failed to create event'),
+        backgroundColor: created ? Colors.green : Colors.red,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = context.select<AuthService, bool>((s) => s.isAdmin);
+    if (!isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Events')),
+        body: const Center(child: Text('Administrator access required')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Events'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            } else {
+              context.go('/admin');
+            }
+          },
+        ),
+        actions: [
+          Consumer<AdminEventsService>(
+            builder: (context, service, _) {
+              return IconButton(
+                tooltip: 'Refresh',
+                icon: service.isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh),
+                onPressed: service.isLoading
+                    ? null
+                    : () => service.fetchEvents(forceRefresh: true),
+              );
+            },
+          ),
+          IconButton(
+            tooltip: 'Add event',
+            icon: const Icon(Icons.add),
+            onPressed: _openCreateDialog,
+          ),
+        ],
+      ),
+      body: Consumer<AdminEventsService>(
+        builder: (context, service, _) {
+          if (service.isLoading && service.events.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (service.error != null && service.events.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.error_outline,
+                      size: 48,
+                      color: Colors.redAccent,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(service.error!, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    FilledButton.icon(
+                      onPressed: () => service.fetchEvents(forceRefresh: true),
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          if (service.events.isEmpty) {
+            return RefreshIndicator(
+              onRefresh: () => service.fetchEvents(forceRefresh: true),
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const [
+                  Padding(
+                    padding: EdgeInsets.only(top: 140),
+                    child: Column(
+                      children: [
+                        Icon(
+                          Icons.event_busy_outlined,
+                          size: 64,
+                          color: Colors.grey,
+                        ),
+                        SizedBox(height: 16),
+                        Text('No events yet'),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final showLoadMore = service.hasMore;
+          final itemCount = service.events.length + (showLoadMore ? 1 : 0);
+
+          return RefreshIndicator(
+            onRefresh: () => service.fetchEvents(forceRefresh: true),
+            child: ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+              itemCount: itemCount,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                if (index >= service.events.length) {
+                  return _EventsLoadMoreFooter(service: service);
+                }
+                return _EventCard(event: service.events[index]);
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _EventCard extends StatelessWidget {
+  const _EventCard({required this.event});
+
+  final ParkourEvent event;
+
+  @override
+  Widget build(BuildContext context) {
+    final startLabel = _formatUtc(event.startAt);
+    final endLabel = event.endAt == null ? null : _formatUtc(event.endAt);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 12, 12, 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(event.title, style: Theme.of(context).textTheme.titleMedium),
+            if (event.description != null &&
+                event.description!.trim().isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(event.description!),
+              ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 6,
+              children: [
+                Chip(
+                  avatar: const Icon(Icons.schedule, size: 16),
+                  label: Text(startLabel),
+                  visualDensity: VisualDensity.compact,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                if (endLabel != null)
+                  Chip(
+                    avatar: const Icon(Icons.hourglass_bottom, size: 16),
+                    label: Text(endLabel),
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                Chip(
+                  avatar: const Icon(Icons.place_outlined, size: 16),
+                  label: Text('${event.spotIds.length} linked spot(s)'),
+                  visualDensity: VisualDensity.compact,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            SelectableText(
+              'Spot IDs: ${event.spotIds.join(', ')}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatUtc(DateTime value) {
+    return '${DateFormat.yMMMd().add_Hm().format(value.toUtc())} UTC';
+  }
+}
+
+class _EventsLoadMoreFooter extends StatelessWidget {
+  const _EventsLoadMoreFooter({required this.service});
+
+  final AdminEventsService service;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Center(
+        child: service.isLoadingMore
+            ? const SizedBox(
+                width: 28,
+                height: 28,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : FilledButton.icon(
+                onPressed: () => service.loadMore(),
+                icon: const Icon(Icons.expand_more),
+                label: const Text('Load more'),
+              ),
+      ),
+    );
+  }
+}
+
+class _CreateEventDialog extends StatefulWidget {
+  const _CreateEventDialog({required this.onCreate});
+
+  final Future<bool> Function({
+    required String title,
+    String? description,
+    required DateTime startAt,
+    DateTime? endAt,
+    required List<String> spotIds,
+  })
+  onCreate;
+
+  @override
+  State<_CreateEventDialog> createState() => _CreateEventDialogState();
+}
+
+class _CreateEventDialogState extends State<_CreateEventDialog> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+
+  DateTime _startAt = DateTime.now().toUtc().add(const Duration(hours: 1));
+  DateTime? _endAt;
+  bool _isSubmitting = false;
+  String? _formError;
+  final List<Spot> _linkedSpots = <Spot>[];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickStartAt() async {
+    final value = await _pickDateTime(context, initial: _startAt);
+    if (value == null) return;
+    setState(() {
+      _startAt = value.toUtc();
+      if (_endAt != null && _endAt!.isBefore(_startAt)) {
+        _endAt = null;
+      }
+    });
+  }
+
+  Future<void> _pickEndAt() async {
+    final initial = _endAt ?? _startAt.add(const Duration(hours: 2));
+    final value = await _pickDateTime(context, initial: initial);
+    if (value == null) return;
+    setState(() {
+      _endAt = value.toUtc();
+    });
+  }
+
+  Future<void> _addLinkedSpot() async {
+    final selectedSpotId = await showDialog<String>(
+      context: context,
+      builder: (_) => const SpotSelectionDialog(allowExternalSources: true),
+    );
+    if (selectedSpotId == null || !mounted) return;
+    if (_linkedSpots.any((spot) => spot.id == selectedSpotId)) return;
+
+    final spotService = context.read<SpotService>();
+    final spot = await spotService.getSpotById(selectedSpotId);
+    if (!mounted) return;
+    if (spot == null || spot.id == null) {
+      setState(() {
+        _formError = 'Could not load the selected spot';
+      });
+      return;
+    }
+
+    setState(() {
+      _linkedSpots.add(spot);
+      _formError = null;
+    });
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    if (_linkedSpots.isEmpty) {
+      setState(() {
+        _formError = 'Link at least one spot to the event';
+      });
+      return;
+    }
+    if (_endAt != null && _endAt!.isBefore(_startAt)) {
+      setState(() {
+        _formError = 'End time cannot be before start time';
+      });
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+      _formError = null;
+    });
+
+    final success = await widget.onCreate(
+      title: _titleController.text.trim(),
+      description: _descriptionController.text.trim(),
+      startAt: _startAt,
+      endAt: _endAt,
+      spotIds: _linkedSpots.map((spot) => spot.id!).toList(),
+    );
+    if (!mounted) return;
+
+    setState(() {
+      _isSubmitting = false;
+    });
+    if (success) {
+      Navigator.of(context).pop(true);
+      return;
+    }
+
+    setState(() {
+      _formError = context.read<AdminEventsService>().error ?? 'Create failed';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Create Event'),
+      content: SizedBox(
+        width: 560,
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(
+                    labelText: 'Title',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Title is required';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _descriptionController,
+                  decoration: const InputDecoration(
+                    labelText: 'Description (optional)',
+                    border: OutlineInputBorder(),
+                  ),
+                  minLines: 2,
+                  maxLines: 4,
+                ),
+                const SizedBox(height: 16),
+                _DateField(
+                  label: 'Start (UTC)',
+                  value: _startAt,
+                  onPick: _pickStartAt,
+                ),
+                const SizedBox(height: 8),
+                _DateField(
+                  label: 'End (UTC, optional)',
+                  value: _endAt,
+                  onPick: _pickEndAt,
+                  onClear: _endAt == null
+                      ? null
+                      : () {
+                          setState(() {
+                            _endAt = null;
+                          });
+                        },
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Text(
+                      'Linked spots',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      onPressed: _isSubmitting ? null : _addLinkedSpot,
+                      icon: const Icon(Icons.add),
+                      label: const Text('Add spot'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (_linkedSpots.isEmpty)
+                  Text(
+                    'No spots selected yet',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                else
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 6,
+                    children: _linkedSpots
+                        .map(
+                          (spot) => Chip(
+                            label: Text('${spot.name} (${spot.id})'),
+                            onDeleted: _isSubmitting
+                                ? null
+                                : () {
+                                    setState(() {
+                                      _linkedSpots.removeWhere(
+                                        (s) => s.id == spot.id,
+                                      );
+                                    });
+                                  },
+                          ),
+                        )
+                        .toList(),
+                  ),
+                if (_formError != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    _formError!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSubmitting ? null : _submit,
+          child: _isSubmitting
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Create'),
+        ),
+      ],
+    );
+  }
+
+  Future<DateTime?> _pickDateTime(
+    BuildContext context, {
+    required DateTime initial,
+  }) async {
+    final selectedDate = await showDatePicker(
+      context: context,
+      initialDate: initial.toLocal(),
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2100),
+    );
+    if (selectedDate == null || !context.mounted) return null;
+
+    final initialTime = TimeOfDay.fromDateTime(initial.toLocal());
+    final selectedTime = await showTimePicker(
+      context: context,
+      initialTime: initialTime,
+    );
+    if (selectedTime == null) return null;
+
+    return DateTime(
+      selectedDate.year,
+      selectedDate.month,
+      selectedDate.day,
+      selectedTime.hour,
+      selectedTime.minute,
+    ).toUtc();
+  }
+}
+
+class _DateField extends StatelessWidget {
+  const _DateField({
+    required this.label,
+    required this.value,
+    required this.onPick,
+    this.onClear,
+  });
+
+  final String label;
+  final DateTime? value;
+  final VoidCallback onPick;
+  final VoidCallback? onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final display = value == null
+        ? 'Not set'
+        : '${DateFormat.yMMMd().add_Hm().format(value!.toUtc())} UTC';
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            '$label: $display',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+        TextButton.icon(
+          onPressed: onPick,
+          icon: const Icon(Icons.edit_calendar),
+          label: const Text('Pick'),
+        ),
+        if (onClear != null)
+          IconButton(
+            onPressed: onClear,
+            tooltip: 'Clear',
+            icon: const Icon(Icons.clear),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/screens/admin/admin_home_screen.dart
+++ b/lib/screens/admin/admin_home_screen.dart
@@ -95,6 +95,18 @@ class AdminHomeScreen extends StatelessWidget {
           const SizedBox(height: 8),
           Card(
             child: ListTile(
+              leading: const Icon(Icons.event_note_outlined),
+              title: const Text('Events'),
+              subtitle: const Text(
+                'Browse and create parkour events linked to spots',
+              ),
+              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+              onTap: () => context.push('/admin/events'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
               leading: const Icon(Icons.phonelink_ring_outlined),
               title: const Text('Web push subscriptions'),
               subtitle: const Text(

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -96,9 +96,9 @@ class EventDetailScreen extends StatelessWidget {
             Text('Website', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             InkWell(
-              onTap: () => _openExternal(websiteUrl!),
+              onTap: () => _openExternal(websiteUrl),
               child: Text(
-                websiteUrl!,
+                websiteUrl,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: Theme.of(context).colorScheme.primary,
                   decoration: TextDecoration.underline,

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../models/parkour_event.dart';
+import '../../models/spot.dart';
+import '../../services/spot_service.dart';
+import '../../widgets/page_scaffold.dart';
+
+class EventDetailScreen extends StatelessWidget {
+  const EventDetailScreen({super.key, required this.event});
+
+  final ParkourEvent event;
+
+  @override
+  Widget build(BuildContext context) {
+    final websiteUrl = event.websiteUrl?.trim();
+    final hasWebsite = websiteUrl != null && websiteUrl.isNotEmpty;
+    final hasLocation = event.latitude != null && event.longitude != null;
+    final hasAddress = event.address?.trim().isNotEmpty == true;
+
+    return PageScaffold(
+      title: event.title,
+      onBack: () {
+        if (Navigator.canPop(context)) {
+          Navigator.pop(context);
+        } else {
+          context.go('/explore');
+        }
+      },
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (event.description?.trim().isNotEmpty == true) ...[
+            Text(
+              event.description!,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16),
+          ],
+          Wrap(
+            spacing: 8,
+            runSpacing: 6,
+            children: [
+              Chip(
+                avatar: const Icon(Icons.schedule, size: 16),
+                label: Text(_formatUtc(event.startAt)),
+              ),
+              if (event.endAt != null)
+                Chip(
+                  avatar: const Icon(Icons.hourglass_bottom, size: 16),
+                  label: Text(_formatUtc(event.endAt!)),
+                ),
+              Chip(
+                avatar: const Icon(Icons.place_outlined, size: 16),
+                label: Text('${event.spotIds.length} linked spot(s)'),
+              ),
+            ],
+          ),
+          if (event.imageUrls.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Text('Images', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 190,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                itemCount: event.imageUrls.length,
+                separatorBuilder: (_, _) => const SizedBox(width: 10),
+                itemBuilder: (context, index) {
+                  return ClipRRect(
+                    borderRadius: BorderRadius.circular(10),
+                    child: Image.network(
+                      event.imageUrls[index],
+                      width: 280,
+                      height: 190,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, _, _) => Container(
+                        width: 280,
+                        height: 190,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHighest,
+                        child: const Icon(Icons.broken_image_outlined),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+          if (hasWebsite) ...[
+            const SizedBox(height: 16),
+            Text('Website', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            InkWell(
+              onTap: () => _openExternal(websiteUrl!),
+              child: Text(
+                websiteUrl!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+            ),
+          ],
+          if (hasLocation || hasAddress) ...[
+            const SizedBox(height: 16),
+            Text('Location', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              hasAddress
+                  ? event.address!.trim()
+                  : '${event.latitude!.toStringAsFixed(5)}, ${event.longitude!.toStringAsFixed(5)}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            if (hasLocation)
+              TextButton.icon(
+                onPressed: () => _openMap(event.latitude!, event.longitude!),
+                icon: const Icon(Icons.map_outlined),
+                label: const Text('Open in maps'),
+              ),
+          ],
+          const SizedBox(height: 16),
+          Text('Linked spots', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          _LinkedSpotsSection(spotIds: event.spotIds),
+          const SizedBox(height: 8),
+          SelectableText(
+            'Event ID: ${event.id ?? '(pending)'}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatUtc(DateTime value) {
+    return '${DateFormat.yMMMd().add_Hm().format(value.toUtc())} UTC';
+  }
+
+  Future<void> _openExternal(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _openMap(double lat, double lng) async {
+    final mapsUri = Uri.parse(
+      'https://www.google.com/maps/search/?api=1&query=$lat,$lng',
+    );
+    await launchUrl(mapsUri, mode: LaunchMode.externalApplication);
+  }
+}
+
+class _LinkedSpotsSection extends StatefulWidget {
+  const _LinkedSpotsSection({required this.spotIds});
+
+  final List<String> spotIds;
+
+  @override
+  State<_LinkedSpotsSection> createState() => _LinkedSpotsSectionState();
+}
+
+class _LinkedSpotsSectionState extends State<_LinkedSpotsSection> {
+  Future<List<Spot>>? _spotsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _spotsFuture = _loadSpots();
+  }
+
+  @override
+  void didUpdateWidget(covariant _LinkedSpotsSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.spotIds.join(',') != widget.spotIds.join(',')) {
+      _spotsFuture = _loadSpots();
+    }
+  }
+
+  Future<List<Spot>> _loadSpots() async {
+    final spotService = context.read<SpotService>();
+    final spots = await Future.wait(
+      widget.spotIds.map(spotService.getSpotById),
+    );
+    return spots.whereType<Spot>().toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<Spot>>(
+      future: _spotsFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: CircularProgressIndicator(strokeWidth: 2),
+          );
+        }
+        final spots = snapshot.data ?? const <Spot>[];
+        if (spots.isEmpty) {
+          return const Text('No linked spots found.');
+        }
+        return Column(
+          children: spots
+              .map(
+                (spot) => Card(
+                  margin: const EdgeInsets.only(bottom: 8),
+                  child: ListTile(
+                    title: Text(spot.name),
+                    subtitle: Text(spot.address ?? spot.city ?? spot.id ?? ''),
+                    trailing: const Icon(Icons.arrow_forward_ios, size: 14),
+                    onTap: spot.id == null
+                        ? null
+                        : () => context.push('/spot/${spot.id}'),
+                  ),
+                ),
+              )
+              .toList(),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -14,6 +14,7 @@ import '../../widgets/spot_training_plan_dialog.dart';
 import '../../utils/spot_check_in_flow.dart';
 import '../../services/spot_service.dart';
 import '../../services/spot_report_service.dart';
+import '../../services/admin_events_service.dart';
 import '../../services/auth_service.dart';
 import '../../services/url_service.dart';
 import '../../services/web_share_service.dart';
@@ -35,6 +36,7 @@ import '../../services/spot_check_in_service.dart';
 import '../../services/spot_training_plan_service.dart';
 import '../../services/feature_access_service.dart';
 import '../../models/spot_list.dart';
+import '../../models/parkour_event.dart';
 import '../../utils/resized_spot_image_provider.dart';
 import '../../widgets/resized_spot_image.dart';
 import '../../widgets/spot_detail_community_section.dart';
@@ -195,6 +197,7 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
 
   /// Cached future for Jumpflix videos (avoids refetch on rebuild).
   Future<List<JumpflixVideo>>? _jumpflixVideosFuture;
+  Future<ParkourEvent?>? _upcomingSpotEventFuture;
 
   // Getter for the current spot (falls back to widget.spot if not updated)
   Spot get _spot => _currentSpot ?? widget.spot;
@@ -205,7 +208,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     try {
-      _exploreDocumentTitle = AppLocalizations.of(context)!.exploreMetaDefaultTitle;
+      _exploreDocumentTitle = AppLocalizations.of(
+        context,
+      )!.exploreMetaDefaultTitle;
     } catch (_) {
       _exploreDocumentTitle = _fallbackDocumentTitle;
     }
@@ -482,8 +487,13 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
         context,
         listen: false,
       ).getJumpflixVideosForSpot(widget.spot.id!);
+      _upcomingSpotEventFuture = Provider.of<AdminEventsService>(
+        context,
+        listen: false,
+      ).getNextUpcomingEventForSpot(widget.spot.id!);
     } else {
       _jumpflixVideosFuture = Future<List<JumpflixVideo>>.value([]);
+      _upcomingSpotEventFuture = Future<ParkourEvent?>.value(null);
     }
 
     // Initialize satellite view from SearchStateService
@@ -511,8 +521,13 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
           context,
           listen: false,
         ).getJumpflixVideosForSpot(widget.spot.id!);
+        _upcomingSpotEventFuture = Provider.of<AdminEventsService>(
+          context,
+          listen: false,
+        ).getNextUpcomingEventForSpot(widget.spot.id!);
       } else {
         _jumpflixVideosFuture = Future<List<JumpflixVideo>>.value([]);
+        _upcomingSpotEventFuture = Future<ParkourEvent?>.value(null);
       }
     }
   }
@@ -630,7 +645,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
       color: theme.colorScheme.onSurfaceVariant,
     );
     final bool hideCreatorAttribution = _spot.createdFromCreateNative;
-    final String? createdByName = hideCreatorAttribution ? null : _spot.createdByName;
+    final String? createdByName = hideCreatorAttribution
+        ? null
+        : _spot.createdByName;
     final String? createdById = hideCreatorAttribution ? null : _spot.createdBy;
     bool hasPreviousContent = false;
 
@@ -2241,6 +2258,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                               },
                             ),
                           ),
+                          const SizedBox(height: 4),
+                          _buildUpcomingSpotEventPanel(),
+                          const SizedBox(height: 12),
                           SpotDetailCommunitySection(
                             spotId: _spot.id!,
                             spotDisplayName: _spot.name,
@@ -4955,6 +4975,79 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
         ),
       ),
     );
+  }
+
+  Widget _buildUpcomingSpotEventPanel() {
+    if (_spot.id == null) return const SizedBox.shrink();
+
+    return FutureBuilder<ParkourEvent?>(
+      future: _upcomingSpotEventFuture ?? Future<ParkourEvent?>.value(null),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const SizedBox.shrink();
+        }
+        final event = snapshot.data;
+        if (event == null || event.id == null) {
+          return const SizedBox.shrink();
+        }
+
+        final colors = Theme.of(context).colorScheme;
+        return Container(
+          width: double.infinity,
+          margin: const EdgeInsets.only(bottom: 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: colors.primaryContainer.withValues(alpha: 0.35),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: colors.primary.withValues(alpha: 0.25)),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.event_available_outlined, color: colors.primary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Upcoming event',
+                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                        color: colors.primary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      event.title,
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _formatUpcomingEventDateTime(event.startAt),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+              TextButton.icon(
+                onPressed: () => context.push('/event/${event.id}'),
+                icon: const Icon(Icons.open_in_new, size: 16),
+                label: const Text('Open'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String _formatUpcomingEventDateTime(DateTime dateTime) {
+    final local = dateTime.toLocal();
+    final localizations = MaterialLocalizations.of(context);
+    final date = localizations.formatMediumDate(local);
+    final time = localizations.formatTimeOfDay(TimeOfDay.fromDateTime(local));
+    return '$date · $time';
   }
 
   Widget _buildFacilityChip(String facilityKey, String status) {

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -221,6 +221,30 @@ class AdminEventsService extends ChangeNotifier {
     }
   }
 
+  Future<ParkourEvent?> getNextUpcomingEventForSpot(String spotId) async {
+    try {
+      final now = DateTime.now().toUtc();
+      final snapshot = await _firestore
+          .collection('events')
+          .where('spotIds', arrayContains: spotId)
+          .limit(100)
+          .get();
+      final events =
+          snapshot.docs
+              .map(ParkourEvent.fromFirestore)
+              .where((event) => event.startAt.toUtc().isAfter(now))
+              .toList()
+            ..sort((a, b) => a.startAt.compareTo(b.startAt));
+      if (events.isEmpty) return null;
+      return events.first;
+    } catch (e, st) {
+      debugPrint(
+        'AdminEventsService.getNextUpcomingEventForSpot error: $e\n$st',
+      );
+      return null;
+    }
+  }
+
   void _applyPage(
     QuerySnapshot<Map<String, dynamic>> snapshot,
     int pageSize, {

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -1,13 +1,18 @@
+import 'dart:typed_data';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
 
 import '../models/parkour_event.dart';
+import '../utils/image_preparation.dart';
 
 class AdminEventsService extends ChangeNotifier {
   AdminEventsService({FirebaseFirestore? firestore})
     : _firestore = firestore ?? FirebaseFirestore.instance;
 
   final FirebaseFirestore _firestore;
+  final FirebaseStorage _storage = FirebaseStorage.instance;
 
   final List<ParkourEvent> _events = <ParkourEvent>[];
   bool _isLoading = false;
@@ -88,11 +93,23 @@ class AdminEventsService extends ChangeNotifier {
   Future<bool> createEvent({
     required String title,
     String? description,
+    List<String>? imageUrls,
+    String? websiteUrl,
     required DateTime startAt,
     DateTime? endAt,
+    double? latitude,
+    double? longitude,
+    String? address,
     required List<String> spotIds,
     required String createdBy,
   }) async {
+    final normalizedImageUrls = (imageUrls ?? const <String>[])
+        .map((url) => url.trim())
+        .where((url) => url.isNotEmpty)
+        .toSet()
+        .toList();
+    final normalizedWebsiteUrl = websiteUrl?.trim();
+    final normalizedAddress = address?.trim();
     final normalizedSpotIds = spotIds
         .map((id) => id.trim())
         .where((id) => id.isNotEmpty)
@@ -100,6 +117,36 @@ class AdminEventsService extends ChangeNotifier {
         .toList();
     if (title.trim().isEmpty || normalizedSpotIds.isEmpty) {
       _error = 'Title and at least one linked spot are required';
+      notifyListeners();
+      return false;
+    }
+    if (normalizedWebsiteUrl != null &&
+        normalizedWebsiteUrl.isNotEmpty &&
+        !_isValidHttpUrl(normalizedWebsiteUrl)) {
+      _error = 'Website URL must be a valid http(s) link';
+      notifyListeners();
+      return false;
+    }
+    final hasLatitude = latitude != null;
+    final hasLongitude = longitude != null;
+    if (hasLatitude != hasLongitude) {
+      _error = 'Both latitude and longitude are required for event location';
+      notifyListeners();
+      return false;
+    }
+    if (latitude != null && (latitude < -90 || latitude > 90)) {
+      _error = 'Latitude must be between -90 and 90';
+      notifyListeners();
+      return false;
+    }
+    if (longitude != null && (longitude < -180 || longitude > 180)) {
+      _error = 'Longitude must be between -180 and 180';
+      notifyListeners();
+      return false;
+    }
+    if (latitude != null &&
+        (normalizedAddress == null || normalizedAddress.isEmpty)) {
+      _error = 'Address is required when coordinates are provided';
       notifyListeners();
       return false;
     }
@@ -117,8 +164,15 @@ class AdminEventsService extends ChangeNotifier {
       final event = ParkourEvent(
         title: title.trim(),
         description: description?.trim().isEmpty == true ? null : description,
+        imageUrls: normalizedImageUrls,
+        websiteUrl: normalizedWebsiteUrl?.isEmpty == true
+            ? null
+            : normalizedWebsiteUrl,
         startAt: startAt.toUtc(),
         endAt: endAt?.toUtc(),
+        latitude: latitude,
+        longitude: longitude,
+        address: normalizedAddress?.isEmpty == true ? null : normalizedAddress,
         spotIds: normalizedSpotIds,
         createdBy: createdBy,
         createdAt: now,
@@ -137,6 +191,23 @@ class AdminEventsService extends ChangeNotifier {
       notifyListeners();
       return false;
     }
+  }
+
+  Future<List<String>> uploadEventImages(List<Uint8List> imageBytesList) async {
+    final List<String> imageUrls = [];
+    for (var index = 0; index < imageBytesList.length; index++) {
+      final prepared = await prepareImageForUpload(imageBytesList[index]);
+      final ext = _extensionForContentType(prepared.contentType);
+      final fileName =
+          'events/${DateTime.now().millisecondsSinceEpoch}_event_image_$index$ext';
+      final ref = _storage.ref().child(fileName);
+      final snapshot = await ref.putData(
+        prepared.bytes,
+        SettableMetadata(contentType: prepared.contentType),
+      );
+      imageUrls.add(await snapshot.ref.getDownloadURL());
+    }
+    return imageUrls;
   }
 
   void _applyPage(
@@ -162,5 +233,26 @@ class AdminEventsService extends ChangeNotifier {
     }
     _lastEventDocument = docs.last;
     _hasMore = docs.length >= pageSize;
+  }
+
+  bool _isValidHttpUrl(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null || uri.host.isEmpty) return false;
+    return uri.scheme == 'http' || uri.scheme == 'https';
+  }
+
+  String _extensionForContentType(String contentType) {
+    switch (contentType) {
+      case 'image/jpeg':
+        return '.jpg';
+      case 'image/png':
+        return '.png';
+      case 'image/gif':
+        return '.gif';
+      case 'image/webp':
+        return '.webp';
+      default:
+        return '.jpg';
+    }
   }
 }

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -1,0 +1,166 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/parkour_event.dart';
+
+class AdminEventsService extends ChangeNotifier {
+  AdminEventsService({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  final List<ParkourEvent> _events = <ParkourEvent>[];
+  bool _isLoading = false;
+  bool _isLoadingMore = false;
+  String? _error;
+  QueryDocumentSnapshot<Map<String, dynamic>>? _lastEventDocument;
+  bool _hasMore = true;
+
+  static const int _defaultPageSize = 30;
+
+  List<ParkourEvent> get events => List<ParkourEvent>.unmodifiable(_events);
+  bool get isLoading => _isLoading;
+  bool get isLoadingMore => _isLoadingMore;
+  bool get hasMore => _hasMore;
+  String? get error => _error;
+
+  Future<void> fetchEvents({
+    bool forceRefresh = false,
+    int pageSize = _defaultPageSize,
+  }) async {
+    if (_isLoading && !forceRefresh) return;
+
+    _isLoading = true;
+    _isLoadingMore = false;
+    _error = null;
+    if (forceRefresh) {
+      _events.clear();
+      _lastEventDocument = null;
+      _hasMore = true;
+    }
+    notifyListeners();
+
+    try {
+      final snapshot = await _firestore
+          .collection('events')
+          .orderBy('startAt', descending: true)
+          .limit(pageSize)
+          .get();
+      _applyPage(snapshot, pageSize, replaceExisting: true);
+    } catch (e, st) {
+      _error = 'Failed to load events';
+      debugPrint('AdminEventsService.fetchEvents error: $e\n$st');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadMore({int pageSize = _defaultPageSize}) async {
+    if (!_hasMore ||
+        _isLoading ||
+        _isLoadingMore ||
+        _lastEventDocument == null) {
+      return;
+    }
+
+    _isLoadingMore = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final snapshot = await _firestore
+          .collection('events')
+          .orderBy('startAt', descending: true)
+          .startAfterDocument(_lastEventDocument!)
+          .limit(pageSize)
+          .get();
+      _applyPage(snapshot, pageSize, replaceExisting: false);
+    } catch (e, st) {
+      _error = 'Failed to load more events';
+      debugPrint('AdminEventsService.loadMore error: $e\n$st');
+    } finally {
+      _isLoadingMore = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> createEvent({
+    required String title,
+    String? description,
+    required DateTime startAt,
+    DateTime? endAt,
+    required List<String> spotIds,
+    required String createdBy,
+  }) async {
+    final normalizedSpotIds = spotIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList();
+    if (title.trim().isEmpty || normalizedSpotIds.isEmpty) {
+      _error = 'Title and at least one linked spot are required';
+      notifyListeners();
+      return false;
+    }
+    if (endAt != null && endAt.isBefore(startAt)) {
+      _error = 'End time cannot be before start time';
+      notifyListeners();
+      return false;
+    }
+
+    _error = null;
+    notifyListeners();
+
+    try {
+      final now = DateTime.now().toUtc();
+      final event = ParkourEvent(
+        title: title.trim(),
+        description: description?.trim().isEmpty == true ? null : description,
+        startAt: startAt.toUtc(),
+        endAt: endAt?.toUtc(),
+        spotIds: normalizedSpotIds,
+        createdBy: createdBy,
+        createdAt: now,
+        updatedAt: now,
+      );
+      final ref = await _firestore
+          .collection('events')
+          .add(event.toFirestore());
+      _events.insert(0, event.copyWith(id: ref.id));
+      _events.sort((a, b) => b.startAt.compareTo(a.startAt));
+      notifyListeners();
+      return true;
+    } catch (e, st) {
+      _error = 'Failed to create event';
+      debugPrint('AdminEventsService.createEvent error: $e\n$st');
+      notifyListeners();
+      return false;
+    }
+  }
+
+  void _applyPage(
+    QuerySnapshot<Map<String, dynamic>> snapshot,
+    int pageSize, {
+    required bool replaceExisting,
+  }) {
+    final docs = snapshot.docs;
+    if (replaceExisting) {
+      _events.clear();
+    }
+    for (final doc in docs) {
+      _events.add(ParkourEvent.fromFirestore(doc));
+    }
+    if (replaceExisting) {
+      _lastEventDocument = docs.isNotEmpty ? docs.last : null;
+      _hasMore = docs.length >= pageSize;
+      return;
+    }
+    if (docs.isEmpty) {
+      _hasMore = false;
+      return;
+    }
+    _lastEventDocument = docs.last;
+    _hasMore = docs.length >= pageSize;
+  }
+}

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -229,12 +229,20 @@ class AdminEventsService extends ChangeNotifier {
           .where('spotIds', arrayContains: spotId)
           .limit(100)
           .get();
-      final events =
-          snapshot.docs
-              .map(ParkourEvent.fromFirestore)
-              .where((event) => event.startAt.toUtc().isAfter(now))
-              .toList()
-            ..sort((a, b) => a.startAt.compareTo(b.startAt));
+      final events = <ParkourEvent>[];
+      for (final doc in snapshot.docs) {
+        try {
+          final event = ParkourEvent.fromFirestore(doc);
+          if (event.startAt.toUtc().isAfter(now)) {
+            events.add(event);
+          }
+        } catch (e) {
+          debugPrint(
+            'AdminEventsService.getNextUpcomingEventForSpot skipping malformed event ${doc.id}: $e',
+          );
+        }
+      }
+      events.sort((a, b) => a.startAt.compareTo(b.startAt));
       if (events.isEmpty) return null;
       return events.first;
     } catch (e, st) {

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -208,6 +208,19 @@ class AdminEventsService extends ChangeNotifier {
     return imageUrls;
   }
 
+  Future<ParkourEvent?> getEventById(String eventId) async {
+    try {
+      final doc = await _firestore.collection('events').doc(eventId).get();
+      if (!doc.exists || doc.data() == null) {
+        return null;
+      }
+      return ParkourEvent.fromFirestore(doc);
+    } catch (e, st) {
+      debugPrint('AdminEventsService.getEventById error: $e\n$st');
+      return null;
+    }
+  }
+
   void _applyPage(
     QuerySnapshot<Map<String, dynamic>> snapshot,
     int pageSize, {

--- a/test/models/parkour_event_test.dart
+++ b/test/models/parkour_event_test.dart
@@ -14,8 +14,13 @@ void main() {
         'id': 'event-1',
         'title': 'Sunset Jam',
         'description': 'Open training session',
+        'imageUrls': ['https://img.example/1.jpg', 'https://img.example/2.jpg'],
+        'websiteUrl': 'https://parkour.spot/events/sunset-jam',
         'startAt': Timestamp.fromDate(startAt),
         'endAt': Timestamp.fromDate(endAt),
+        'latitude': 52.3702,
+        'longitude': 4.8952,
+        'address': 'Amsterdam, Netherlands',
         'spotIds': ['spot-a', 'spot-b'],
         'createdBy': 'admin-uid',
         'createdAt': Timestamp.fromDate(createdAt),
@@ -25,8 +30,16 @@ void main() {
       expect(event.id, 'event-1');
       expect(event.title, 'Sunset Jam');
       expect(event.description, 'Open training session');
+      expect(event.imageUrls, [
+        'https://img.example/1.jpg',
+        'https://img.example/2.jpg',
+      ]);
+      expect(event.websiteUrl, 'https://parkour.spot/events/sunset-jam');
       expect(event.startAt.toUtc(), startAt);
       expect(event.endAt?.toUtc(), endAt);
+      expect(event.latitude, 52.3702);
+      expect(event.longitude, 4.8952);
+      expect(event.address, 'Amsterdam, Netherlands');
       expect(event.spotIds, ['spot-a', 'spot-b']);
       expect(event.createdBy, 'admin-uid');
       expect(event.createdAt?.toUtc(), createdAt);
@@ -38,8 +51,13 @@ void main() {
         id: 'event-2',
         title: 'Community Session',
         description: '  Meet and train  ',
+        imageUrls: const ['https://img.example/event.jpg'],
+        websiteUrl: ' https://event.example/info ',
         startAt: DateTime.utc(2026, 6, 1, 14, 0),
         endAt: DateTime.utc(2026, 6, 1, 16, 0),
+        latitude: 48.8566,
+        longitude: 2.3522,
+        address: '  Paris, France ',
         spotIds: const ['spot-c', 'spot-d'],
         createdBy: 'admin-uid',
         createdAt: DateTime.utc(2026, 5, 25, 8, 0),
@@ -50,9 +68,14 @@ void main() {
 
       expect(map['title'], 'Community Session');
       expect(map['description'], 'Meet and train');
+      expect(map['imageUrls'], ['https://img.example/event.jpg']);
+      expect(map['websiteUrl'], 'https://event.example/info');
       expect(map['spotIds'], ['spot-c', 'spot-d']);
       expect(map['startAt'], DateTime.utc(2026, 6, 1, 14, 0));
       expect(map['endAt'], DateTime.utc(2026, 6, 1, 16, 0));
+      expect(map['latitude'], 48.8566);
+      expect(map['longitude'], 2.3522);
+      expect(map['address'], 'Paris, France');
       expect(map['createdBy'], 'admin-uid');
       expect(map['createdAt'], DateTime.utc(2026, 5, 25, 8, 0));
       expect(map['updatedAt'], DateTime.utc(2026, 5, 25, 9, 0));

--- a/test/models/parkour_event_test.dart
+++ b/test/models/parkour_event_test.dart
@@ -1,0 +1,61 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/models/parkour_event.dart';
+
+void main() {
+  group('ParkourEvent', () {
+    test('fromMap parses required fields and linked spot IDs', () {
+      final startAt = DateTime.utc(2026, 5, 8, 17, 0);
+      final endAt = DateTime.utc(2026, 5, 8, 19, 0);
+      final createdAt = DateTime.utc(2026, 5, 1, 10, 0);
+      final updatedAt = DateTime.utc(2026, 5, 2, 10, 0);
+
+      final event = ParkourEvent.fromMap({
+        'id': 'event-1',
+        'title': 'Sunset Jam',
+        'description': 'Open training session',
+        'startAt': Timestamp.fromDate(startAt),
+        'endAt': Timestamp.fromDate(endAt),
+        'spotIds': ['spot-a', 'spot-b'],
+        'createdBy': 'admin-uid',
+        'createdAt': Timestamp.fromDate(createdAt),
+        'updatedAt': Timestamp.fromDate(updatedAt),
+      });
+
+      expect(event.id, 'event-1');
+      expect(event.title, 'Sunset Jam');
+      expect(event.description, 'Open training session');
+      expect(event.startAt, startAt);
+      expect(event.endAt, endAt);
+      expect(event.spotIds, ['spot-a', 'spot-b']);
+      expect(event.createdBy, 'admin-uid');
+      expect(event.createdAt, createdAt);
+      expect(event.updatedAt, updatedAt);
+    });
+
+    test('toFirestore keeps linked spots and trims description', () {
+      final event = ParkourEvent(
+        id: 'event-2',
+        title: 'Community Session',
+        description: '  Meet and train  ',
+        startAt: DateTime.utc(2026, 6, 1, 14, 0),
+        endAt: DateTime.utc(2026, 6, 1, 16, 0),
+        spotIds: const ['spot-c', 'spot-d'],
+        createdBy: 'admin-uid',
+        createdAt: DateTime.utc(2026, 5, 25, 8, 0),
+        updatedAt: DateTime.utc(2026, 5, 25, 9, 0),
+      );
+
+      final map = event.toFirestore();
+
+      expect(map['title'], 'Community Session');
+      expect(map['description'], 'Meet and train');
+      expect(map['spotIds'], ['spot-c', 'spot-d']);
+      expect(map['startAt'], DateTime.utc(2026, 6, 1, 14, 0));
+      expect(map['endAt'], DateTime.utc(2026, 6, 1, 16, 0));
+      expect(map['createdBy'], 'admin-uid');
+      expect(map['createdAt'], DateTime.utc(2026, 5, 25, 8, 0));
+      expect(map['updatedAt'], DateTime.utc(2026, 5, 25, 9, 0));
+    });
+  });
+}

--- a/test/models/parkour_event_test.dart
+++ b/test/models/parkour_event_test.dart
@@ -25,12 +25,12 @@ void main() {
       expect(event.id, 'event-1');
       expect(event.title, 'Sunset Jam');
       expect(event.description, 'Open training session');
-      expect(event.startAt, startAt);
-      expect(event.endAt, endAt);
+      expect(event.startAt.toUtc(), startAt);
+      expect(event.endAt?.toUtc(), endAt);
       expect(event.spotIds, ['spot-a', 'spot-b']);
       expect(event.createdBy, 'admin-uid');
-      expect(event.createdAt, createdAt);
-      expect(event.updatedAt, updatedAt);
+      expect(event.createdAt?.toUtc(), createdAt);
+      expect(event.updatedAt?.toUtc(), updatedAt);
     });
 
     test('toFirestore keeps linked spots and trims description', () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a spot-detail `Upcoming event` panel that appears when the spot has a linked future event and provides one-click navigation to `/event/:eventId`
- add `AdminEventsService.getNextUpcomingEventForSpot()` and make it resilient by skipping malformed event docs instead of failing the entire lookup
- keep admin event click-through explicit with an `Open event page` action on each event card

## Walkthrough artifacts
[spot_detail_upcoming_event_navigation.mp4](https://cursor.com/agents/bc-bb19d7f5-d8f8-40a1-b469-775b0b1b3024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspot_detail_upcoming_event_navigation.mp4)

[Upcoming event panel on spot detail](https://cursor.com/agents/bc-bb19d7f5-d8f8-40a1-b469-775b0b1b3024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspot_detail_upcoming_event_panel.webp)
[Opened event detail page](https://cursor.com/agents/bc-bb19d7f5-d8f8-40a1-b469-775b0b1b3024/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspot_detail_event_detail_page.webp)

## Testing
- `flutter analyze --no-fatal-infos lib/screens/spots/spot_detail_screen.dart lib/screens/admin/admin_events_screen.dart lib/services/admin_events_service.dart`
- `flutter test`
- manual browser walkthrough: created linked future event, confirmed panel visibility on spot detail, confirmed Open button navigation to event detail

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb19d7f5-d8f8-40a1-b469-775b0b1b3024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb19d7f5-d8f8-40a1-b469-775b0b1b3024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

