### PR TITLE
Add external event source sync for Google ICS calendars

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -23,6 +23,7 @@ const admin = require("firebase-admin");
 const sharp = require("sharp");
 const yauzl = require("yauzl");
 const xml2js = require("xml2js");
+const http = require("http");
 const https = require("https");
 const path = require("path");
 const {google} = require("googleapis");
@@ -99,6 +100,11 @@ const {
   generateImageHash,
 } = require("./lib/import-helpers");
 const {shouldRunSync} = require("./lib/sync-helpers");
+const {
+  hasExternalEventContentChanges,
+  parseExternalEventsFromIcs,
+  buildExternalEventKey,
+} = require("./lib/event-sync");
 
 // Import shared HTML template
 const {generateHtmlPage} = require("./html-template");
@@ -3849,6 +3855,538 @@ exports.getSyncSource = onCall({region: "europe-west1"}, async (request) => {
     throw new Error(`Failed to get sync source: ${error.message}`);
   }
 });
+
+/**
+ * Normalizes and validates an external ICS URL.
+ * @param {*} value
+ * @return {string}
+ */
+function normalizeIcsUrl(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("icsUrl is required");
+  }
+  const trimmed = value.trim();
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch (_) {
+    throw new Error("icsUrl must be a valid URL");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("icsUrl must use http or https");
+  }
+  return parsed.toString();
+}
+
+/**
+ * Downloads text content and follows redirects.
+ * @param {string} url
+ * @param {number=} redirectCount
+ * @return {Promise<string>}
+ */
+function downloadTextFromUrl(url, redirectCount = 0) {
+  if (redirectCount > 5) {
+    throw new Error("Too many redirects while fetching ICS");
+  }
+
+  const parsedUrl = new URL(url);
+  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    throw new Error("ICS URL must use http or https");
+  }
+  const client = parsedUrl.protocol === "http:" ? http : https;
+
+  return new Promise((resolve, reject) => {
+    const request = client.get(parsedUrl, (response) => {
+      if (
+        response.statusCode &&
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location
+      ) {
+        response.resume();
+        const redirectedUrl = new URL(
+            response.headers.location,
+            parsedUrl,
+        ).toString();
+        resolve(downloadTextFromUrl(redirectedUrl, redirectCount + 1));
+        return;
+      }
+
+      if (!response.statusCode || response.statusCode >= 400) {
+        const statusCode = response.statusCode || 0;
+        response.resume();
+        reject(new Error(`Failed fetching ICS (HTTP ${statusCode})`));
+        return;
+      }
+
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        resolve(body);
+      });
+    });
+
+    request.on("error", reject);
+    request.setTimeout(15000, () => {
+      request.destroy(new Error("ICS request timed out"));
+    });
+  });
+}
+
+/**
+ * Builds Firestore payload for newly imported external events.
+ * @param {Object} parsedEvent
+ * @return {Object}
+ */
+function buildExternalEventCreateData(parsedEvent) {
+  const createData = {
+    title: parsedEvent.title,
+    startAt: parsedEvent.startAt,
+    spotIds: [],
+    imageUrls: [],
+    createdBy: "external-event-sync",
+    eventSourceId: parsedEvent.eventSourceId,
+    eventSourceName: parsedEvent.eventSourceName,
+    externalEventUid: parsedEvent.externalEventUid,
+    externalEventKey: parsedEvent.externalEventKey,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+    externalSyncLastSeenAt: FieldValue.serverTimestamp(),
+    externalSyncLastChangedAt: FieldValue.serverTimestamp(),
+  };
+
+  if (parsedEvent.description) createData.description = parsedEvent.description;
+  if (parsedEvent.websiteUrl) createData.websiteUrl = parsedEvent.websiteUrl;
+  if (parsedEvent.address) createData.address = parsedEvent.address;
+  if (parsedEvent.endAt) createData.endAt = parsedEvent.endAt;
+  if (parsedEvent.externalEventRecurrenceId) {
+    createData.externalEventRecurrenceId = parsedEvent.externalEventRecurrenceId;
+  }
+
+  return createData;
+}
+
+/**
+ * Builds Firestore update payload for changed external events.
+ * @param {Object} parsedEvent
+ * @return {Object}
+ */
+function buildExternalEventChangedUpdate(parsedEvent) {
+  const updateData = {
+    title: parsedEvent.title,
+    startAt: parsedEvent.startAt,
+    eventSourceId: parsedEvent.eventSourceId,
+    eventSourceName: parsedEvent.eventSourceName,
+    externalEventUid: parsedEvent.externalEventUid,
+    externalEventKey: parsedEvent.externalEventKey,
+    updatedAt: FieldValue.serverTimestamp(),
+    externalSyncLastSeenAt: FieldValue.serverTimestamp(),
+    externalSyncLastChangedAt: FieldValue.serverTimestamp(),
+  };
+
+  updateData.description = parsedEvent.description || FieldValue.delete();
+  updateData.websiteUrl = parsedEvent.websiteUrl || FieldValue.delete();
+  updateData.address = parsedEvent.address || FieldValue.delete();
+  updateData.endAt = parsedEvent.endAt || FieldValue.delete();
+  updateData.externalEventRecurrenceId =
+    parsedEvent.externalEventRecurrenceId || FieldValue.delete();
+
+  return updateData;
+}
+
+/**
+ * Syncs one external event source into events collection.
+ * @param {DocumentSnapshot} sourceDoc
+ * @return {Promise<Object>}
+ */
+async function syncExternalEventSource(sourceDoc) {
+  const sourceData = sourceDoc.data() || {};
+  const sourceId = sourceDoc.id;
+  const sourceName = typeof sourceData.name === "string" &&
+      sourceData.name.trim().length > 0 ?
+    sourceData.name.trim() :
+    sourceId;
+  const icsUrl = normalizeIcsUrl(sourceData.icsUrl);
+  const icsText = await downloadTextFromUrl(icsUrl);
+  const parsedEvents = parseExternalEventsFromIcs(icsText, {
+    sourceId,
+    sourceName,
+  });
+
+  const uniqueEventsByKey = new Map();
+  for (const parsedEvent of parsedEvents) {
+    uniqueEventsByKey.set(parsedEvent.externalEventKey, parsedEvent);
+  }
+  const uniqueEvents = Array.from(uniqueEventsByKey.values());
+
+  const existingEventsSnapshot = await db
+      .collection("events")
+      .where("eventSourceId", "==", sourceId)
+      .get();
+  const existingByKey = new Map();
+  for (const existingDoc of existingEventsSnapshot.docs) {
+    const existingData = existingDoc.data() || {};
+    let existingKey = null;
+    if (
+      typeof existingData.externalEventKey === "string" &&
+      existingData.externalEventKey.trim().length > 0
+    ) {
+      existingKey = existingData.externalEventKey.trim();
+    } else if (
+      typeof existingData.externalEventUid === "string" &&
+      existingData.externalEventUid.trim().length > 0
+    ) {
+      try {
+        existingKey = buildExternalEventKey(
+            existingData.externalEventUid,
+            existingData.externalEventRecurrenceId || null,
+        );
+      } catch (_) {
+        existingKey = null;
+      }
+    }
+
+    if (existingKey) {
+      existingByKey.set(existingKey, {ref: existingDoc.ref, data: existingData});
+    }
+  }
+
+  let batch = db.batch();
+  let operationCount = 0;
+  const stats = {
+    totalParsed: parsedEvents.length,
+    totalUnique: uniqueEvents.length,
+    duplicatesInFeed: parsedEvents.length - uniqueEvents.length,
+    created: 0,
+    changed: 0,
+    unchanged: 0,
+  };
+
+  const commitBatch = async () => {
+    if (operationCount === 0) return;
+    await batch.commit();
+    batch = db.batch();
+    operationCount = 0;
+  };
+
+  for (const parsedEvent of uniqueEvents) {
+    const existing = existingByKey.get(parsedEvent.externalEventKey);
+    if (!existing) {
+      const newEventRef = db.collection("events").doc();
+      batch.set(newEventRef, buildExternalEventCreateData(parsedEvent));
+      stats.created += 1;
+      operationCount += 1;
+    } else if (hasExternalEventContentChanges(existing.data, parsedEvent)) {
+      batch.update(existing.ref, buildExternalEventChangedUpdate(parsedEvent));
+      stats.changed += 1;
+      operationCount += 1;
+    } else {
+      batch.update(existing.ref, {
+        externalSyncLastSeenAt: FieldValue.serverTimestamp(),
+      });
+      stats.unchanged += 1;
+      operationCount += 1;
+    }
+
+    if (operationCount >= 400) {
+      await commitBatch();
+    }
+  }
+
+  await commitBatch();
+  await sourceDoc.ref.update({
+    lastSyncAt: FieldValue.serverTimestamp(),
+    lastSyncStats: stats,
+  });
+
+  return {
+    sourceId,
+    sourceName,
+    stats,
+  };
+}
+
+// Function to create an event sync source (admin only).
+exports.createEventSyncSource = onCall(
+    {region: "europe-west1"},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const {
+          name,
+          icsUrl,
+          description,
+          publicUrl,
+          isActive = true,
+        } = request.data || {};
+
+        if (typeof name !== "string" || name.trim().length === 0) {
+          throw new Error("name is required");
+        }
+
+        const sourceData = {
+          name: name.trim(),
+          icsUrl: normalizeIcsUrl(icsUrl),
+          isActive: Boolean(isActive),
+          createdAt: FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        };
+
+        if (typeof description === "string" && description.trim().length > 0) {
+          sourceData.description = description.trim();
+        }
+        if (typeof publicUrl === "string" && publicUrl.trim().length > 0) {
+          sourceData.publicUrl = publicUrl.trim();
+        }
+
+        const docRef = await db.collection("eventSyncSources").add(sourceData);
+        return {
+          success: true,
+          sourceId: docRef.id,
+          message: "Event sync source created successfully",
+        };
+      } catch (error) {
+        console.error("Error creating event sync source:", error);
+        throw new Error(`Failed to create event sync source: ${error.message}`);
+      }
+    },
+);
+
+// Function to update an event sync source (admin only).
+exports.updateEventSyncSource = onCall(
+    {region: "europe-west1"},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const {
+          sourceId,
+          name,
+          icsUrl,
+          description,
+          publicUrl,
+          isActive,
+        } = request.data || {};
+
+        if (typeof sourceId !== "string" || sourceId.trim().length === 0) {
+          throw new Error("sourceId is required");
+        }
+
+        const updateData = {
+          updatedAt: FieldValue.serverTimestamp(),
+        };
+
+        if (name !== undefined) {
+          if (typeof name !== "string" || name.trim().length === 0) {
+            throw new Error("name must be a non-empty string");
+          }
+          updateData.name = name.trim();
+        }
+        if (icsUrl !== undefined) {
+          updateData.icsUrl = normalizeIcsUrl(icsUrl);
+        }
+        if (description !== undefined) {
+          if (typeof description === "string" && description.trim().length > 0) {
+            updateData.description = description.trim();
+          } else {
+            updateData.description = FieldValue.delete();
+          }
+        }
+        if (publicUrl !== undefined) {
+          if (typeof publicUrl === "string" && publicUrl.trim().length > 0) {
+            updateData.publicUrl = publicUrl.trim();
+          } else {
+            updateData.publicUrl = FieldValue.delete();
+          }
+        }
+        if (isActive !== undefined) {
+          updateData.isActive = Boolean(isActive);
+        }
+
+        await db.collection("eventSyncSources").doc(sourceId.trim())
+            .update(updateData);
+
+        return {
+          success: true,
+          sourceId: sourceId.trim(),
+          message: "Event sync source updated successfully",
+        };
+      } catch (error) {
+        console.error("Error updating event sync source:", error);
+        throw new Error(`Failed to update event sync source: ${error.message}`);
+      }
+    },
+);
+
+// Function to delete an event sync source (admin only).
+exports.deleteEventSyncSource = onCall(
+    {region: "europe-west1"},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const {sourceId} = request.data || {};
+        if (typeof sourceId !== "string" || sourceId.trim().length === 0) {
+          throw new Error("sourceId is required");
+        }
+
+        await db.collection("eventSyncSources").doc(sourceId.trim()).delete();
+        return {
+          success: true,
+          sourceId: sourceId.trim(),
+          message: "Event sync source deleted successfully",
+        };
+      } catch (error) {
+        console.error("Error deleting event sync source:", error);
+        throw new Error(`Failed to delete event sync source: ${error.message}`);
+      }
+    },
+);
+
+// Function to get event sync sources (admin only).
+exports.getEventSyncSources = onCall(
+    {region: "europe-west1"},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const {includeInactive = true} = request.data || {};
+        let query = db.collection("eventSyncSources");
+
+        if (!includeInactive) {
+          query = query.where("isActive", "==", true);
+        }
+
+        const snapshot = await query.orderBy("createdAt", "desc").get();
+        const sources = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+
+        return {
+          success: true,
+          sources,
+          count: sources.length,
+        };
+      } catch (error) {
+        console.error("Error getting event sync sources:", error);
+        throw new Error(`Failed to get event sync sources: ${error.message}`);
+      }
+    },
+);
+
+// Function to sync one configured event source (admin only).
+exports.syncEventSource = onCall(
+    {region: "europe-west1", timeoutSeconds: 540, memory: "1GiB"},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const {sourceId} = request.data || {};
+        if (typeof sourceId !== "string" || sourceId.trim().length === 0) {
+          throw new Error("sourceId is required");
+        }
+
+        const sourceDoc = await db.collection("eventSyncSources")
+            .doc(sourceId.trim()).get();
+        if (!sourceDoc.exists) {
+          throw new Error(`Event sync source with ID ${sourceId} not found`);
+        }
+        const sourceData = sourceDoc.data() || {};
+        if (sourceData.isActive === false) {
+          throw new Error("Cannot sync an inactive event source");
+        }
+
+        const result = await syncExternalEventSource(sourceDoc);
+        return {
+          success: true,
+          sourceId: result.sourceId,
+          sourceName: result.sourceName,
+          stats: result.stats,
+          message: "Event source sync completed successfully",
+        };
+      } catch (error) {
+        console.error("Error syncing event source:", error);
+        throw new Error(`Failed to sync event source: ${error.message}`);
+      }
+    },
+);
+
+// Function to sync all active event sources (admin only).
+exports.syncAllEventSources = onCall(
+    {region: "europe-west1", timeoutSeconds: 540, memory: "1GiB"},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const snapshot = await db.collection("eventSyncSources")
+            .where("isActive", "==", true).get();
+
+        if (snapshot.empty) {
+          return {
+            success: true,
+            results: [],
+            totalStats: {
+              totalParsed: 0,
+              totalUnique: 0,
+              duplicatesInFeed: 0,
+              created: 0,
+              changed: 0,
+              unchanged: 0,
+            },
+            message: "No active event sources found",
+          };
+        }
+
+        const results = [];
+        const totalStats = {
+          totalParsed: 0,
+          totalUnique: 0,
+          duplicatesInFeed: 0,
+          created: 0,
+          changed: 0,
+          unchanged: 0,
+        };
+
+        for (const sourceDoc of snapshot.docs) {
+          try {
+            const result = await syncExternalEventSource(sourceDoc);
+            totalStats.totalParsed += result.stats.totalParsed;
+            totalStats.totalUnique += result.stats.totalUnique;
+            totalStats.duplicatesInFeed += result.stats.duplicatesInFeed;
+            totalStats.created += result.stats.created;
+            totalStats.changed += result.stats.changed;
+            totalStats.unchanged += result.stats.unchanged;
+            results.push({
+              sourceId: result.sourceId,
+              sourceName: result.sourceName,
+              success: true,
+              stats: result.stats,
+            });
+          } catch (sourceError) {
+            console.error(
+                `Failed syncing event source ${sourceDoc.id}:`,
+                sourceError,
+            );
+            results.push({
+              sourceId: sourceDoc.id,
+              sourceName: sourceDoc.data()?.name || sourceDoc.id,
+              success: false,
+              error: sourceError.message,
+            });
+          }
+        }
+
+        return {
+          success: true,
+          results,
+          totalStats,
+          message: `Processed ${results.length} event source(s)`,
+        };
+      } catch (error) {
+        console.error("Error syncing all event sources:", error);
+        throw new Error(`Failed to sync all event sources: ${error.message}`);
+      }
+    },
+);
 
 // Admin callable to backfill source/folder default spot attributes.
 exports.backfillSourceSpotAttributes = onCall(

--- a/functions/lib/event-sync.js
+++ b/functions/lib/event-sync.js
@@ -94,25 +94,41 @@ function nullableDateEqual(storedValue, incomingDate) {
  */
 function hasExternalEventContentChanges(existingData, incomingData) {
   if (!nullableStringEqual(existingData.title, incomingData.title)) return true;
-  if (!nullableStringEqual(existingData.description, incomingData.description)) {
+  if (
+    !nullableStringEqual(existingData.description, incomingData.description)
+  ) {
     return true;
   }
   if (!nullableStringEqual(existingData.websiteUrl, incomingData.websiteUrl)) {
     return true;
   }
-  if (!nullableStringEqual(existingData.address, incomingData.address)) return true;
-  if (!nullableDateEqual(existingData.startAt, incomingData.startAt)) return true;
-  if (!nullableDateEqual(existingData.endAt, incomingData.endAt)) return true;
-  if (!nullableStringEqual(existingData.eventSourceId, incomingData.eventSourceId)) {
+  if (!nullableStringEqual(existingData.address, incomingData.address)) {
+    return true;
+  }
+  if (!nullableDateEqual(existingData.startAt, incomingData.startAt)) {
+    return true;
+  }
+  if (!nullableDateEqual(existingData.endAt, incomingData.endAt)) {
     return true;
   }
   if (
-    !nullableStringEqual(existingData.eventSourceName, incomingData.eventSourceName)
+    !nullableStringEqual(existingData.eventSourceId, incomingData.eventSourceId)
   ) {
     return true;
   }
   if (
-    !nullableStringEqual(existingData.externalEventUid, incomingData.externalEventUid)
+    !nullableStringEqual(
+        existingData.eventSourceName,
+        incomingData.eventSourceName,
+    )
+  ) {
+    return true;
+  }
+  if (
+    !nullableStringEqual(
+        existingData.externalEventUid,
+        incomingData.externalEventUid,
+    )
   ) {
     return true;
   }
@@ -125,7 +141,10 @@ function hasExternalEventContentChanges(existingData, incomingData) {
     return true;
   }
   if (
-    !nullableStringEqual(existingData.externalEventKey, incomingData.externalEventKey)
+    !nullableStringEqual(
+        existingData.externalEventKey,
+        incomingData.externalEventKey,
+    )
   ) {
     return true;
   }

--- a/functions/lib/event-sync.js
+++ b/functions/lib/event-sync.js
@@ -1,0 +1,180 @@
+const ical = require("node-ical");
+
+/**
+ * Coerces unknown input into a non-empty trimmed string.
+ * @param {*} value
+ * @return {string|null}
+ */
+function toNonEmptyString(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Normalizes a potentially date-like value.
+ * @param {*} value
+ * @return {Date|null}
+ */
+function normalizeDate(value) {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value.toDate === "function") {
+    const asDate = value.toDate();
+    if (asDate instanceof Date && !Number.isNaN(asDate.getTime())) {
+      return asDate;
+    }
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Normalizes an iCal recurrence ID so it can be persisted.
+ * @param {*} value
+ * @return {string|null}
+ */
+function normalizeRecurrenceId(value) {
+  const asDate = normalizeDate(value);
+  if (asDate) return asDate.toISOString();
+  return toNonEmptyString(value);
+}
+
+/**
+ * Builds a unique key for one imported external event.
+ * @param {string} uid
+ * @param {string|null} recurrenceId
+ * @return {string}
+ */
+function buildExternalEventKey(uid, recurrenceId) {
+  const normalizedUid = toNonEmptyString(uid);
+  if (!normalizedUid) {
+    throw new Error("External event UID is required");
+  }
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (!normalizedRecurrenceId) return normalizedUid;
+  return `${normalizedUid}::${normalizedRecurrenceId}`;
+}
+
+/**
+ * Compares nullable strings while ignoring whitespace and empty-string/null.
+ * @param {*} left
+ * @param {*} right
+ * @return {boolean}
+ */
+function nullableStringEqual(left, right) {
+  const normalizedLeft = toNonEmptyString(left);
+  const normalizedRight = toNonEmptyString(right);
+  return normalizedLeft === normalizedRight;
+}
+
+/**
+ * Compares a stored Firestore timestamp-like field against a Date value.
+ * @param {*} storedValue
+ * @param {Date|null} incomingDate
+ * @return {boolean}
+ */
+function nullableDateEqual(storedValue, incomingDate) {
+  const normalizedStoredDate = normalizeDate(storedValue);
+  if (!normalizedStoredDate && !incomingDate) return true;
+  if (!normalizedStoredDate || !incomingDate) return false;
+  return normalizedStoredDate.getTime() === incomingDate.getTime();
+}
+
+/**
+ * Checks whether a source-sync should update event content fields.
+ * @param {Object} existingData
+ * @param {Object} incomingData
+ * @return {boolean}
+ */
+function hasExternalEventContentChanges(existingData, incomingData) {
+  if (!nullableStringEqual(existingData.title, incomingData.title)) return true;
+  if (!nullableStringEqual(existingData.description, incomingData.description)) {
+    return true;
+  }
+  if (!nullableStringEqual(existingData.websiteUrl, incomingData.websiteUrl)) {
+    return true;
+  }
+  if (!nullableStringEqual(existingData.address, incomingData.address)) return true;
+  if (!nullableDateEqual(existingData.startAt, incomingData.startAt)) return true;
+  if (!nullableDateEqual(existingData.endAt, incomingData.endAt)) return true;
+  if (!nullableStringEqual(existingData.eventSourceId, incomingData.eventSourceId)) {
+    return true;
+  }
+  if (
+    !nullableStringEqual(existingData.eventSourceName, incomingData.eventSourceName)
+  ) {
+    return true;
+  }
+  if (
+    !nullableStringEqual(existingData.externalEventUid, incomingData.externalEventUid)
+  ) {
+    return true;
+  }
+  if (
+    !nullableStringEqual(
+        existingData.externalEventRecurrenceId,
+        incomingData.externalEventRecurrenceId,
+    )
+  ) {
+    return true;
+  }
+  if (
+    !nullableStringEqual(existingData.externalEventKey, incomingData.externalEventKey)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Parses VEVENT records from an ICS file into normalized event payloads.
+ * @param {string} icsText
+ * @param {Object} sourceMeta
+ * @param {string} sourceMeta.sourceId
+ * @param {string} sourceMeta.sourceName
+ * @return {Array<Object>}
+ */
+function parseExternalEventsFromIcs(icsText, {sourceId, sourceName}) {
+  const parsedCalendar = ical.sync.parseICS(icsText);
+  const parsedEvents = [];
+
+  for (const value of Object.values(parsedCalendar)) {
+    if (!value || value.type !== "VEVENT") continue;
+
+    const uid = toNonEmptyString(value.uid);
+    if (!uid) continue;
+
+    const startAt = normalizeDate(value.start);
+    if (!startAt) continue;
+
+    const recurrenceId = normalizeRecurrenceId(value.recurrenceid);
+    parsedEvents.push({
+      title: toNonEmptyString(value.summary) || "Untitled event",
+      description: toNonEmptyString(value.description),
+      websiteUrl: toNonEmptyString(value.url),
+      address: toNonEmptyString(value.location),
+      startAt,
+      endAt: normalizeDate(value.end),
+      eventSourceId: sourceId,
+      eventSourceName: sourceName,
+      externalEventUid: uid,
+      externalEventRecurrenceId: recurrenceId,
+      externalEventKey: buildExternalEventKey(uid, recurrenceId),
+    });
+  }
+
+  return parsedEvents;
+}
+
+module.exports = {
+  buildExternalEventKey,
+  hasExternalEventContentChanges,
+  parseExternalEventsFromIcs,
+  normalizeRecurrenceId,
+};

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,6 +11,7 @@
         "firebase-functions": "^7.1.1",
         "googleapis": "^144.0.0",
         "i18n-iso-countries": "^7.9.0",
+        "node-ical": "^0.26.1",
         "sharp": "^0.33.0",
         "xml2js": "^0.6.2",
         "yauzl": "^3.2.1"
@@ -1676,6 +1677,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@nodable/entities": {
@@ -5339,6 +5352,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5891,6 +5910,19 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-ical": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.26.1.tgz",
+      "integrity": "sha512-KoYLpsz7Ga9lPDpt9vy0iKcgcb/9Ix7ICRZd0csLXMl2lZOSONGj7HrcktJFR7Jid1l44Zu1H4k/1nB04rWPgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrule-temporal": "^1.5.3",
+        "temporal-polyfill": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/node-int64": {
@@ -6631,6 +6663,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrule-temporal": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.5.3.tgz",
+      "integrity": "sha512-qALnXyu4MKNUeykkkO0r6Xxl5or3rM8Cf6ibKIe/29sgmq3tGm1oNq4G1Ddp8Ku3mnKmvC3+3yFAJ3OgOu6OJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7213,6 +7254,21 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,6 +20,7 @@
     "firebase-functions": "^7.1.1",
     "googleapis": "^144.0.0",
     "i18n-iso-countries": "^7.9.0",
+    "node-ical": "^0.26.1",
     "sharp": "^0.33.0",
     "xml2js": "^0.6.2",
     "yauzl": "^3.2.1"

--- a/functions/test/event-sync.test.js
+++ b/functions/test/event-sync.test.js
@@ -1,0 +1,95 @@
+const {
+  buildExternalEventKey,
+  hasExternalEventContentChanges,
+  parseExternalEventsFromIcs,
+} = require("../lib/event-sync");
+
+describe("event-sync helpers", () => {
+  describe("buildExternalEventKey", () => {
+    it("returns UID when recurrence ID is missing", () => {
+      expect(buildExternalEventKey("abc-123", null)).toBe("abc-123");
+    });
+
+    it("builds UID+recurrence key when recurrence ID exists", () => {
+      const key = buildExternalEventKey(
+          "recurring-uid",
+          "20260513T120000Z",
+      );
+      expect(key).toBe("recurring-uid::20260513T120000Z");
+    });
+  });
+
+  describe("hasExternalEventContentChanges", () => {
+    const incoming = {
+      title: "Jam Session",
+      description: "Bring water",
+      websiteUrl: "https://example.com/jam",
+      address: "Central Park",
+      startAt: new Date("2026-05-13T10:00:00.000Z"),
+      endAt: new Date("2026-05-13T12:00:00.000Z"),
+      eventSourceId: "source-1",
+      eventSourceName: "Source 1",
+      externalEventUid: "uid-1",
+      externalEventRecurrenceId: null,
+      externalEventKey: "uid-1",
+    };
+
+    it("returns false when relevant fields are unchanged", () => {
+      const existing = {...incoming};
+      expect(hasExternalEventContentChanges(existing, incoming)).toBe(false);
+    });
+
+    it("returns true when one tracked field changes", () => {
+      const existing = {...incoming, title: "Old title"};
+      expect(hasExternalEventContentChanges(existing, incoming)).toBe(true);
+    });
+
+    it("treats empty string and null as equivalent", () => {
+      const existing = {...incoming, description: ""};
+      const incomingWithoutDescription = {...incoming, description: null};
+      expect(
+          hasExternalEventContentChanges(existing, incomingWithoutDescription),
+      ).toBe(false);
+    });
+  });
+
+  describe("parseExternalEventsFromIcs", () => {
+    it("parses UID and recurrence ID into unique keys", () => {
+      const icsText = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//parkour spot test//EN",
+        "BEGIN:VEVENT",
+        "UID:single-event-uid@example.com",
+        "DTSTART:20260512T180000Z",
+        "DTEND:20260512T200000Z",
+        "SUMMARY:Single event",
+        "DESCRIPTION:Bring friends",
+        "URL:https://example.com/single",
+        "LOCATION:Single place",
+        "END:VEVENT",
+        "BEGIN:VEVENT",
+        "UID:recurring-event-uid@example.com",
+        "RECURRENCE-ID:20260513T180000Z",
+        "DTSTART:20260513T180000Z",
+        "DTEND:20260513T200000Z",
+        "SUMMARY:Recurring event instance",
+        "END:VEVENT",
+        "END:VCALENDAR",
+      ].join("\r\n");
+
+      const events = parseExternalEventsFromIcs(icsText, {
+        sourceId: "source-1",
+        sourceName: "Source name",
+      });
+
+      expect(events).toHaveLength(2);
+      expect(events[0].externalEventKey).toBe("single-event-uid@example.com");
+      expect(events[1].externalEventKey).toBe(
+          "recurring-event-uid@example.com::2026-05-13T18:00:00.000Z",
+      );
+      expect(events[0].eventSourceId).toBe("source-1");
+      expect(events[0].eventSourceName).toBe("Source name");
+    });
+  });
+});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'package:parkour_spot/services/jumpflix_service.dart';
 import 'package:parkour_spot/services/user_management_service.dart';
 import 'package:parkour_spot/services/admin_notifications_service.dart';
 import 'package:parkour_spot/services/admin_events_service.dart';
+import 'package:parkour_spot/services/event_sync_source_service.dart';
 import 'package:parkour_spot/services/admin_push_subscriptions_service.dart';
 import 'package:parkour_spot/services/snackbar_service.dart';
 import 'package:parkour_spot/services/spot_list_service.dart';
@@ -185,6 +186,7 @@ class ParkourSpotApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => UserManagementService()),
         ChangeNotifierProvider(create: (_) => AdminNotificationsService()),
         ChangeNotifierProvider(create: (_) => AdminEventsService()),
+        ChangeNotifierProvider(create: (_) => EventSyncSourceService()),
         ChangeNotifierProvider(create: (_) => AdminPushSubscriptionsService()),
         ChangeNotifierProvider(create: (_) => SpotService()),
         ChangeNotifierProvider(create: (_) => SyncSourceService()),

--- a/lib/models/parkour_event.dart
+++ b/lib/models/parkour_event.dart
@@ -15,6 +15,13 @@ class ParkourEvent {
   final String? createdBy;
   final DateTime? createdAt;
   final DateTime? updatedAt;
+  final String? eventSourceId;
+  final String? eventSourceName;
+  final String? externalEventUid;
+  final String? externalEventRecurrenceId;
+  final String? externalEventKey;
+  final DateTime? externalSyncLastSeenAt;
+  final DateTime? externalSyncLastChangedAt;
 
   ParkourEvent({
     this.id,
@@ -31,6 +38,13 @@ class ParkourEvent {
     this.createdBy,
     this.createdAt,
     this.updatedAt,
+    this.eventSourceId,
+    this.eventSourceName,
+    this.externalEventUid,
+    this.externalEventRecurrenceId,
+    this.externalEventKey,
+    this.externalSyncLastSeenAt,
+    this.externalSyncLastChangedAt,
   });
 
   factory ParkourEvent.fromFirestore(DocumentSnapshot doc) {
@@ -59,6 +73,17 @@ class ParkourEvent {
           : null,
       updatedAt: data['updatedAt'] is Timestamp
           ? (data['updatedAt'] as Timestamp).toDate()
+          : null,
+      eventSourceId: data['eventSourceId'] as String?,
+      eventSourceName: data['eventSourceName'] as String?,
+      externalEventUid: data['externalEventUid'] as String?,
+      externalEventRecurrenceId: data['externalEventRecurrenceId'] as String?,
+      externalEventKey: data['externalEventKey'] as String?,
+      externalSyncLastSeenAt: data['externalSyncLastSeenAt'] is Timestamp
+          ? (data['externalSyncLastSeenAt'] as Timestamp).toDate()
+          : null,
+      externalSyncLastChangedAt: data['externalSyncLastChangedAt'] is Timestamp
+          ? (data['externalSyncLastChangedAt'] as Timestamp).toDate()
           : null,
     );
   }
@@ -91,6 +116,13 @@ class ParkourEvent {
       createdBy: data['createdBy'] as String?,
       createdAt: parseDate(data['createdAt']),
       updatedAt: parseDate(data['updatedAt']),
+      eventSourceId: data['eventSourceId'] as String?,
+      eventSourceName: data['eventSourceName'] as String?,
+      externalEventUid: data['externalEventUid'] as String?,
+      externalEventRecurrenceId: data['externalEventRecurrenceId'] as String?,
+      externalEventKey: data['externalEventKey'] as String?,
+      externalSyncLastSeenAt: parseDate(data['externalSyncLastSeenAt']),
+      externalSyncLastChangedAt: parseDate(data['externalSyncLastChangedAt']),
     );
   }
 
@@ -112,6 +144,21 @@ class ParkourEvent {
       if (createdBy != null) 'createdBy': createdBy,
       if (createdAt != null) 'createdAt': createdAt!.toUtc(),
       if (updatedAt != null) 'updatedAt': updatedAt!.toUtc(),
+      if (eventSourceId != null && eventSourceId!.trim().isNotEmpty)
+        'eventSourceId': eventSourceId!.trim(),
+      if (eventSourceName != null && eventSourceName!.trim().isNotEmpty)
+        'eventSourceName': eventSourceName!.trim(),
+      if (externalEventUid != null && externalEventUid!.trim().isNotEmpty)
+        'externalEventUid': externalEventUid!.trim(),
+      if (externalEventRecurrenceId != null &&
+          externalEventRecurrenceId!.trim().isNotEmpty)
+        'externalEventRecurrenceId': externalEventRecurrenceId!.trim(),
+      if (externalEventKey != null && externalEventKey!.trim().isNotEmpty)
+        'externalEventKey': externalEventKey!.trim(),
+      if (externalSyncLastSeenAt != null)
+        'externalSyncLastSeenAt': externalSyncLastSeenAt!.toUtc(),
+      if (externalSyncLastChangedAt != null)
+        'externalSyncLastChangedAt': externalSyncLastChangedAt!.toUtc(),
     };
   }
 
@@ -130,6 +177,13 @@ class ParkourEvent {
     Object? createdBy = _unset,
     Object? createdAt = _unset,
     Object? updatedAt = _unset,
+    Object? eventSourceId = _unset,
+    Object? eventSourceName = _unset,
+    Object? externalEventUid = _unset,
+    Object? externalEventRecurrenceId = _unset,
+    Object? externalEventKey = _unset,
+    Object? externalSyncLastSeenAt = _unset,
+    Object? externalSyncLastChangedAt = _unset,
   }) {
     return ParkourEvent(
       id: id ?? this.id,
@@ -158,6 +212,27 @@ class ParkourEvent {
       updatedAt: identical(updatedAt, _unset)
           ? this.updatedAt
           : updatedAt as DateTime?,
+      eventSourceId: identical(eventSourceId, _unset)
+          ? this.eventSourceId
+          : eventSourceId as String?,
+      eventSourceName: identical(eventSourceName, _unset)
+          ? this.eventSourceName
+          : eventSourceName as String?,
+      externalEventUid: identical(externalEventUid, _unset)
+          ? this.externalEventUid
+          : externalEventUid as String?,
+      externalEventRecurrenceId: identical(externalEventRecurrenceId, _unset)
+          ? this.externalEventRecurrenceId
+          : externalEventRecurrenceId as String?,
+      externalEventKey: identical(externalEventKey, _unset)
+          ? this.externalEventKey
+          : externalEventKey as String?,
+      externalSyncLastSeenAt: identical(externalSyncLastSeenAt, _unset)
+          ? this.externalSyncLastSeenAt
+          : externalSyncLastSeenAt as DateTime?,
+      externalSyncLastChangedAt: identical(externalSyncLastChangedAt, _unset)
+          ? this.externalSyncLastChangedAt
+          : externalSyncLastChangedAt as DateTime?,
     );
   }
 

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -14,6 +14,7 @@ import '../screens/admin/spot_management_screen.dart';
 import '../screens/admin/user_management_screen.dart';
 import '../screens/admin/admin_notifications_screen.dart';
 import '../screens/admin/admin_events_screen.dart';
+import '../screens/admin/event_sync_sources_screen.dart';
 import '../screens/admin/admin_push_subscriptions_screen.dart';
 import '../screens/admin/user_activity_metrics_screen.dart';
 import '../screens/admin/audit_log_viewer_screen.dart';
@@ -386,6 +387,10 @@ class AppRouter {
         GoRoute(
           path: '/admin/events',
           builder: (context, state) => const AdminEventsScreen(),
+        ),
+        GoRoute(
+          path: '/admin/event-sources',
+          builder: (context, state) => const EventSyncSourcesScreen(),
         ),
         GoRoute(
           path: '/admin/push-subscriptions',

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -238,6 +238,8 @@ class _EventCard extends StatelessWidget {
     final websiteUrl = event.websiteUrl?.trim();
     final hasWebsite = websiteUrl != null && websiteUrl.isNotEmpty;
     final hasLocation = event.latitude != null && event.longitude != null;
+    final sourceName = event.eventSourceName?.trim();
+    final hasSource = sourceName != null && sourceName.isNotEmpty;
     final openEventPage = event.id == null
         ? null
         : () => context.push('/event/${event.id}');
@@ -297,8 +299,44 @@ class _EventCard extends StatelessWidget {
                     visualDensity: VisualDensity.compact,
                     materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
+                  if (hasSource)
+                    Chip(
+                      avatar: const Icon(Icons.sync, size: 16),
+                      label: Text(sourceName),
+                      visualDensity: VisualDensity.compact,
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
                 ],
               ),
+              if (hasSource &&
+                  (event.externalSyncLastSeenAt != null ||
+                      event.externalSyncLastChangedAt != null)) ...[
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 6,
+                  children: [
+                    if (event.externalSyncLastSeenAt != null)
+                      Chip(
+                        avatar: const Icon(Icons.update, size: 16),
+                        label: Text(
+                          'Seen: ${_formatUtc(event.externalSyncLastSeenAt!)}',
+                        ),
+                        visualDensity: VisualDensity.compact,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    if (event.externalSyncLastChangedAt != null)
+                      Chip(
+                        avatar: const Icon(Icons.edit_calendar, size: 16),
+                        label: Text(
+                          'Changed: ${_formatUtc(event.externalSyncLastChangedAt!)}',
+                        ),
+                        visualDensity: VisualDensity.compact,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                  ],
+                ),
+              ],
               const SizedBox(height: 10),
               SelectableText(
                 'Spot IDs: ${event.spotIds.join(', ')}',

--- a/lib/screens/admin/admin_home_screen.dart
+++ b/lib/screens/admin/admin_home_screen.dart
@@ -107,6 +107,18 @@ class AdminHomeScreen extends StatelessWidget {
           const SizedBox(height: 8),
           Card(
             child: ListTile(
+              leading: const Icon(Icons.event_repeat_outlined),
+              title: const Text('Event Sync Sources'),
+              subtitle: const Text(
+                'Configure and sync external calendar sources',
+              ),
+              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+              onTap: () => context.push('/admin/event-sources'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
               leading: const Icon(Icons.phonelink_ring_outlined),
               title: const Text('Web push subscriptions'),
               subtitle: const Text(

--- a/lib/screens/admin/event_sync_sources_screen.dart
+++ b/lib/screens/admin/event_sync_sources_screen.dart
@@ -1,0 +1,530 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../services/auth_service.dart';
+import '../../services/event_sync_source_service.dart';
+
+class EventSyncSourcesScreen extends StatefulWidget {
+  const EventSyncSourcesScreen({super.key});
+
+  @override
+  State<EventSyncSourcesScreen> createState() => _EventSyncSourcesScreenState();
+}
+
+class _EventSyncSourcesScreenState extends State<EventSyncSourcesScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final service = context.read<EventSyncSourceService>();
+      if (service.sources.isEmpty && !service.isLoading) {
+        service.fetchSources(includeInactive: true);
+      }
+    });
+  }
+
+  Future<void> _openEditDialog({EventSyncSource? source}) async {
+    final saved = await showDialog<bool>(
+      context: context,
+      builder: (_) => EventSyncSourceEditDialog(source: source),
+    );
+    if (saved == true && mounted) {
+      await context.read<EventSyncSourceService>().fetchSources(
+        includeInactive: true,
+      );
+    }
+  }
+
+  Future<void> _runSyncForSource(EventSyncSource source) async {
+    final service = context.read<EventSyncSourceService>();
+    final result = await service.syncSource(source.id);
+    if (!mounted) return;
+    if (result != null) {
+      final stats = result['stats'] as Map<dynamic, dynamic>?;
+      final created = (stats?['created'] ?? 0).toString();
+      final changed = (stats?['changed'] ?? 0).toString();
+      final unchanged = (stats?['unchanged'] ?? 0).toString();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Colors.green,
+          content: Text(
+            '${source.name} synced. Created: $created, Changed: $changed, Unchanged: $unchanged',
+          ),
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Colors.red,
+          content: Text(service.error ?? 'Failed to sync ${source.name}'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _runSyncAll() async {
+    final service = context.read<EventSyncSourceService>();
+    final result = await service.syncAllSources();
+    if (!mounted) return;
+    if (result != null) {
+      final stats = result['totalStats'] as Map<dynamic, dynamic>?;
+      final created = (stats?['created'] ?? 0).toString();
+      final changed = (stats?['changed'] ?? 0).toString();
+      final unchanged = (stats?['unchanged'] ?? 0).toString();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Colors.green,
+          content: Text(
+            'Event source sync complete. Created: $created, Changed: $changed, Unchanged: $unchanged',
+          ),
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Colors.red,
+          content: Text(service.error ?? 'Failed to sync all event sources'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = context.select<AuthService, bool>((s) => s.isAdmin);
+    if (!isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Event Sync Sources')),
+        body: const Center(child: Text('Administrator access required')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Event Sync Sources'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            if (Navigator.canPop(context)) {
+              Navigator.pop(context);
+            } else {
+              context.go('/admin');
+            }
+          },
+        ),
+        actions: [
+          Consumer<EventSyncSourceService>(
+            builder: (context, service, _) {
+              return IconButton(
+                tooltip: 'Sync all active sources',
+                icon: service.isSyncingAll
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.sync),
+                onPressed: service.isSyncingAll ? null : _runSyncAll,
+              );
+            },
+          ),
+          IconButton(
+            tooltip: 'Add event source',
+            icon: const Icon(Icons.add),
+            onPressed: () => _openEditDialog(),
+          ),
+        ],
+      ),
+      body: Consumer<EventSyncSourceService>(
+        builder: (context, service, _) {
+          if (service.isLoading && service.sources.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (service.error != null && service.sources.isEmpty) {
+            return Center(child: Text(service.error!));
+          }
+
+          if (service.sources.isEmpty) {
+            return RefreshIndicator(
+              onRefresh: () => service.fetchSources(includeInactive: true),
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const [
+                  Padding(
+                    padding: EdgeInsets.only(top: 160),
+                    child: Center(
+                      child: Text('No event sources configured yet'),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final sortedSources = [...service.sources]
+            ..sort((a, b) => a.name.compareTo(b.name));
+          return RefreshIndicator(
+            onRefresh: () => service.fetchSources(includeInactive: true),
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: sortedSources.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final source = sortedSources[index];
+                final isSyncing = service.syncingSources.contains(source.id);
+                return Card(
+                  child: ListTile(
+                    title: Text(source.name),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (source.description?.trim().isNotEmpty == true)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(source.description!.trim()),
+                          ),
+                        const SizedBox(height: 6),
+                        SelectableText(
+                          source.icsUrl,
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        if (source.publicUrl?.trim().isNotEmpty == true)
+                          InkWell(
+                            onTap: () async {
+                              final uri = Uri.tryParse(
+                                source.publicUrl!.trim(),
+                              );
+                              if (uri == null) return;
+                              if (await canLaunchUrl(uri)) {
+                                await launchUrl(
+                                  uri,
+                                  mode: LaunchMode.externalApplication,
+                                );
+                              }
+                            },
+                            child: Text(
+                              source.publicUrl!.trim(),
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: Colors.blue,
+                                decoration: TextDecoration.underline,
+                              ),
+                            ),
+                          ),
+                        const SizedBox(height: 6),
+                        Wrap(
+                          spacing: 6,
+                          runSpacing: 6,
+                          children: [
+                            Chip(
+                              label: Text(
+                                source.isActive ? 'Active' : 'Inactive',
+                              ),
+                            ),
+                            if (source.lastSyncAt != null)
+                              Chip(
+                                label: Text('Last sync: ${source.lastSyncAt}'),
+                              ),
+                          ],
+                        ),
+                        if (source.lastSyncStats != null)
+                          Wrap(
+                            spacing: 6,
+                            runSpacing: 6,
+                            children: [
+                              _StatChip(
+                                label: 'Created',
+                                value: source.lastSyncStats!['created'],
+                                color: Colors.green.shade100,
+                              ),
+                              _StatChip(
+                                label: 'Changed',
+                                value: source.lastSyncStats!['changed'],
+                                color: Colors.blue.shade100,
+                              ),
+                              _StatChip(
+                                label: 'Unchanged',
+                                value: source.lastSyncStats!['unchanged'],
+                                color: Colors.grey.shade200,
+                              ),
+                            ],
+                          ),
+                      ],
+                    ),
+                    isThreeLine: true,
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (source.isActive)
+                          IconButton(
+                            tooltip: 'Sync source',
+                            icon: isSyncing
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Icon(Icons.sync),
+                            onPressed: isSyncing
+                                ? null
+                                : () => _runSyncForSource(source),
+                          ),
+                        PopupMenuButton<String>(
+                          onSelected: (action) async {
+                            switch (action) {
+                              case 'edit':
+                                await _openEditDialog(source: source);
+                                return;
+                              case 'toggleActive':
+                                await context
+                                    .read<EventSyncSourceService>()
+                                    .updateSource(
+                                      sourceId: source.id,
+                                      isActive: !source.isActive,
+                                    );
+                                return;
+                              case 'delete':
+                                final confirmed = await showDialog<bool>(
+                                  context: context,
+                                  builder: (dialogContext) => AlertDialog(
+                                    title: const Text('Delete event source'),
+                                    content: Text('Delete "${source.name}"?'),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () =>
+                                            Navigator.pop(dialogContext, false),
+                                        child: const Text('Cancel'),
+                                      ),
+                                      TextButton(
+                                        onPressed: () =>
+                                            Navigator.pop(dialogContext, true),
+                                        child: const Text('Delete'),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                                if (confirmed == true && mounted) {
+                                  await context
+                                      .read<EventSyncSourceService>()
+                                      .deleteSource(source.id);
+                                }
+                                return;
+                            }
+                          },
+                          itemBuilder: (_) => [
+                            const PopupMenuItem(
+                              value: 'edit',
+                              child: Text('Edit'),
+                            ),
+                            PopupMenuItem(
+                              value: 'toggleActive',
+                              child: Text(
+                                source.isActive ? 'Deactivate' : 'Activate',
+                              ),
+                            ),
+                            const PopupMenuItem(
+                              value: 'delete',
+                              child: Text('Delete'),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class EventSyncSourceEditDialog extends StatefulWidget {
+  final EventSyncSource? source;
+
+  const EventSyncSourceEditDialog({super.key, this.source});
+
+  @override
+  State<EventSyncSourceEditDialog> createState() =>
+      _EventSyncSourceEditDialogState();
+}
+
+class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameCtrl;
+  late final TextEditingController _icsUrlCtrl;
+  late final TextEditingController _descriptionCtrl;
+  late final TextEditingController _publicUrlCtrl;
+  late bool _isActive;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameCtrl = TextEditingController(text: widget.source?.name ?? '');
+    _icsUrlCtrl = TextEditingController(text: widget.source?.icsUrl ?? '');
+    _descriptionCtrl = TextEditingController(
+      text: widget.source?.description ?? '',
+    );
+    _publicUrlCtrl = TextEditingController(
+      text: widget.source?.publicUrl ?? '',
+    );
+    _isActive = widget.source?.isActive ?? true;
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _icsUrlCtrl.dispose();
+    _descriptionCtrl.dispose();
+    _publicUrlCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        widget.source == null ? 'Add Event Source' : 'Edit Event Source',
+      ),
+      content: SizedBox(
+        width: 520,
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: _nameCtrl,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                  validator: (value) => (value == null || value.trim().isEmpty)
+                      ? 'Required'
+                      : null,
+                ),
+                TextFormField(
+                  controller: _icsUrlCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'ICS URL',
+                    helperText: 'Google Calendar public .ics URL',
+                  ),
+                  validator: (value) {
+                    final trimmed = value?.trim() ?? '';
+                    if (trimmed.isEmpty) return 'Required';
+                    final uri = Uri.tryParse(trimmed);
+                    if (uri == null || uri.host.isEmpty) return 'Invalid URL';
+                    if (uri.scheme != 'http' && uri.scheme != 'https') {
+                      return 'URL must start with http or https';
+                    }
+                    return null;
+                  },
+                ),
+                TextFormField(
+                  controller: _descriptionCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Description (optional)',
+                  ),
+                  maxLines: 3,
+                ),
+                TextFormField(
+                  controller: _publicUrlCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Public URL (optional)',
+                  ),
+                ),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Active'),
+                  value: _isActive,
+                  onChanged: (value) => setState(() => _isActive = value),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSaving ? null : () => Navigator.pop(context, false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isSaving
+              ? null
+              : () async {
+                  if (!_formKey.currentState!.validate()) return;
+                  final service = context.read<EventSyncSourceService>();
+                  setState(() => _isSaving = true);
+                  final trimmedDescription = _descriptionCtrl.text.trim();
+                  final trimmedPublicUrl = _publicUrlCtrl.text.trim();
+
+                  bool ok;
+                  if (widget.source == null) {
+                    ok = await service.createSource(
+                      name: _nameCtrl.text.trim(),
+                      icsUrl: _icsUrlCtrl.text.trim(),
+                      description: trimmedDescription.isEmpty
+                          ? null
+                          : trimmedDescription,
+                      publicUrl: trimmedPublicUrl.isEmpty
+                          ? null
+                          : trimmedPublicUrl,
+                      isActive: _isActive,
+                    );
+                  } else {
+                    ok = await service.updateSource(
+                      sourceId: widget.source!.id,
+                      name: _nameCtrl.text.trim(),
+                      icsUrl: _icsUrlCtrl.text.trim(),
+                      description: trimmedDescription,
+                      publicUrl: trimmedPublicUrl,
+                      isActive: _isActive,
+                    );
+                  }
+
+                  if (!mounted) return;
+                  setState(() => _isSaving = false);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(ok ? 'Saved' : 'Failed to save')),
+                  );
+                  if (ok) {
+                    Navigator.pop(context, true);
+                  }
+                },
+          child: _isSaving
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Save'),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  final String label;
+  final dynamic value;
+  final Color color;
+
+  const _StatChip({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final number = value is num ? value.toInt() : 0;
+    return Chip(backgroundColor: color, label: Text('$label: $number'));
+  }
+}

--- a/lib/screens/admin/event_sync_sources_screen.dart
+++ b/lib/screens/admin/event_sync_sources_screen.dart
@@ -289,6 +289,8 @@ class _EventSyncSourcesScreenState extends State<EventSyncSourcesScreen> {
                                     );
                                 return;
                               case 'delete':
+                                final eventSourceService = context
+                                    .read<EventSyncSourceService>();
                                 final confirmed = await showDialog<bool>(
                                   context: context,
                                   builder: (dialogContext) => AlertDialog(
@@ -309,9 +311,9 @@ class _EventSyncSourcesScreenState extends State<EventSyncSourcesScreen> {
                                   ),
                                 );
                                 if (confirmed == true && mounted) {
-                                  await context
-                                      .read<EventSyncSourceService>()
-                                      .deleteSource(source.id);
+                                  await eventSourceService.deleteSource(
+                                    source.id,
+                                  );
                                 }
                                 return;
                             }
@@ -461,6 +463,8 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
               : () async {
                   if (!_formKey.currentState!.validate()) return;
                   final service = context.read<EventSyncSourceService>();
+                  final navigator = Navigator.of(context);
+                  final messenger = ScaffoldMessenger.of(context);
                   setState(() => _isSaving = true);
                   final trimmedDescription = _descriptionCtrl.text.trim();
                   final trimmedPublicUrl = _publicUrlCtrl.text.trim();
@@ -491,11 +495,11 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
 
                   if (!mounted) return;
                   setState(() => _isSaving = false);
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  messenger.showSnackBar(
                     SnackBar(content: Text(ok ? 'Saved' : 'Failed to save')),
                   );
                   if (ok) {
-                    Navigator.pop(context, true);
+                    navigator.pop(true);
                   }
                 },
           child: _isSaving

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -20,6 +20,8 @@ class EventDetailScreen extends StatelessWidget {
     final hasWebsite = websiteUrl != null && websiteUrl.isNotEmpty;
     final hasLocation = event.latitude != null && event.longitude != null;
     final hasAddress = event.address?.trim().isNotEmpty == true;
+    final sourceName = event.eventSourceName?.trim();
+    final hasSource = sourceName != null && sourceName.isNotEmpty;
 
     return PageScaffold(
       title: event.title,
@@ -57,8 +59,38 @@ class EventDetailScreen extends StatelessWidget {
                 avatar: const Icon(Icons.place_outlined, size: 16),
                 label: Text('${event.spotIds.length} linked spot(s)'),
               ),
+              if (hasSource)
+                Chip(
+                  avatar: const Icon(Icons.sync, size: 16),
+                  label: Text(sourceName),
+                ),
             ],
           ),
+          if (hasSource &&
+              (event.externalSyncLastSeenAt != null ||
+                  event.externalSyncLastChangedAt != null)) ...[
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 6,
+              children: [
+                if (event.externalSyncLastSeenAt != null)
+                  Chip(
+                    avatar: const Icon(Icons.update, size: 16),
+                    label: Text(
+                      'Seen: ${_formatUtc(event.externalSyncLastSeenAt!)}',
+                    ),
+                  ),
+                if (event.externalSyncLastChangedAt != null)
+                  Chip(
+                    avatar: const Icon(Icons.edit_calendar, size: 16),
+                    label: Text(
+                      'Changed: ${_formatUtc(event.externalSyncLastChangedAt!)}',
+                    ),
+                  ),
+              ],
+            ),
+          ],
           if (event.imageUrls.isNotEmpty) ...[
             const SizedBox(height: 16),
             Text('Images', style: Theme.of(context).textTheme.titleMedium),

--- a/lib/services/event_sync_source_service.dart
+++ b/lib/services/event_sync_source_service.dart
@@ -1,0 +1,260 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/foundation.dart';
+
+Map<String, dynamic> _callableMap(dynamic value) {
+  if (value is! Map) {
+    throw FormatException('Expected Map, got ${value.runtimeType}');
+  }
+  return Map<String, dynamic>.from(value);
+}
+
+List<dynamic> _callableList(dynamic value) {
+  if (value == null) return <dynamic>[];
+  if (value is List) return List<dynamic>.from(value);
+  if (value is Iterable) return value.toList();
+  throw FormatException('Expected List/Iterable, got ${value.runtimeType}');
+}
+
+DateTime? _parseTimestamp(dynamic timestamp) {
+  if (timestamp == null) return null;
+  if (timestamp is Timestamp) return timestamp.toDate();
+  if (timestamp is DateTime) return timestamp;
+  if (timestamp is Map) {
+    final map = Map<String, dynamic>.from(timestamp);
+    final secondsRaw = map['_seconds'];
+    final nanosecondsRaw = map['_nanoseconds'];
+    final seconds = secondsRaw is int
+        ? secondsRaw
+        : (secondsRaw as num?)?.toInt();
+    final nanoseconds = nanosecondsRaw is int
+        ? nanosecondsRaw
+        : (nanosecondsRaw as num?)?.toInt() ?? 0;
+    if (seconds != null) {
+      return DateTime.fromMillisecondsSinceEpoch(
+        seconds * 1000 + (nanoseconds / 1000000).round(),
+      );
+    }
+  }
+  return null;
+}
+
+class EventSyncSource {
+  final String id;
+  final String name;
+  final String icsUrl;
+  final String? description;
+  final String? publicUrl;
+  final bool isActive;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? lastSyncAt;
+  final Map<String, dynamic>? lastSyncStats;
+
+  const EventSyncSource({
+    required this.id,
+    required this.name,
+    required this.icsUrl,
+    this.description,
+    this.publicUrl,
+    required this.isActive,
+    this.createdAt,
+    this.updatedAt,
+    this.lastSyncAt,
+    this.lastSyncStats,
+  });
+
+  factory EventSyncSource.fromMap(Map<String, dynamic> data) {
+    return EventSyncSource(
+      id: data['id']?.toString() ?? '',
+      name: data['name']?.toString() ?? '',
+      icsUrl: data['icsUrl']?.toString() ?? '',
+      description: data['description'] as String?,
+      publicUrl: data['publicUrl'] as String?,
+      isActive: data['isActive'] is bool ? data['isActive'] as bool : true,
+      createdAt: _parseTimestamp(data['createdAt']),
+      updatedAt: _parseTimestamp(data['updatedAt']),
+      lastSyncAt: _parseTimestamp(data['lastSyncAt']),
+      lastSyncStats: data['lastSyncStats'] is Map
+          ? Map<String, dynamic>.from(data['lastSyncStats'] as Map)
+          : null,
+    );
+  }
+}
+
+class EventSyncSourceService extends ChangeNotifier {
+  final FirebaseFunctions _functions = FirebaseFunctions.instanceFor(
+    region: 'europe-west1',
+  );
+
+  List<EventSyncSource> _sources = <EventSyncSource>[];
+  bool _isLoading = false;
+  bool _isSyncingAll = false;
+  final Set<String> _syncingSources = <String>{};
+  String? _error;
+
+  List<EventSyncSource> get sources => _sources;
+  bool get isLoading => _isLoading;
+  bool get isSyncingAll => _isSyncingAll;
+  Set<String> get syncingSources => _syncingSources;
+  String? get error => _error;
+
+  Future<void> fetchSources({bool includeInactive = true}) async {
+    try {
+      _isLoading = true;
+      _error = null;
+      notifyListeners();
+
+      final callable = _functions.httpsCallable('getEventSyncSources');
+      final result = await callable.call({'includeInactive': includeInactive});
+      final data = _callableMap(result.data);
+      if (data['success'] == true) {
+        _sources = _callableList(
+          data['sources'],
+        ).map((item) => EventSyncSource.fromMap(_callableMap(item))).toList();
+      } else {
+        _error = 'Failed to fetch event sources';
+      }
+    } catch (e) {
+      _error = 'Failed to fetch event sources: $e';
+      debugPrint('EventSyncSourceService.fetchSources error: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> createSource({
+    required String name,
+    required String icsUrl,
+    String? description,
+    String? publicUrl,
+    bool isActive = true,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('createEventSyncSource');
+      final result = await callable.call({
+        'name': name,
+        'icsUrl': icsUrl,
+        'description': description,
+        'publicUrl': publicUrl,
+        'isActive': isActive,
+      });
+      final success = _callableMap(result.data)['success'] == true;
+      if (success) {
+        await fetchSources(includeInactive: true);
+      }
+      return success;
+    } catch (e) {
+      _error = 'Failed to create event source: $e';
+      debugPrint(_error);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> updateSource({
+    required String sourceId,
+    String? name,
+    String? icsUrl,
+    String? description,
+    String? publicUrl,
+    bool? isActive,
+  }) async {
+    try {
+      final payload = <String, dynamic>{'sourceId': sourceId};
+      if (name != null) payload['name'] = name;
+      if (icsUrl != null) payload['icsUrl'] = icsUrl;
+      if (description != null) payload['description'] = description;
+      if (publicUrl != null) payload['publicUrl'] = publicUrl;
+      if (isActive != null) payload['isActive'] = isActive;
+
+      final callable = _functions.httpsCallable('updateEventSyncSource');
+      final result = await callable.call(payload);
+      final success = _callableMap(result.data)['success'] == true;
+      if (success) {
+        await fetchSources(includeInactive: true);
+      }
+      return success;
+    } catch (e) {
+      _error = 'Failed to update event source: $e';
+      debugPrint(_error);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> deleteSource(String sourceId) async {
+    try {
+      final callable = _functions.httpsCallable('deleteEventSyncSource');
+      final result = await callable.call({'sourceId': sourceId});
+      final success = _callableMap(result.data)['success'] == true;
+      if (success) {
+        _sources.removeWhere((source) => source.id == sourceId);
+        notifyListeners();
+      }
+      return success;
+    } catch (e) {
+      _error = 'Failed to delete event source: $e';
+      debugPrint(_error);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<Map<String, dynamic>?> syncSource(String sourceId) async {
+    try {
+      _syncingSources.add(sourceId);
+      _error = null;
+      notifyListeners();
+
+      final callable = _functions.httpsCallable('syncEventSource');
+      final result = await callable.call({'sourceId': sourceId});
+      _syncingSources.remove(sourceId);
+      notifyListeners();
+
+      final data = _callableMap(result.data);
+      if (data['success'] == true) {
+        await fetchSources(includeInactive: true);
+        return data;
+      }
+      _error = data['error']?.toString() ?? 'Sync failed';
+      notifyListeners();
+      return null;
+    } catch (e) {
+      _syncingSources.remove(sourceId);
+      _error = 'Failed to sync event source: $e';
+      debugPrint(_error);
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<Map<String, dynamic>?> syncAllSources() async {
+    try {
+      _isSyncingAll = true;
+      _error = null;
+      notifyListeners();
+
+      final callable = _functions.httpsCallable('syncAllEventSources');
+      final result = await callable.call({});
+      _isSyncingAll = false;
+      notifyListeners();
+
+      final data = _callableMap(result.data);
+      if (data['success'] == true) {
+        await fetchSources(includeInactive: true);
+        return data;
+      }
+      _error = data['error']?.toString() ?? 'Sync all failed';
+      notifyListeners();
+      return null;
+    } catch (e) {
+      _isSyncingAll = false;
+      _error = 'Failed to sync all event sources: $e';
+      debugPrint(_error);
+      notifyListeners();
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Cloud Functions support for external event sources via new `eventSyncSources` callables (`create/update/delete/get`, plus `syncEventSource` and `syncAllEventSources`)
- import Google ICS events into `events` with source attribution and deterministic upsert keys (`UID` or `UID::RECURRENCE-ID`)
- track sync encounter vs content mutation separately on events using `externalSyncLastSeenAt` and `externalSyncLastChangedAt`
- add Flutter admin tooling to configure/sync event sources and expose source/sync metadata on Admin Events and Event Detail views
- add unit tests for event-sync keying, change detection, and ICS parsing

## Testing
- `cd functions && npm run lint`
- `cd functions && npm test -- event-sync.test.js`
- `flutter analyze "lib/services/event_sync_source_service.dart" "lib/screens/admin/event_sync_sources_screen.dart" "lib/models/parkour_event.dart" "lib/screens/admin/admin_events_screen.dart" "lib/screens/events/event_detail_screen.dart" "lib/router/app_router.dart" "lib/main.dart" "lib/screens/admin/admin_home_screen.dart"`
- manual admin E2E verification: add ICS source, run sync, confirm imported events show source + Seen/Changed chips

## Walkthrough Artifacts
[event_sync_source_end_to_end_demo.mp4](https://cursor.com/agents/bc-a266fb32-cd86-427c-b066-3f5eb7f182f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_sync_source_end_to_end_demo.mp4)
[Event source sync stats](https://cursor.com/agents/bc-a266fb32-cd86-427c-b066-3f5eb7f182f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_sync_source_stats.webp)
[Imported events with source metadata](https://cursor.com/agents/bc-a266fb32-cd86-427c-b066-3f5eb7f182f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimported_events_with_source_chips.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a266fb32-cd86-427c-b066-3f5eb7f182f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a266fb32-cd86-427c-b066-3f5eb7f182f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

