### PR TITLE
Add cron scheduling for event sync sources

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4348,6 +4348,8 @@ exports.createEventSyncSource = onCall(
           description,
           publicUrl,
           isActive = true,
+          syncSchedule,
+          autoSyncEnabled = false,
         } = request.data || {};
 
         if (typeof name !== "string" || name.trim().length === 0) {
@@ -4358,6 +4360,7 @@ exports.createEventSyncSource = onCall(
           name: name.trim(),
           icsUrl: normalizeIcsUrl(icsUrl),
           isActive: Boolean(isActive),
+          autoSyncEnabled: Boolean(autoSyncEnabled),
           createdAt: FieldValue.serverTimestamp(),
           updatedAt: FieldValue.serverTimestamp(),
         };
@@ -4367,6 +4370,9 @@ exports.createEventSyncSource = onCall(
         }
         if (typeof publicUrl === "string" && publicUrl.trim().length > 0) {
           sourceData.publicUrl = publicUrl.trim();
+        }
+        if (typeof syncSchedule === "string" && syncSchedule.trim().length > 0) {
+          sourceData.syncSchedule = syncSchedule.trim();
         }
 
         const docRef = await db.collection("eventSyncSources").add(sourceData);
@@ -4395,6 +4401,8 @@ exports.updateEventSyncSource = onCall(
           description,
           publicUrl,
           isActive,
+          syncSchedule,
+          autoSyncEnabled,
         } = request.data || {};
 
         if (typeof sourceId !== "string" || sourceId.trim().length === 0) {
@@ -4430,6 +4438,16 @@ exports.updateEventSyncSource = onCall(
         }
         if (isActive !== undefined) {
           updateData.isActive = Boolean(isActive);
+        }
+        if (syncSchedule !== undefined) {
+          if (typeof syncSchedule === "string" && syncSchedule.trim().length > 0) {
+            updateData.syncSchedule = syncSchedule.trim();
+          } else {
+            updateData.syncSchedule = FieldValue.delete();
+          }
+        }
+        if (autoSyncEnabled !== undefined) {
+          updateData.autoSyncEnabled = Boolean(autoSyncEnabled);
         }
 
         await db.collection("eventSyncSources").doc(sourceId.trim())
@@ -4657,6 +4675,92 @@ exports.syncAllEventSources = onCall(
       } catch (error) {
         console.error("Error syncing all event sources:", error);
         throw new Error(`Failed to sync all event sources: ${error.message}`);
+      }
+    },
+);
+
+/**
+ * Scheduled function to check and run automated syncs for event sources.
+ * Runs every hour to check which sources need syncing based on cron schedule.
+ * Processes only one source per run to avoid timeout issues.
+ */
+exports.checkAndRunEventAutoSyncs = onSchedule(
+    {
+      schedule: "every 1 hours",
+      timeZone: "UTC",
+      region: "europe-west1",
+      memory: "2GiB",
+      timeoutSeconds: 1800,
+      secrets: ["GOOGLE_MAPS_API_KEY"],
+    },
+    async () => {
+      console.log("Event auto-sync check started");
+      const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+      if (!apiKey) {
+        throw new Error("Google Maps API key not configured");
+      }
+
+      try {
+        const sourcesSnapshot = await db
+            .collection("eventSyncSources")
+            .where("isActive", "==", true)
+            .get();
+
+        const now = new Date();
+        for (const sourceDoc of sourcesSnapshot.docs) {
+          const source = sourceDoc.data();
+          const sourceId = sourceDoc.id;
+
+          // Skip when auto-sync is disabled or no schedule is configured.
+          if (source.autoSyncEnabled !== true) continue;
+          if (typeof source.syncSchedule !== "string" ||
+              source.syncSchedule.trim().length === 0) {
+            continue;
+          }
+
+          const lastSync = source.lastSyncAt &&
+              typeof source.lastSyncAt.toDate === "function" ?
+              source.lastSyncAt.toDate() :
+              new Date(0);
+
+          const shouldRun = shouldRunSync(source.syncSchedule, lastSync, now);
+          if (!shouldRun) continue;
+
+          try {
+            console.log(
+                `Running scheduled event sync for source: ${source.name} (${sourceId})`,
+            );
+            const result = await syncExternalEventSource(sourceDoc);
+            return {
+              success: true,
+              sourceId: result.sourceId,
+              sourceName: result.sourceName,
+              schedule: source.syncSchedule,
+              stats: result.stats,
+              message: "Processed 1 event source",
+            };
+          } catch (error) {
+            console.error(`Error running scheduled event sync for ${source.name}:`, error);
+            return {
+              success: false,
+              sourceId,
+              sourceName: source.name || sourceId,
+              schedule: source.syncSchedule,
+              error: error.message,
+              message: `Failed to process source: ${source.name || sourceId}`,
+            };
+          }
+        }
+
+        console.log("Event auto-sync check completed. No sources needed syncing at this time.");
+        return {
+          success: true,
+          message: "No event sources needed syncing",
+          processed: 0,
+        };
+      } catch (error) {
+        console.error("Error in event auto-sync check:", error);
+        throw error;
       }
     },
 );

--- a/lib/screens/admin/event_sync_sources_screen.dart
+++ b/lib/screens/admin/event_sync_sources_screen.dart
@@ -6,6 +6,11 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../services/auth_service.dart';
 import '../../services/event_sync_source_service.dart';
 
+const TextStyle _kEventSyncChipLabelText = TextStyle(
+  fontSize: 11,
+  fontWeight: FontWeight.normal,
+);
+
 class EventSyncSourcesScreen extends StatefulWidget {
   const EventSyncSourcesScreen({super.key});
 
@@ -228,8 +233,32 @@ class _EventSyncSourcesScreenState extends State<EventSyncSourcesScreen> {
                               Chip(
                                 label: Text('Last sync: ${source.lastSyncAt}'),
                               ),
+                            if (source.autoSyncEnabled == true)
+                              Chip(
+                                backgroundColor: Colors.green.shade100,
+                                label: const Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(Icons.schedule, size: 16),
+                                    SizedBox(width: 4),
+                                    Text('Auto-Sync ON'),
+                                  ],
+                                ),
+                              ),
                           ],
                         ),
+                        if (source.autoSyncEnabled == true &&
+                            source.syncSchedule != null &&
+                            source.syncSchedule!.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Chip(
+                            backgroundColor: Colors.blue.shade50,
+                            label: Text(
+                              'Schedule: ${source.syncSchedule}',
+                              style: _kEventSyncChipLabelText,
+                            ),
+                          ),
+                        ],
                         if (source.lastSyncStats != null)
                           Wrap(
                             spacing: 6,
@@ -364,7 +393,9 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
   late final TextEditingController _icsUrlCtrl;
   late final TextEditingController _descriptionCtrl;
   late final TextEditingController _publicUrlCtrl;
+  late final TextEditingController _syncScheduleCtrl;
   late bool _isActive;
+  late bool _autoSyncEnabled;
   bool _isSaving = false;
 
   @override
@@ -378,7 +409,11 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
     _publicUrlCtrl = TextEditingController(
       text: widget.source?.publicUrl ?? '',
     );
+    _syncScheduleCtrl = TextEditingController(
+      text: widget.source?.syncSchedule ?? '',
+    );
     _isActive = widget.source?.isActive ?? true;
+    _autoSyncEnabled = widget.source?.autoSyncEnabled ?? false;
   }
 
   @override
@@ -387,6 +422,7 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
     _icsUrlCtrl.dispose();
     _descriptionCtrl.dispose();
     _publicUrlCtrl.dispose();
+    _syncScheduleCtrl.dispose();
     super.dispose();
   }
 
@@ -447,6 +483,30 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
                   value: _isActive,
                   onChanged: (value) => setState(() => _isActive = value),
                 ),
+                const Divider(),
+                const Text(
+                  'Auto-Sync Configuration',
+                  style: TextStyle(fontSize: 16),
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Enable Auto-Sync'),
+                  subtitle: const Text(
+                    'Automatically sync this event source according to the schedule below',
+                  ),
+                  value: _autoSyncEnabled,
+                  onChanged: (value) =>
+                      setState(() => _autoSyncEnabled = value),
+                ),
+                TextFormField(
+                  controller: _syncScheduleCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Sync Schedule (Cron)',
+                    helperText:
+                        'Cron expression (e.g., "0 */6 * * *" every 6 hours in UTC). Leave empty to disable schedule.',
+                  ),
+                ),
               ],
             ),
           ),
@@ -481,6 +541,10 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
                           ? null
                           : trimmedPublicUrl,
                       isActive: _isActive,
+                      syncSchedule: _syncScheduleCtrl.text.trim().isEmpty
+                          ? null
+                          : _syncScheduleCtrl.text.trim(),
+                      autoSyncEnabled: _autoSyncEnabled,
                     );
                   } else {
                     ok = await service.updateSource(
@@ -490,6 +554,8 @@ class _EventSyncSourceEditDialogState extends State<EventSyncSourceEditDialog> {
                       description: trimmedDescription,
                       publicUrl: trimmedPublicUrl,
                       isActive: _isActive,
+                      syncSchedule: _syncScheduleCtrl.text.trim(),
+                      autoSyncEnabled: _autoSyncEnabled,
                     );
                   }
 

--- a/lib/services/event_sync_source_service.dart
+++ b/lib/services/event_sync_source_service.dart
@@ -50,6 +50,8 @@ class EventSyncSource {
   final DateTime? updatedAt;
   final DateTime? lastSyncAt;
   final Map<String, dynamic>? lastSyncStats;
+  final String? syncSchedule;
+  final bool? autoSyncEnabled;
 
   const EventSyncSource({
     required this.id,
@@ -62,6 +64,8 @@ class EventSyncSource {
     this.updatedAt,
     this.lastSyncAt,
     this.lastSyncStats,
+    this.syncSchedule,
+    this.autoSyncEnabled,
   });
 
   factory EventSyncSource.fromMap(Map<String, dynamic> data) {
@@ -77,6 +81,10 @@ class EventSyncSource {
       lastSyncAt: _parseTimestamp(data['lastSyncAt']),
       lastSyncStats: data['lastSyncStats'] is Map
           ? Map<String, dynamic>.from(data['lastSyncStats'] as Map)
+          : null,
+      syncSchedule: data['syncSchedule'] as String?,
+      autoSyncEnabled: data['autoSyncEnabled'] is bool
+          ? data['autoSyncEnabled'] as bool
           : null,
     );
   }
@@ -152,6 +160,8 @@ class EventSyncSourceService extends ChangeNotifier {
     String? description,
     String? publicUrl,
     bool isActive = true,
+    String? syncSchedule,
+    bool autoSyncEnabled = false,
   }) async {
     try {
       final callable = _functions.httpsCallable('createEventSyncSource');
@@ -161,6 +171,9 @@ class EventSyncSourceService extends ChangeNotifier {
         'description': description,
         'publicUrl': publicUrl,
         'isActive': isActive,
+        if (syncSchedule != null && syncSchedule.isNotEmpty)
+          'syncSchedule': syncSchedule,
+        'autoSyncEnabled': autoSyncEnabled,
       });
       final success = _callableMap(result.data)['success'] == true;
       if (success) {
@@ -182,6 +195,8 @@ class EventSyncSourceService extends ChangeNotifier {
     String? description,
     String? publicUrl,
     bool? isActive,
+    String? syncSchedule,
+    bool? autoSyncEnabled,
   }) async {
     try {
       final payload = <String, dynamic>{'sourceId': sourceId};
@@ -190,6 +205,12 @@ class EventSyncSourceService extends ChangeNotifier {
       if (description != null) payload['description'] = description;
       if (publicUrl != null) payload['publicUrl'] = publicUrl;
       if (isActive != null) payload['isActive'] = isActive;
+      if (syncSchedule != null) {
+        payload['syncSchedule'] = syncSchedule.isEmpty ? null : syncSchedule;
+      }
+      if (autoSyncEnabled != null) {
+        payload['autoSyncEnabled'] = autoSyncEnabled;
+      }
 
       final callable = _functions.httpsCallable('updateEventSyncSource');
       final result = await callable.call(payload);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- added cron schedule (`syncSchedule`) and auto-sync (`autoSyncEnabled`) support to event sync source create/update callables
- added scheduled Cloud Function `checkAndRunEventAutoSyncs` to process active event sources when cron schedules are due
- extended event sync source admin UI/service so admins can configure and view cron schedule + auto-sync status chips

## Testing
- `cd functions && npm test -- --runInBand sync-helpers.test.js`
- `cd functions && npx eslint index.js`
- `flutter analyze lib/screens/admin/event_sync_sources_screen.dart lib/services/event_sync_source_service.dart`
- `flutter test test/models/parkour_event_test.dart`
- manual browser walkthrough (admin login -> event source create/edit with cron)

## Walkthrough Artifacts
[event_source_cron_schedule_walkthrough.mp4](https://cursor.com/agents/bc-5680b339-3ee6-4e7d-b334-a1a2e9af21dc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_source_cron_schedule_walkthrough.mp4)
[event-source-cron-chips](https://cursor.com/agents/bc-5680b339-3ee6-4e7d-b334-a1a2e9af21dc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_source_cron_chips.webp)
[event-source-cron-edit-dialog](https://cursor.com/agents/bc-5680b339-3ee6-4e7d-b334-a1a2e9af21dc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_source_cron_edit_dialog.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5680b339-3ee6-4e7d-b334-a1a2e9af21dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5680b339-3ee6-4e7d-b334-a1a2e9af21dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

