### PR TITLE
Add event city/country geocoding and explore card location

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2310,11 +2310,39 @@ async function reverseGeocodeAddress(address, apiKey) {
       response.results &&
       response.results.length > 0
     ) {
-      const location = response.results[0].geometry.location;
+      const topResult = response.results[0];
+      const location = topResult.geometry.location;
+      let city = null;
+      let countryCode = null;
+      if (Array.isArray(topResult.address_components)) {
+        const components = topResult.address_components;
+        const countryComp = components.find(
+            (c) => c.types && c.types.includes("country"),
+        );
+        if (countryComp && countryComp.short_name) {
+          countryCode = countryComp.short_name;
+        }
+        const cityTypesPriority = [
+          "locality",
+          "postal_town",
+          "administrative_area_level_2",
+          "administrative_area_level_1",
+        ];
+        for (const t of cityTypesPriority) {
+          const comp = components.find((c) => c.types && c.types.includes(t));
+          if (comp && comp.long_name) {
+            city = comp.long_name;
+            break;
+          }
+        }
+      }
       return {
         success: true,
         latitude: location.lat,
         longitude: location.lng,
+        city,
+        countryCode,
+        formattedAddress: topResult.formatted_address || null,
       };
     } else {
       logger.warn("mapsGeocode.addressToCoordsNonOk", {
@@ -4024,8 +4052,8 @@ function downloadTextFromUrl(url, redirectCount = 0) {
  * @param {string|null|undefined} address
  * @param {Object} options
  * @param {string=} options.googleMapsApiKey
- * @param {Map<string, {latitude: number, longitude: number}|null>=} options.geocodeCache
- * @return {Promise<{latitude: number, longitude: number}|null>}
+ * @param {Map<string, {latitude: number, longitude: number, city: string|null, countryCode: string|null, address: string|null}|null>=} options.geocodeCache
+ * @return {Promise<{latitude: number, longitude: number, city: string|null, countryCode: string|null, address: string|null}|null>}
  */
 async function geocodeExternalEventAddress(address, options = {}) {
   const normalizedAddress = typeof address === "string" ? address.trim() : "";
@@ -4052,9 +4080,21 @@ async function geocodeExternalEventAddress(address, options = {}) {
       Number.isFinite(geocodeResult.latitude) &&
       Number.isFinite(geocodeResult.longitude);
 
-  const coordinates = hasValidCoordinates ? {
+  const geocodedLocation = hasValidCoordinates ? {
     latitude: geocodeResult.latitude,
     longitude: geocodeResult.longitude,
+    city: typeof geocodeResult.city === "string" &&
+      geocodeResult.city.trim().length > 0 ?
+      geocodeResult.city.trim() :
+      null,
+    countryCode: typeof geocodeResult.countryCode === "string" &&
+      geocodeResult.countryCode.trim().length > 0 ?
+      geocodeResult.countryCode.trim().toUpperCase() :
+      null,
+    address: typeof geocodeResult.formattedAddress === "string" &&
+      geocodeResult.formattedAddress.trim().length > 0 ?
+      geocodeResult.formattedAddress.trim() :
+      null,
   } : null;
   if (!hasValidCoordinates) {
     logger.warn("externalEventGeocode.noCoordinatesFromMaps", {
@@ -4064,8 +4104,8 @@ async function geocodeExternalEventAddress(address, options = {}) {
       geocodeError: geocodeResult?.error || null,
     });
   }
-  if (geocodeCache instanceof Map) geocodeCache.set(cacheKey, coordinates);
-  return coordinates;
+  if (geocodeCache instanceof Map) geocodeCache.set(cacheKey, geocodedLocation);
+  return geocodedLocation;
 }
 
 /**
@@ -4073,7 +4113,7 @@ async function geocodeExternalEventAddress(address, options = {}) {
  * @param {Object} parsedEvent
  * @param {Object=} options
  * @param {string=} options.googleMapsApiKey
- * @param {Map<string, {latitude: number, longitude: number}|null>=} options.geocodeCache
+ * @param {Map<string, {latitude: number, longitude: number, city: string|null, countryCode: string|null, address: string|null}|null>=} options.geocodeCache
  * @return {Promise<Object>}
  */
 async function buildExternalEventCreateData(parsedEvent, options = {}) {
@@ -4103,13 +4143,20 @@ async function buildExternalEventCreateData(parsedEvent, options = {}) {
   }
 
   if (shouldGeocodeExternalEventAddress(null, parsedEvent)) {
-    const coordinates = await geocodeExternalEventAddress(
+    const geocodedLocation = await geocodeExternalEventAddress(
         parsedEvent.address,
         options,
     );
-    if (coordinates) {
-      createData.latitude = coordinates.latitude;
-      createData.longitude = coordinates.longitude;
+    if (geocodedLocation) {
+      createData.latitude = geocodedLocation.latitude;
+      createData.longitude = geocodedLocation.longitude;
+      if (geocodedLocation.city) createData.city = geocodedLocation.city;
+      if (geocodedLocation.countryCode) {
+        createData.countryCode = geocodedLocation.countryCode;
+      }
+      if (!createData.address && geocodedLocation.address) {
+        createData.address = geocodedLocation.address;
+      }
     }
   }
 
@@ -4122,7 +4169,7 @@ async function buildExternalEventCreateData(parsedEvent, options = {}) {
  * @param {Object} existingData
  * @param {Object=} options
  * @param {string=} options.googleMapsApiKey
- * @param {Map<string, {latitude: number, longitude: number}|null>=} options.geocodeCache
+ * @param {Map<string, {latitude: number, longitude: number, city: string|null, countryCode: string|null, address: string|null}|null>=} options.geocodeCache
  * @return {Promise<Object>}
  */
 async function buildExternalEventChangedUpdate(
@@ -4156,28 +4203,46 @@ async function buildExternalEventChangedUpdate(
 
   if (addressChanged) {
     if (shouldGeocodeExternalEventAddress(existingData, parsedEvent)) {
-      const coordinates = await geocodeExternalEventAddress(
+      const geocodedLocation = await geocodeExternalEventAddress(
           parsedEvent.address,
           options,
       );
-      updateData.latitude = coordinates ?
-        coordinates.latitude :
+      updateData.latitude = geocodedLocation ?
+        geocodedLocation.latitude :
         FieldValue.delete();
-      updateData.longitude = coordinates ?
-        coordinates.longitude :
+      updateData.longitude = geocodedLocation ?
+        geocodedLocation.longitude :
         FieldValue.delete();
+      updateData.city = geocodedLocation && geocodedLocation.city ?
+        geocodedLocation.city :
+        FieldValue.delete();
+      updateData.countryCode = geocodedLocation && geocodedLocation.countryCode ?
+        geocodedLocation.countryCode :
+        FieldValue.delete();
+      if (geocodedLocation && geocodedLocation.address) {
+        updateData.address = geocodedLocation.address;
+      }
     } else {
       updateData.latitude = FieldValue.delete();
       updateData.longitude = FieldValue.delete();
+      updateData.city = FieldValue.delete();
+      updateData.countryCode = FieldValue.delete();
     }
   } else if (shouldGeocodeExternalEventAddress(existingData, parsedEvent)) {
-    const coordinates = await geocodeExternalEventAddress(
+    const geocodedLocation = await geocodeExternalEventAddress(
         parsedEvent.address,
         options,
     );
-    if (coordinates) {
-      updateData.latitude = coordinates.latitude;
-      updateData.longitude = coordinates.longitude;
+    if (geocodedLocation) {
+      updateData.latitude = geocodedLocation.latitude;
+      updateData.longitude = geocodedLocation.longitude;
+      if (geocodedLocation.city) updateData.city = geocodedLocation.city;
+      if (geocodedLocation.countryCode) {
+        updateData.countryCode = geocodedLocation.countryCode;
+      }
+      if (!parsedEvent.address && geocodedLocation.address) {
+        updateData.address = geocodedLocation.address;
+      }
     }
   }
 
@@ -4294,17 +4359,24 @@ async function syncExternalEventSource(sourceDoc) {
     } else {
       let wroteCoords = false;
       if (shouldGeocodeExternalEventAddress(existing.data, parsedEvent)) {
-        const coordinates = await geocodeExternalEventAddress(
+        const geocodedLocation = await geocodeExternalEventAddress(
             parsedEvent.address,
             externalEventGeocodeOptions,
         );
-        if (coordinates) {
-          batch.update(existing.ref, {
-            latitude: coordinates.latitude,
-            longitude: coordinates.longitude,
+        if (geocodedLocation) {
+          const coordinateBackfillUpdate = {
+            latitude: geocodedLocation.latitude,
+            longitude: geocodedLocation.longitude,
             updatedAt: FieldValue.serverTimestamp(),
             externalSyncLastSeenAt: FieldValue.serverTimestamp(),
-          });
+          };
+          if (geocodedLocation.city) {
+            coordinateBackfillUpdate.city = geocodedLocation.city;
+          }
+          if (geocodedLocation.countryCode) {
+            coordinateBackfillUpdate.countryCode = geocodedLocation.countryCode;
+          }
+          batch.update(existing.ref, coordinateBackfillUpdate);
           wroteCoords = true;
           stats.coordinatesBackfilled += 1;
         }

--- a/functions/lib/event-map-pins.js
+++ b/functions/lib/event-map-pins.js
@@ -173,6 +173,20 @@ function pickEventCardFields(eventData) {
     fields.imageUrls = imageUrls;
   }
 
+  const city = typeof eventData.city === "string" ?
+    eventData.city.trim() :
+    "";
+  if (city.length > 0) {
+    fields.city = city;
+  }
+
+  const countryCode = typeof eventData.countryCode === "string" ?
+    eventData.countryCode.trim().toUpperCase() :
+    "";
+  if (countryCode.length > 0) {
+    fields.countryCode = countryCode;
+  }
+
   return fields;
 }
 

--- a/functions/lib/events-in-bounds.js
+++ b/functions/lib/events-in-bounds.js
@@ -57,6 +57,18 @@ function normalizePin(docId, data) {
     pin.description = description;
   }
 
+  const city = typeof data.city === "string" ? data.city.trim() : "";
+  if (city.length > 0) {
+    pin.city = city;
+  }
+
+  const countryCode = typeof data.countryCode === "string" ?
+    data.countryCode.trim().toUpperCase() :
+    "";
+  if (countryCode.length > 0) {
+    pin.countryCode = countryCode;
+  }
+
   const imageUrls = normalizeImageUrls(data.imageUrls);
   if (imageUrls.length > 0) {
     pin.imageUrls = imageUrls;
@@ -87,7 +99,13 @@ function pinNeedsCardFieldsEnrichment(pin) {
     pin.description.trim() :
     "";
   const missingDescription = description.length === 0;
-  return missingImages || missingDescription;
+  const city = typeof pin.city === "string" ? pin.city.trim() : "";
+  const countryCode = typeof pin.countryCode === "string" ?
+    pin.countryCode.trim() :
+    "";
+  const missingCity = city.length === 0;
+  const missingCountryCode = countryCode.length === 0;
+  return missingImages || missingDescription || missingCity || missingCountryCode;
 }
 
 /**
@@ -121,10 +139,23 @@ async function enrichPinsWithEventCardFields(db, pins) {
       const description = typeof cardFields.description === "string" ?
         cardFields.description.trim() :
         "";
-      if (urls.length === 0 && description.length === 0) continue;
+      const city = typeof cardFields.city === "string" ?
+        cardFields.city.trim() :
+        "";
+      const countryCode = typeof cardFields.countryCode === "string" ?
+        cardFields.countryCode.trim().toUpperCase() :
+        "";
+      if (urls.length === 0 &&
+          description.length === 0 &&
+          city.length === 0 &&
+          countryCode.length === 0) {
+        continue;
+      }
       cardFieldsByEventId.set(snap.id, {
         imageUrls: urls,
         description: description.length > 0 ? description : undefined,
+        city: city.length > 0 ? city : undefined,
+        countryCode: countryCode.length > 0 ? countryCode : undefined,
       });
     }
   }
@@ -146,6 +177,16 @@ async function enrichPinsWithEventCardFields(db, pins) {
       "";
     if (pinDescription.length === 0 && fields.description) {
       updated.description = fields.description;
+    }
+    const pinCity = typeof pin.city === "string" ? pin.city.trim() : "";
+    if (pinCity.length === 0 && fields.city) {
+      updated.city = fields.city;
+    }
+    const pinCountryCode = typeof pin.countryCode === "string" ?
+      pin.countryCode.trim() :
+      "";
+    if (pinCountryCode.length === 0 && fields.countryCode) {
+      updated.countryCode = fields.countryCode;
     }
     return updated;
   });

--- a/functions/test/event-map-pins.test.js
+++ b/functions/test/event-map-pins.test.js
@@ -114,6 +114,8 @@ describe("event-map-pins helpers", () => {
         title: "Jam",
         description: "Community jam in the park.",
         imageUrls: ["https://example.com/events/jam.jpg"],
+        city: "Rotterdam",
+        countryCode: "nl",
         startAt: futureStart,
         endAt: futureEnd,
         latitude: 51.0,
@@ -130,6 +132,8 @@ describe("event-map-pins helpers", () => {
       expect(pins[0].data.imageUrls).toEqual(
           ["https://example.com/events/jam.jpg"],
       );
+      expect(pins[0].data.city).toBe("Rotterdam");
+      expect(pins[0].data.countryCode).toBe("NL");
     });
 
     it("skips spots without valid coordinates", () => {

--- a/functions/test/events-in-bounds.test.js
+++ b/functions/test/events-in-bounds.test.js
@@ -45,6 +45,8 @@ describe("events-in-bounds helpers", () => {
         title: " Jam ",
         startAt: futureStart,
         endAt: futureEnd,
+        city: "Utrecht",
+        countryCode: "nl",
       });
       expect(pin).toEqual({
         id: "evt1_venue",
@@ -55,6 +57,8 @@ describe("events-in-bounds helpers", () => {
         title: "Jam",
         startAt: futureStart.toISOString(),
         endAt: futureEnd.toISOString(),
+        city: "Utrecht",
+        countryCode: "NL",
       });
     });
 
@@ -175,6 +179,36 @@ describe("events-in-bounds helpers", () => {
       expect(enriched[0].description).toBe("Community jam in the park.");
     });
 
+    it("fills missing city and countryCode from event documents", async () => {
+      const db = {
+        collection: (name) => ({
+          doc: (id) => ({collection: name, id}),
+        }),
+        getAll: jest.fn(async (...refs) => refs.map((ref) => ({
+          id: ref.id,
+          exists: true,
+          data: () => ({
+            city: "Ghent",
+            countryCode: "be",
+          }),
+        }))),
+      };
+
+      const pins = [{
+        id: "evt1_venue",
+        eventId: "evt1",
+        kind: "venue",
+        latitude: 1,
+        longitude: 2,
+        title: "Jam",
+        startAt: futureStart.toISOString(),
+      }];
+
+      const enriched = await enrichPinsWithEventCardFields(db, pins);
+      expect(enriched[0].city).toBe("Ghent");
+      expect(enriched[0].countryCode).toBe("BE");
+    });
+
     it("leaves pins unchanged when they already have card fields", async () => {
       const db = {getAll: jest.fn()};
       const pins = [{
@@ -182,6 +216,8 @@ describe("events-in-bounds helpers", () => {
         eventId: "evt1",
         imageUrls: ["https://example.com/a.jpg"],
         description: "Already here",
+        city: "Paris",
+        countryCode: "FR",
       }];
       const enriched = await enrichPinsWithEventCardFields(db, pins);
       expect(enriched).toEqual(pins);

--- a/lib/models/event_map_pin.dart
+++ b/lib/models/event_map_pin.dart
@@ -15,6 +15,8 @@ class EventMapPin {
   final String? spotId;
   final String? description;
   final List<String> imageUrls;
+  final String? city;
+  final String? countryCode;
 
   const EventMapPin({
     required this.id,
@@ -28,6 +30,8 @@ class EventMapPin {
     this.spotId,
     this.description,
     this.imageUrls = const [],
+    this.city,
+    this.countryCode,
   });
 
   factory EventMapPin.fromCallableMap(Map<String, dynamic> data) {
@@ -52,6 +56,8 @@ class EventMapPin {
       imageUrls: data['imageUrls'] is List
           ? List<String>.from(data['imageUrls'])
           : const [],
+      city: data['city'] as String?,
+      countryCode: data['countryCode'] as String?,
     );
   }
 
@@ -82,6 +88,8 @@ class EventMapPin {
       imageUrls: data['imageUrls'] is List
           ? List<String>.from(data['imageUrls'])
           : const [],
+      city: data['city'] as String?,
+      countryCode: data['countryCode'] as String?,
     );
   }
 }

--- a/lib/models/parkour_event.dart
+++ b/lib/models/parkour_event.dart
@@ -11,6 +11,8 @@ class ParkourEvent {
   final double? latitude;
   final double? longitude;
   final String? address;
+  final String? city;
+  final String? countryCode;
   final List<String> spotIds;
   final List<String> spotListIds;
   final String? createdBy;
@@ -23,8 +25,10 @@ class ParkourEvent {
   final String? externalEventKey;
   final DateTime? externalSyncLastSeenAt;
   final DateTime? externalSyncLastChangedAt;
+
   /// When set, this event is a duplicate of the canonical native event [duplicateOf].
   final String? duplicateOf;
+
   /// Whether this event was created via "Create native event" from an external import.
   final bool createdFromCreateNative;
 
@@ -39,6 +43,8 @@ class ParkourEvent {
     this.latitude,
     this.longitude,
     this.address,
+    this.city,
+    this.countryCode,
     this.spotIds = const <String>[],
     this.spotListIds = const <String>[],
     this.createdBy,
@@ -76,6 +82,8 @@ class ParkourEvent {
       latitude: (data['latitude'] as num?)?.toDouble(),
       longitude: (data['longitude'] as num?)?.toDouble(),
       address: data['address'] as String?,
+      city: data['city'] as String?,
+      countryCode: data['countryCode'] as String?,
       spotIds: data['spotIds'] is List
           ? List<String>.from(data['spotIds'])
           : const <String>[],
@@ -127,6 +135,8 @@ class ParkourEvent {
       latitude: (data['latitude'] as num?)?.toDouble(),
       longitude: (data['longitude'] as num?)?.toDouble(),
       address: data['address'] as String?,
+      city: data['city'] as String?,
+      countryCode: data['countryCode'] as String?,
       spotIds: data['spotIds'] is List
           ? List<String>.from(data['spotIds'])
           : const <String>[],
@@ -162,6 +172,9 @@ class ParkourEvent {
       if (longitude != null) 'longitude': longitude,
       if (address != null && address!.trim().isNotEmpty)
         'address': address!.trim(),
+      if (city != null && city!.trim().isNotEmpty) 'city': city!.trim(),
+      if (countryCode != null && countryCode!.trim().isNotEmpty)
+        'countryCode': countryCode!.trim(),
       'spotIds': spotIds,
       'spotListIds': spotListIds,
       if (createdBy != null) 'createdBy': createdBy,
@@ -199,6 +212,8 @@ class ParkourEvent {
     Object? latitude = _unset,
     Object? longitude = _unset,
     Object? address = _unset,
+    Object? city = _unset,
+    Object? countryCode = _unset,
     List<String>? spotIds,
     List<String>? spotListIds,
     Object? createdBy = _unset,
@@ -231,6 +246,10 @@ class ParkourEvent {
           ? this.longitude
           : longitude as double?,
       address: identical(address, _unset) ? this.address : address as String?,
+      city: identical(city, _unset) ? this.city : city as String?,
+      countryCode: identical(countryCode, _unset)
+          ? this.countryCode
+          : countryCode as String?,
       spotIds: spotIds ?? this.spotIds,
       spotListIds: spotListIds ?? this.spotListIds,
       createdBy: identical(createdBy, _unset)

--- a/lib/screens/admin/admin_event_edit_screen.dart
+++ b/lib/screens/admin/admin_event_edit_screen.dart
@@ -46,6 +46,8 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
   bool _isSubmitting = false;
   bool _isGeocoding = false;
   String? _formError;
+  String? _currentCity;
+  String? _currentCountryCode;
   final List<Spot> _linkedSpots = <Spot>[];
   final List<SpotList> _linkedLists = <SpotList>[];
   final List<Uint8List?> _selectedImageBytes = <Uint8List?>[];
@@ -109,6 +111,8 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
         _longitudeController.text = event.longitude.toString();
       }
       _addressController.text = event.address ?? '';
+      _currentCity = event.city;
+      _currentCountryCode = event.countryCode;
       _startAt = event.startAt.toUtc();
       _endAt = event.endAt?.toUtc();
       _linkedSpots
@@ -313,18 +317,23 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       if (coords == null) {
         setState(() {
           _formError =
-              geocoding.error ?? 'Unable to locate coordinates for this address';
+              geocoding.error ??
+              'Unable to locate coordinates for this address';
         });
         return false;
       }
       final latitude = coords['latitude'];
       final longitude = coords['longitude'];
       if (latitude == null || longitude == null) {
-        setState(() => _formError = 'Unable to locate coordinates for this address');
+        setState(
+          () => _formError = 'Unable to locate coordinates for this address',
+        );
         return false;
       }
       _latitudeController.text = latitude.toString();
       _longitudeController.text = longitude.toString();
+      _currentCity = null;
+      _currentCountryCode = null;
       return true;
     } catch (e) {
       if (!mounted) return false;
@@ -342,7 +351,11 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
     final hasLongitudeText = lngRaw.isNotEmpty;
     final hasAddress = _addressController.text.trim().isNotEmpty;
 
-    if (!hasLatitudeText && !hasLongitudeText) return true;
+    if (!hasLatitudeText && !hasLongitudeText) {
+      _currentCity = null;
+      _currentCountryCode = null;
+      return true;
+    }
     if (hasLatitudeText != hasLongitudeText) {
       setState(() => _formError = 'Both latitude and longitude are required');
       return false;
@@ -350,20 +363,23 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
     final latitude = double.tryParse(latRaw);
     final longitude = double.tryParse(lngRaw);
     if (latitude == null || longitude == null) {
-      setState(() => _formError = 'Latitude and longitude must be valid numbers');
+      setState(
+        () => _formError = 'Latitude and longitude must be valid numbers',
+      );
       return false;
     }
-    if (hasAddress && !force) return true;
+    final hasCity = _currentCity?.trim().isNotEmpty == true;
+    final hasCountryCode = _currentCountryCode?.trim().isNotEmpty == true;
+    if (hasAddress && hasCity && hasCountryCode && !force) return true;
 
     setState(() {
       _isGeocoding = true;
       _formError = null;
     });
     try {
-      final details = await context.read<GeocodingService>().geocodeCoordinatesDetails(
-        latitude,
-        longitude,
-      );
+      final details = await context
+          .read<GeocodingService>()
+          .geocodeCoordinatesDetails(latitude, longitude);
       final resolvedAddress = details['address']?.trim();
       if (!mounted) return false;
       if (resolvedAddress == null || resolvedAddress.isEmpty) {
@@ -371,6 +387,8 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
         return false;
       }
       _addressController.text = resolvedAddress;
+      _currentCity = details['city']?.trim();
+      _currentCountryCode = details['countryCode']?.trim().toUpperCase();
       return true;
     } catch (e) {
       if (!mounted) return false;
@@ -439,6 +457,8 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       latitude: double.tryParse(_latitudeController.text.trim()),
       longitude: double.tryParse(_longitudeController.text.trim()),
       address: _addressController.text.trim(),
+      city: _currentCity,
+      countryCode: _currentCountryCode,
       spotIds: _linkedSpots.map((s) => s.id!).toList(),
       spotListIds: _linkedLists.map((l) => l.id!).toList(),
     );
@@ -533,13 +553,18 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
     if (!isStaff) {
       return Scaffold(
         appBar: AppBar(title: Text(l10n.adminEventEditTitle)),
-        body: const Center(child: Text('Moderator or administrator access required')),
+        body: const Center(
+          child: Text('Moderator or administrator access required'),
+        ),
       );
     }
 
     final isModeratorOnly = auth.isModerator && !auth.isAdmin;
     final isExternalBlocked =
-        !_isLoading && _event != null && !_event!.isNativeEvent && isModeratorOnly;
+        !_isLoading &&
+        _event != null &&
+        !_event!.isNativeEvent &&
+        isModeratorOnly;
 
     return Scaffold(
       appBar: AppBar(
@@ -562,10 +587,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                 children: [
                   if (!_event!.isNativeEvent && auth.isAdmin) ...[
                     MaterialBanner(
-                      backgroundColor: Theme.of(context)
-                          .colorScheme
-                          .tertiaryContainer
-                          .withValues(alpha: 0.5),
+                      backgroundColor: Theme.of(
+                        context,
+                      ).colorScheme.tertiaryContainer.withValues(alpha: 0.5),
                       leading: const Icon(Icons.sync),
                       content: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -588,8 +612,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                       labelText: 'Title',
                       border: OutlineInputBorder(),
                     ),
-                    validator: (v) =>
-                        v == null || v.trim().isEmpty ? 'Title is required' : null,
+                    validator: (v) => v == null || v.trim().isEmpty
+                        ? 'Title is required'
+                        : null,
                   ),
                   const SizedBox(height: 12),
                   TextFormField(
@@ -653,7 +678,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                             ? const SizedBox(
                                 width: 16,
                                 height: 16,
-                                child: CircularProgressIndicator(strokeWidth: 2),
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
                               )
                             : const Icon(Icons.pin_drop_outlined),
                         label: const Text('To address'),
@@ -679,12 +706,16 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                       FilledButton.tonalIcon(
                         onPressed: (_isSubmitting || _isGeocoding)
                             ? null
-                            : () => _tryReverseGeocodeAddressIfNeeded(force: true),
+                            : () => _tryReverseGeocodeAddressIfNeeded(
+                                force: true,
+                              ),
                         icon: _isGeocoding
                             ? const SizedBox(
                                 width: 16,
                                 height: 16,
-                                child: CircularProgressIndicator(strokeWidth: 2),
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
                               )
                             : const Icon(Icons.location_searching_outlined),
                         label: const Text('To coords'),
@@ -719,13 +750,17 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                     label: 'End (UTC, optional)',
                     value: _endAt,
                     onPick: _pickEndAt,
-                    onClear: _endAt == null ? null : () => setState(() => _endAt = null),
+                    onClear: _endAt == null
+                        ? null
+                        : () => setState(() => _endAt = null),
                   ),
                   if (_formError != null) ...[
                     const SizedBox(height: 16),
                     Text(
                       _formError!,
-                      style: TextStyle(color: Theme.of(context).colorScheme.error),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
                     ),
                   ],
                   const SizedBox(height: 24),
@@ -762,7 +797,10 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
         ),
         const SizedBox(height: 8),
         if (_linkedSpots.isEmpty)
-          Text('No spots selected', style: Theme.of(context).textTheme.bodySmall)
+          Text(
+            'No spots selected',
+            style: Theme.of(context).textTheme.bodySmall,
+          )
         else
           Wrap(
             spacing: 8,
@@ -774,7 +812,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                     onDeleted: _isSubmitting
                         ? null
                         : () => setState(
-                            () => _linkedSpots.removeWhere((s) => s.id == spot.id),
+                            () => _linkedSpots.removeWhere(
+                              (s) => s.id == spot.id,
+                            ),
                           ),
                   ),
                 )
@@ -819,7 +859,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                     onDeleted: _isSubmitting
                         ? null
                         : () => setState(
-                            () => _linkedLists.removeWhere((l) => l.id == list.id),
+                            () => _linkedLists.removeWhere(
+                              (l) => l.id == list.id,
+                            ),
                           ),
                   ),
                 )

--- a/lib/screens/admin/admin_event_edit_screen.dart
+++ b/lib/screens/admin/admin_event_edit_screen.dart
@@ -350,6 +350,7 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
     final hasLatitudeText = latRaw.isNotEmpty;
     final hasLongitudeText = lngRaw.isNotEmpty;
     final hasAddress = _addressController.text.trim().isNotEmpty;
+    final shouldRequireGeocodeSuccess = force || !hasAddress;
 
     if (!hasLatitudeText && !hasLongitudeText) {
       _currentCity = null;
@@ -383,6 +384,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       final resolvedAddress = details['address']?.trim();
       if (!mounted) return false;
       if (resolvedAddress == null || resolvedAddress.isEmpty) {
+        if (!shouldRequireGeocodeSuccess) {
+          return true;
+        }
         setState(() => _formError = 'Unable to geocode these coordinates');
         return false;
       }
@@ -392,6 +396,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       return true;
     } catch (e) {
       if (!mounted) return false;
+      if (!shouldRequireGeocodeSuccess) {
+        return true;
+      }
       setState(() => _formError = 'Failed to geocode coordinates: $e');
       return false;
     } finally {

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -962,6 +962,7 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
     final hasLatitudeText = latRaw.isNotEmpty;
     final hasLongitudeText = lngRaw.isNotEmpty;
     final hasAddress = _addressController.text.trim().isNotEmpty;
+    final shouldRequireGeocodeSuccess = force || !hasAddress;
 
     if (!hasLatitudeText && !hasLongitudeText) {
       _currentCity = null;
@@ -1013,6 +1014,9 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       final resolvedAddress = details['address']?.trim();
       if (!mounted) return false;
       if (resolvedAddress == null || resolvedAddress.isEmpty) {
+        if (!shouldRequireGeocodeSuccess) {
+          return true;
+        }
         setState(() {
           _formError = 'Unable to geocode these coordinates';
         });
@@ -1027,6 +1031,9 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       return true;
     } catch (e) {
       if (!mounted) return false;
+      if (!shouldRequireGeocodeSuccess) {
+        return true;
+      }
       setState(() {
         _formError = 'Failed to geocode coordinates: $e';
       });

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -172,9 +172,7 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
     );
 
     try {
-      final result = await eventsService.backfillEventMapPins(
-        eventId: eventId,
-      );
+      final result = await eventsService.backfillEventMapPins(eventId: eventId);
       progressNavigator.pop();
       if (!mounted) return;
 
@@ -231,6 +229,8 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
               double? latitude,
               double? longitude,
               String? address,
+              String? city,
+              String? countryCode,
               required List<String> spotIds,
               List<String> spotListIds = const <String>[],
             }) async {
@@ -246,6 +246,8 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
                 latitude: latitude,
                 longitude: longitude,
                 address: address,
+                city: city,
+                countryCode: countryCode,
                 spotIds: spotIds,
                 spotListIds: spotListIds,
                 createdBy: createdBy,
@@ -412,8 +414,7 @@ class _EventCard extends StatelessWidget {
     final sourceName = event.eventSourceName?.trim();
     final hasSource = sourceName != null && sourceName.isNotEmpty;
     final duplicateOfId = event.duplicateOf?.trim();
-    final hasDuplicateLink =
-        duplicateOfId != null && duplicateOfId.isNotEmpty;
+    final hasDuplicateLink = duplicateOfId != null && duplicateOfId.isNotEmpty;
     final openEventPage = event.id == null
         ? null
         : () => context.push('/event/${event.id}');
@@ -704,9 +705,8 @@ class _EventDuplicateChipState extends State<_EventDuplicateChip> {
                     Text(
                       widget.duplicateOfLabel,
                       style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSecondaryContainer.withValues(
-                          alpha: 0.8,
-                        ),
+                        color: theme.colorScheme.onSecondaryContainer
+                            .withValues(alpha: 0.8),
                       ),
                     ),
                     Text(
@@ -773,6 +773,8 @@ class _CreateEventDialog extends StatefulWidget {
     double? latitude,
     double? longitude,
     String? address,
+    String? city,
+    String? countryCode,
     required List<String> spotIds,
     List<String> spotListIds,
   })
@@ -797,6 +799,8 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   bool _isSubmitting = false;
   bool _isGeocoding = false;
   String? _formError;
+  String? _currentCity;
+  String? _currentCountryCode;
   final List<Spot> _linkedSpots = <Spot>[];
   final List<SpotList> _linkedLists = <SpotList>[];
   final List<Uint8List> _selectedImageBytes = <Uint8List>[];
@@ -960,6 +964,8 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
     final hasAddress = _addressController.text.trim().isNotEmpty;
 
     if (!hasLatitudeText && !hasLongitudeText) {
+      _currentCity = null;
+      _currentCountryCode = null;
       return true;
     }
     if (hasLatitudeText != hasLongitudeText) {
@@ -988,7 +994,9 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       });
       return false;
     }
-    if (hasAddress && !force) {
+    final hasCity = _currentCity?.trim().isNotEmpty == true;
+    final hasCountryCode = _currentCountryCode?.trim().isNotEmpty == true;
+    if (hasAddress && hasCity && hasCountryCode && !force) {
       return true;
     }
 
@@ -1012,6 +1020,8 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       }
       _addressController.text = resolvedAddress;
       setState(() {
+        _currentCity = details['city']?.trim();
+        _currentCountryCode = details['countryCode']?.trim().toUpperCase();
         _formError = null;
       });
       return true;
@@ -1075,6 +1085,8 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       latitude: double.tryParse(_latitudeController.text.trim()),
       longitude: double.tryParse(_longitudeController.text.trim()),
       address: _addressController.text.trim(),
+      city: _currentCity,
+      countryCode: _currentCountryCode,
       spotIds: _linkedSpots.map((spot) => spot.id!).toList(),
       spotListIds: _linkedLists.map((list) => list.id!).toList(),
     );

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -12,9 +12,9 @@ class AdminEventsService extends ChangeNotifier {
   AdminEventsService({
     FirebaseFirestore? firestore,
     FirebaseFunctions? functions,
-  })  : _firestore = firestore ?? FirebaseFirestore.instance,
-        _functions =
-            functions ?? FirebaseFunctions.instanceFor(region: 'europe-west1');
+  }) : _firestore = firestore ?? FirebaseFirestore.instance,
+       _functions =
+           functions ?? FirebaseFunctions.instanceFor(region: 'europe-west1');
 
   final FirebaseFirestore _firestore;
   final FirebaseFunctions _functions;
@@ -106,6 +106,8 @@ class AdminEventsService extends ChangeNotifier {
     double? latitude,
     double? longitude,
     String? address,
+    String? city,
+    String? countryCode,
     required List<String> spotIds,
     List<String> spotListIds = const <String>[],
     required String createdBy,
@@ -122,6 +124,8 @@ class AdminEventsService extends ChangeNotifier {
       endAt: endAt,
       latitude: latitude,
       longitude: longitude,
+      city: city,
+      countryCode: countryCode,
     );
     if (normalized.error != null) {
       _error = normalized.error;
@@ -153,6 +157,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: normalized.latitude,
         longitude: normalized.longitude,
         address: normalized.address,
+        city: normalized.city,
+        countryCode: normalized.countryCode,
         spotIds: normalized.spotIds,
         spotListIds: normalized.spotListIds,
         createdBy: createdBy,
@@ -198,6 +204,8 @@ class AdminEventsService extends ChangeNotifier {
       endAt: sourceEvent.endAt,
       latitude: sourceEvent.latitude,
       longitude: sourceEvent.longitude,
+      city: sourceEvent.city,
+      countryCode: sourceEvent.countryCode,
     );
     if (normalized.error != null) {
       _error = normalized.error;
@@ -229,6 +237,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: normalized.latitude,
         longitude: normalized.longitude,
         address: normalized.address,
+        city: normalized.city,
+        countryCode: normalized.countryCode,
         spotIds: normalized.spotIds,
         spotListIds: normalized.spotListIds,
         createdBy: createdBy,
@@ -244,7 +254,9 @@ class AdminEventsService extends ChangeNotifier {
       return ref.id;
     } catch (e, st) {
       _error = 'Failed to create native event';
-      debugPrint('AdminEventsService.createNativeEventFromExisting error: $e\n$st');
+      debugPrint(
+        'AdminEventsService.createNativeEventFromExisting error: $e\n$st',
+      );
       notifyListeners();
       return null;
     }
@@ -261,6 +273,8 @@ class AdminEventsService extends ChangeNotifier {
     double? latitude,
     double? longitude,
     String? address,
+    String? city,
+    String? countryCode,
     required List<String> spotIds,
     List<String> spotListIds = const <String>[],
   }) async {
@@ -294,6 +308,8 @@ class AdminEventsService extends ChangeNotifier {
       endAt: endAt,
       latitude: latitude,
       longitude: longitude,
+      city: city,
+      countryCode: countryCode,
     );
     if (normalized.error != null) {
       _error = normalized.error;
@@ -325,6 +341,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: normalized.latitude,
         longitude: normalized.longitude,
         address: normalized.address,
+        city: normalized.city,
+        countryCode: normalized.countryCode,
         spotIds: normalized.spotIds,
         spotListIds: normalized.spotListIds,
         updatedAt: now,
@@ -413,7 +431,8 @@ class AdminEventsService extends ChangeNotifier {
       for (final doc in snapshot.docs) {
         try {
           final event = ParkourEvent.fromFirestore(doc);
-          if (event.duplicateOf != null && event.duplicateOf!.trim().isNotEmpty) {
+          if (event.duplicateOf != null &&
+              event.duplicateOf!.trim().isNotEmpty) {
             continue;
           }
           if (event.startAt.toUtc().isAfter(now)) {
@@ -472,9 +491,12 @@ class AdminEventsService extends ChangeNotifier {
     double? latitude,
     double? longitude,
     String? address,
+    String? city,
+    String? countryCode,
     List<String> spotIds,
     List<String> spotListIds,
-  }) _normalizeEventInput({
+  })
+  _normalizeEventInput({
     required String title,
     String? description,
     List<String>? imageUrls,
@@ -484,6 +506,8 @@ class AdminEventsService extends ChangeNotifier {
     double? latitude,
     double? longitude,
     String? address,
+    String? city,
+    String? countryCode,
     required List<String> spotIds,
     required List<String> spotListIds,
   }) {
@@ -494,6 +518,8 @@ class AdminEventsService extends ChangeNotifier {
         .toList();
     final normalizedWebsiteUrl = websiteUrl?.trim();
     final normalizedAddress = address?.trim();
+    final normalizedCity = city?.trim();
+    final normalizedCountryCode = countryCode?.trim().toUpperCase();
     final normalizedSpotIds = spotIds
         .map((id) => id.trim())
         .where((id) => id.isNotEmpty)
@@ -517,6 +543,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -533,6 +561,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -551,6 +581,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -569,6 +601,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -585,6 +619,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -601,6 +637,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -618,6 +656,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -634,6 +674,8 @@ class AdminEventsService extends ChangeNotifier {
         latitude: null,
         longitude: null,
         address: null,
+        city: null,
+        countryCode: null,
         spotIds: const <String>[],
         spotListIds: const <String>[],
       );
@@ -642,14 +684,22 @@ class AdminEventsService extends ChangeNotifier {
     return (
       error: null,
       title: title.trim(),
-      description: description?.trim().isEmpty == true ? null : description?.trim(),
+      description: description?.trim().isEmpty == true
+          ? null
+          : description?.trim(),
       imageUrls: normalizedImageUrls,
-      websiteUrl: normalizedWebsiteUrl?.isEmpty == true ? null : normalizedWebsiteUrl,
+      websiteUrl: normalizedWebsiteUrl?.isEmpty == true
+          ? null
+          : normalizedWebsiteUrl,
       startAt: startAt.toUtc(),
       endAt: endAt?.toUtc(),
       latitude: latitude,
       longitude: longitude,
       address: normalizedAddress?.isEmpty == true ? null : normalizedAddress,
+      city: normalizedCity?.isEmpty == true ? null : normalizedCity,
+      countryCode: normalizedCountryCode?.isEmpty == true
+          ? null
+          : normalizedCountryCode,
       spotIds: normalizedSpotIds,
       spotListIds: normalizedSpotListIds,
     );
@@ -745,7 +795,8 @@ class AdminEventsService extends ChangeNotifier {
       }
       final origDup = original.duplicateOf?.trim();
       if (origDup != null && origDup.isNotEmpty) {
-        _error = 'Cannot point to an event that is already marked as a duplicate';
+        _error =
+            'Cannot point to an event that is already marked as a duplicate';
         notifyListeners();
         return false;
       }
@@ -813,9 +864,7 @@ class AdminEventsService extends ChangeNotifier {
     try {
       final callable = _functions.httpsCallable(
         'backfillEventMapPins',
-        options: HttpsCallableOptions(
-          timeout: const Duration(minutes: 9),
-        ),
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 9)),
       );
       final result = await callable.call({
         if (eventId != null && eventId.trim().isNotEmpty)

--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
+import 'package:country_flags/country_flags.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models/event_map_pin.dart';
@@ -12,10 +13,7 @@ import '../services/web_share_service.dart';
 import 'no_images_placeholder.dart';
 import 'resized_spot_image.dart';
 
-enum EventCardVariant {
-  list,
-  overlay,
-}
+enum EventCardVariant { list, overlay }
 
 /// Card for an event in Explore, styled like [SpotCard].
 class EventCard extends StatefulWidget {
@@ -80,9 +78,7 @@ class _EventCardState extends State<EventCard> {
 
     return Card(
       elevation: 2,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: InkWell(
         onTap: widget.onTapWithImageIndex != null
             ? () => widget.onTapWithImageIndex!(_currentPage)
@@ -119,9 +115,18 @@ class _EventCardState extends State<EventCard> {
               left: 16,
               right: 16,
               bottom: 12,
-              child: Align(
-                alignment: Alignment.centerRight,
-                child: _buildListActionButtons(context),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  _buildLocationMeta(
+                    context,
+                    flagHeight: 20,
+                    flagWidth: 30,
+                    spacing: 8,
+                  ),
+                  _buildListActionButtons(context),
+                ],
               ),
             ),
           ],
@@ -244,13 +249,59 @@ class _EventCardState extends State<EventCard> {
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
           height: 1.4,
-          fontStyle:
-              description.isEmpty ? FontStyle.italic : FontStyle.normal,
+          fontStyle: description.isEmpty ? FontStyle.italic : FontStyle.normal,
         ),
         maxLines: descriptionMaxLines,
         overflow: TextOverflow.ellipsis,
       ),
+      if (widget.pin.city != null || widget.pin.countryCode != null) ...[
+        const SizedBox(height: 12),
+        _buildLocationMeta(context, flagHeight: 16, flagWidth: 24, spacing: 6),
+      ],
     ];
+  }
+
+  Widget _buildLocationMeta(
+    BuildContext context, {
+    required double flagHeight,
+    required double flagWidth,
+    required double spacing,
+  }) {
+    final city = widget.pin.city?.trim();
+    final countryCode = widget.pin.countryCode?.trim().toUpperCase();
+    if ((city == null || city.isEmpty) &&
+        (countryCode == null || countryCode.isEmpty)) {
+      return const SizedBox.shrink();
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (countryCode != null && countryCode.isNotEmpty)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(2),
+            child: SizedBox(
+              height: flagHeight,
+              width: flagWidth,
+              child: CountryFlag.fromCountryCode(countryCode),
+            ),
+          ),
+        if (countryCode != null &&
+            countryCode.isNotEmpty &&
+            city != null &&
+            city.isNotEmpty)
+          SizedBox(width: spacing),
+        if (city != null && city.isNotEmpty)
+          Text(
+            city,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.7),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+      ],
+    );
   }
 
   Widget _buildImageSection(
@@ -277,9 +328,7 @@ class _EventCardState extends State<EventCard> {
         aspectRatio: 16 / 9,
         child: Container(
           color: Theme.of(context).colorScheme.surfaceContainerHighest,
-          child: Center(
-            child: NoImagesPlaceholder(label: l10n.noImagesYet),
-          ),
+          child: Center(child: NoImagesPlaceholder(label: l10n.noImagesYet)),
         ),
       ),
     );
@@ -461,8 +510,7 @@ class _EventCardState extends State<EventCard> {
       final label = widget.pin.title.trim();
       final text = l10n.spotCardShareClipboardText(label, url);
 
-      final outcome =
-          await WebShareService.tryShareLink(text: label, url: url);
+      final outcome = await WebShareService.tryShareLink(text: label, url: url);
       if (outcome == WebShareOutcome.shared ||
           outcome == WebShareOutcome.cancelled) {
         return;
@@ -510,10 +558,7 @@ class _EventCardState extends State<EventCard> {
 }
 
 /// Centers the map on [pin] (used from Explore locate).
-void locateEventPinOnMap(
-  GoogleMapController? controller,
-  EventMapPin pin,
-) {
+void locateEventPinOnMap(GoogleMapController? controller, EventMapPin pin) {
   controller?.animateCamera(
     CameraUpdate.newLatLng(LatLng(pin.latitude, pin.longitude)),
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- persist `city` and `countryCode` when event geocoding runs (external sync geocoding + admin create/edit geocoding flow)
- add event `city`/`countryCode` to event map pin materialization and stale-pin enrichment payloads
- update Explore `EventCard` (list + overlay) to render flag + city like `SpotCard`
- keep admin event save working when geocoding is unavailable but address is already provided
- add/adjust functions unit tests for pin normalization/enrichment and map-pin write behavior

## Testing
- `npm test -- event-map-pins events-in-bounds`
- `flutter analyze lib/widgets/event_card.dart lib/models/event_map_pin.dart lib/models/parkour_event.dart lib/services/admin_events_service.dart lib/screens/admin/admin_event_edit_screen.dart lib/screens/admin/admin_events_screen.dart`
- `flutter analyze lib/screens/admin/admin_event_edit_screen.dart lib/screens/admin/admin_events_screen.dart`
- Manual validation in running emulator + Flutter web app:
  - created/geocoded an admin event and confirmed save behavior with geocoding fallback
  - validated Explore Events card shows flag + city on-card

## Walkthrough artifacts
[explore_event_card_flag_city_demo.mp4](https://cursor.com/agents/bc-d2e0d1bc-bd5d-49f5-a1af-00d99f48cc3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexplore_event_card_flag_city_demo.mp4)
[Explore event card showing flag and city](https://cursor.com/agents/bc-d2e0d1bc-bd5d-49f5-a1af-00d99f48cc3f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexplore_event_card_flag_city.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2e0d1bc-bd5d-49f5-a1af-00d99f48cc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e0d1bc-bd5d-49f5-a1af-00d99f48cc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

