### PR TITLE
Add timezone-aware and date-only scheduling for parkour events

### DIFF
--- a/functions/lib/event-map-pins.js
+++ b/functions/lib/event-map-pins.js
@@ -154,6 +154,15 @@ function collectLinkedSpotIds(eventData, listsById) {
  */
 function pickEventCardFields(eventData) {
   const fields = {};
+  if (eventData.isDateOnly === true) {
+    fields.isDateOnly = true;
+  }
+  const timeZone = typeof eventData.timeZone === "string" ?
+    eventData.timeZone.trim() :
+    "";
+  if (timeZone.length > 0) {
+    fields.timeZone = timeZone;
+  }
   const description = typeof eventData.description === "string" ?
     eventData.description.trim() :
     "";

--- a/functions/lib/events-in-bounds.js
+++ b/functions/lib/events-in-bounds.js
@@ -44,6 +44,13 @@ function normalizePin(docId, data) {
 
   const endAt = normalizeDate(data.endAt);
   if (endAt) pin.endAt = endAt.toISOString();
+  if (data.isDateOnly === true) {
+    pin.isDateOnly = true;
+  }
+  const timeZone = typeof data.timeZone === "string" ? data.timeZone.trim() : "";
+  if (timeZone.length > 0) {
+    pin.timeZone = timeZone;
+  }
 
   if (kind === "spot") {
     const spotId = typeof data.spotId === "string" ? data.spotId.trim() : "";
@@ -145,10 +152,16 @@ async function enrichPinsWithEventCardFields(db, pins) {
       const countryCode = typeof cardFields.countryCode === "string" ?
         cardFields.countryCode.trim().toUpperCase() :
         "";
+      const timeZone = typeof cardFields.timeZone === "string" ?
+        cardFields.timeZone.trim() :
+        "";
+      const isDateOnly = cardFields.isDateOnly === true;
       if (urls.length === 0 &&
           description.length === 0 &&
           city.length === 0 &&
-          countryCode.length === 0) {
+          countryCode.length === 0 &&
+          timeZone.length === 0 &&
+          !isDateOnly) {
         continue;
       }
       cardFieldsByEventId.set(snap.id, {
@@ -156,6 +169,8 @@ async function enrichPinsWithEventCardFields(db, pins) {
         description: description.length > 0 ? description : undefined,
         city: city.length > 0 ? city : undefined,
         countryCode: countryCode.length > 0 ? countryCode : undefined,
+        timeZone: timeZone.length > 0 ? timeZone : undefined,
+        isDateOnly: isDateOnly || undefined,
       });
     }
   }
@@ -187,6 +202,13 @@ async function enrichPinsWithEventCardFields(db, pins) {
       "";
     if (pinCountryCode.length === 0 && fields.countryCode) {
       updated.countryCode = fields.countryCode;
+    }
+    const pinTimeZone = typeof pin.timeZone === "string" ? pin.timeZone.trim() : "";
+    if (pinTimeZone.length === 0 && fields.timeZone) {
+      updated.timeZone = fields.timeZone;
+    }
+    if (pin.isDateOnly !== true && fields.isDateOnly === true) {
+      updated.isDateOnly = true;
     }
     return updated;
   });

--- a/functions/test/event-map-pins.test.js
+++ b/functions/test/event-map-pins.test.js
@@ -116,6 +116,8 @@ describe("event-map-pins helpers", () => {
         imageUrls: ["https://example.com/events/jam.jpg"],
         city: "Rotterdam",
         countryCode: "nl",
+        isDateOnly: true,
+        timeZone: "Europe/Paris",
         startAt: futureStart,
         endAt: futureEnd,
         latitude: 51.0,
@@ -134,6 +136,8 @@ describe("event-map-pins helpers", () => {
       );
       expect(pins[0].data.city).toBe("Rotterdam");
       expect(pins[0].data.countryCode).toBe("NL");
+      expect(pins[0].data.isDateOnly).toBe(true);
+      expect(pins[0].data.timeZone).toBe("Europe/Paris");
     });
 
     it("skips spots without valid coordinates", () => {

--- a/functions/test/events-in-bounds.test.js
+++ b/functions/test/events-in-bounds.test.js
@@ -45,6 +45,8 @@ describe("events-in-bounds helpers", () => {
         title: " Jam ",
         startAt: futureStart,
         endAt: futureEnd,
+        isDateOnly: true,
+        timeZone: "Europe/Paris",
         city: "Utrecht",
         countryCode: "nl",
       });
@@ -57,6 +59,8 @@ describe("events-in-bounds helpers", () => {
         title: "Jam",
         startAt: futureStart.toISOString(),
         endAt: futureEnd.toISOString(),
+        isDateOnly: true,
+        timeZone: "Europe/Paris",
         city: "Utrecht",
         countryCode: "NL",
       });

--- a/lib/models/event_map_pin.dart
+++ b/lib/models/event_map_pin.dart
@@ -14,6 +14,8 @@ class EventMapPin {
   final String title;
   final DateTime startAt;
   final DateTime? endAt;
+  final bool isDateOnly;
+  final String? timeZone;
   final String? spotId;
   final String? description;
   final List<String> imageUrls;
@@ -29,6 +31,8 @@ class EventMapPin {
     required this.title,
     required this.startAt,
     this.endAt,
+    this.isDateOnly = false,
+    this.timeZone,
     this.spotId,
     this.description,
     this.imageUrls = const [],
@@ -53,6 +57,8 @@ class EventMapPin {
       endAt: data['endAt'] is String
           ? DateTime.parse(data['endAt'] as String)
           : null,
+      isDateOnly: data['isDateOnly'] == true,
+      timeZone: data['timeZone'] as String?,
       spotId: data['spotId'] as String?,
       description: data['description'] as String?,
       imageUrls: data['imageUrls'] is List
@@ -88,6 +94,8 @@ class EventMapPin {
       title: event.title,
       startAt: event.startAt,
       endAt: event.endAt,
+      isDateOnly: event.isDateOnly,
+      timeZone: event.timeZone,
       spotId: event.spotIds.isNotEmpty ? event.spotIds.first : null,
       description: event.description,
       imageUrls: event.imageUrls,
@@ -118,6 +126,8 @@ class EventMapPin {
       title: (data['title'] as String?) ?? 'Event',
       startAt: parseDate(data['startAt']),
       endAt: data['endAt'] != null ? parseDate(data['endAt']) : null,
+      isDateOnly: data['isDateOnly'] == true,
+      timeZone: data['timeZone'] as String?,
       spotId: data['spotId'] as String?,
       description: data['description'] as String?,
       imageUrls: data['imageUrls'] is List

--- a/lib/models/parkour_event.dart
+++ b/lib/models/parkour_event.dart
@@ -8,6 +8,8 @@ class ParkourEvent {
   final String? websiteUrl;
   final DateTime startAt;
   final DateTime? endAt;
+  final bool isDateOnly;
+  final String? timeZone;
   final double? latitude;
   final double? longitude;
   final String? address;
@@ -40,6 +42,8 @@ class ParkourEvent {
     this.websiteUrl,
     required this.startAt,
     this.endAt,
+    this.isDateOnly = false,
+    this.timeZone,
     this.latitude,
     this.longitude,
     this.address,
@@ -79,6 +83,8 @@ class ParkourEvent {
       endAt: data['endAt'] is Timestamp
           ? (data['endAt'] as Timestamp).toDate()
           : null,
+      isDateOnly: data['isDateOnly'] == true,
+      timeZone: data['timeZone'] as String?,
       latitude: (data['latitude'] as num?)?.toDouble(),
       longitude: (data['longitude'] as num?)?.toDouble(),
       address: data['address'] as String?,
@@ -132,6 +138,8 @@ class ParkourEvent {
       websiteUrl: data['websiteUrl'] as String?,
       startAt: parseDate(data['startAt']) ?? DateTime.now().toUtc(),
       endAt: parseDate(data['endAt']),
+      isDateOnly: data['isDateOnly'] == true,
+      timeZone: data['timeZone'] as String?,
       latitude: (data['latitude'] as num?)?.toDouble(),
       longitude: (data['longitude'] as num?)?.toDouble(),
       address: data['address'] as String?,
@@ -168,6 +176,9 @@ class ParkourEvent {
         'websiteUrl': websiteUrl!.trim(),
       'startAt': startAt.toUtc(),
       if (endAt != null) 'endAt': endAt!.toUtc(),
+      if (isDateOnly) 'isDateOnly': true,
+      if (timeZone != null && timeZone!.trim().isNotEmpty)
+        'timeZone': timeZone!.trim(),
       if (latitude != null) 'latitude': latitude,
       if (longitude != null) 'longitude': longitude,
       if (address != null && address!.trim().isNotEmpty)
@@ -209,6 +220,8 @@ class ParkourEvent {
     Object? websiteUrl = _unset,
     DateTime? startAt,
     Object? endAt = _unset,
+    bool? isDateOnly,
+    Object? timeZone = _unset,
     Object? latitude = _unset,
     Object? longitude = _unset,
     Object? address = _unset,
@@ -239,6 +252,10 @@ class ParkourEvent {
           : websiteUrl as String?,
       startAt: startAt ?? this.startAt,
       endAt: identical(endAt, _unset) ? this.endAt : endAt as DateTime?,
+      isDateOnly: isDateOnly ?? this.isDateOnly,
+      timeZone: identical(timeZone, _unset)
+          ? this.timeZone
+          : timeZone as String?,
       latitude: identical(latitude, _unset)
           ? this.latitude
           : latitude as double?,

--- a/lib/screens/admin/admin_event_edit_screen.dart
+++ b/lib/screens/admin/admin_event_edit_screen.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../../l10n/app_localizations.dart';
@@ -15,6 +14,7 @@ import '../../services/auth_service.dart';
 import '../../services/geocoding_service.dart';
 import '../../services/spot_list_service.dart';
 import '../../services/spot_service.dart';
+import '../../utils/event_schedule_utils.dart';
 import '../../utils/image_preparation.dart';
 import '../../widgets/spot_form/image_section.dart';
 import '../../widgets/spot_list_selection_dialog.dart';
@@ -30,6 +30,8 @@ class AdminEventEditScreen extends StatefulWidget {
 }
 
 class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
+  static const String _localTimeZoneValue = '__local__';
+
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _titleController = TextEditingController();
   final TextEditingController _descriptionController = TextEditingController();
@@ -42,6 +44,9 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
   ParkourEvent? _event;
   DateTime _startAt = DateTime.now().toUtc();
   DateTime? _endAt;
+  bool _isDateOnly = false;
+  String _selectedTimeZone = _localTimeZoneValue;
+  late final List<String> _timeZoneOptions;
   bool _isLoading = true;
   bool _isSubmitting = false;
   bool _isGeocoding = false;
@@ -56,6 +61,10 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
   @override
   void initState() {
     super.initState();
+    _timeZoneOptions = <String>[
+      _localTimeZoneValue,
+      ...EventScheduleUtils.availableTimeZoneIds(),
+    ];
     WidgetsBinding.instance.addPostFrameCallback((_) => _loadEvent());
   }
 
@@ -115,6 +124,8 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       _currentCountryCode = event.countryCode;
       _startAt = event.startAt.toUtc();
       _endAt = event.endAt?.toUtc();
+      _isDateOnly = event.isDateOnly;
+      _selectedTimeZone = _selectionForTimeZone(event.timeZone);
       _linkedSpots
         ..clear()
         ..addAll(spots);
@@ -128,8 +139,64 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
     });
   }
 
+  String _selectionForTimeZone(String? timeZone) {
+    final normalized = EventScheduleUtils.normalizeTimeZone(timeZone);
+    return normalized ?? _localTimeZoneValue;
+  }
+
+  String? get _effectiveTimeZone {
+    if (_selectedTimeZone == _localTimeZoneValue) return null;
+    return EventScheduleUtils.normalizeTimeZone(_selectedTimeZone);
+  }
+
+  DateTime _displayInSelectedTimeZone(DateTime value) {
+    return EventScheduleUtils.toDisplayDateTime(
+      value,
+      timeZone: _effectiveTimeZone,
+    );
+  }
+
+  String _timeZoneLabel(String value) {
+    if (value == _localTimeZoneValue) {
+      return 'Viewer local timezone (legacy)';
+    }
+    return EventScheduleUtils.formatTimeZoneLabel(
+      value,
+      referenceUtc: _startAt,
+    );
+  }
+
   Future<void> _pickStartAt() async {
-    final value = await _pickDateTime(context, initial: _startAt);
+    if (_isDateOnly) {
+      final initialDate = _displayInSelectedTimeZone(_startAt);
+      final selectedDate = await showDatePicker(
+        context: context,
+        initialDate: DateTime(
+          initialDate.year,
+          initialDate.month,
+          initialDate.day,
+        ),
+        firstDate: DateTime(2020),
+        lastDate: DateTime(2100),
+      );
+      if (selectedDate == null) return;
+      final value = EventScheduleUtils.dateStartToUtc(
+        selectedDate,
+        timeZone: _effectiveTimeZone,
+      );
+      setState(() {
+        _startAt = value;
+        if (_endAt != null && _endAt!.isBefore(_startAt)) {
+          _endAt = null;
+        }
+      });
+      return;
+    }
+    final value = await _pickDateTime(
+      context,
+      initial: _startAt,
+      timeZone: _effectiveTimeZone,
+    );
     if (value == null) return;
     setState(() {
       _startAt = value.toUtc();
@@ -140,8 +207,33 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
   }
 
   Future<void> _pickEndAt() async {
+    if (_isDateOnly) {
+      final initialDateTime = _displayInSelectedTimeZone(_endAt ?? _startAt);
+      final selectedDate = await showDatePicker(
+        context: context,
+        initialDate: DateTime(
+          initialDateTime.year,
+          initialDateTime.month,
+          initialDateTime.day,
+        ),
+        firstDate: DateTime(2020),
+        lastDate: DateTime(2100),
+      );
+      if (selectedDate == null) return;
+      setState(
+        () => _endAt = EventScheduleUtils.dateEndToUtc(
+          selectedDate,
+          timeZone: _effectiveTimeZone,
+        ),
+      );
+      return;
+    }
     final initial = _endAt ?? _startAt.add(const Duration(hours: 2));
-    final value = await _pickDateTime(context, initial: initial);
+    final value = await _pickDateTime(
+      context,
+      initial: initial,
+      timeZone: _effectiveTimeZone,
+    );
     if (value == null) return;
     setState(() => _endAt = value.toUtc());
   }
@@ -383,8 +475,7 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
           .geocodeCoordinatesDetails(latitude, longitude);
       final resolvedAddress = details['address']?.trim();
       final resolvedCity = details['city']?.trim();
-      final resolvedCountryCode =
-          details['countryCode']?.trim().toUpperCase();
+      final resolvedCountryCode = details['countryCode']?.trim().toUpperCase();
       if (!mounted) return false;
 
       if (force) {
@@ -484,7 +575,23 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
 
     final eventsService = context.read<AdminEventsService>();
     if (!_formKey.currentState!.validate()) return;
-    if (_endAt != null && _endAt!.isBefore(_startAt)) {
+    final timeZone = _effectiveTimeZone;
+    DateTime normalizedStartAt = _startAt;
+    DateTime? normalizedEndAt = _endAt;
+    if (_isDateOnly) {
+      final startDate = _displayInSelectedTimeZone(_startAt);
+      normalizedStartAt = EventScheduleUtils.dateStartToUtc(
+        startDate,
+        timeZone: timeZone,
+      );
+      final endDate = _displayInSelectedTimeZone(_endAt ?? _startAt);
+      normalizedEndAt = EventScheduleUtils.dateEndToUtc(
+        endDate,
+        timeZone: timeZone,
+      );
+    }
+    if (normalizedEndAt != null &&
+        normalizedEndAt.isBefore(normalizedStartAt)) {
       setState(() => _formError = 'End time cannot be before start time');
       return;
     }
@@ -524,8 +631,10 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       description: _descriptionController.text.trim(),
       imageUrls: [..._existingImageUrls, ...uploadedImageUrls],
       websiteUrl: _websiteController.text.trim(),
-      startAt: _startAt,
-      endAt: _endAt,
+      startAt: normalizedStartAt,
+      endAt: normalizedEndAt,
+      isDateOnly: _isDateOnly,
+      timeZone: timeZone,
       latitude: double.tryParse(_latitudeController.text.trim()),
       longitude: double.tryParse(_longitudeController.text.trim()),
       address: _addressController.text.trim(),
@@ -831,15 +940,65 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
                   const SizedBox(height: 16),
                   _buildLinkedListsSection(l10n),
                   const SizedBox(height: 16),
+                  Text(
+                    'Schedule',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<String>(
+                    value: _selectedTimeZone,
+                    decoration: const InputDecoration(
+                      labelText: 'Timezone',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: _timeZoneOptions
+                        .map(
+                          (value) => DropdownMenuItem<String>(
+                            value: value,
+                            child: Text(
+                              _timeZoneLabel(value),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: _isSubmitting
+                        ? null
+                        : (value) {
+                            if (value == null) return;
+                            setState(() => _selectedTimeZone = value);
+                          },
+                  ),
+                  const SizedBox(height: 8),
+                  SwitchListTile.adaptive(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Date only (no times)'),
+                    subtitle: const Text(
+                      'Display this event everywhere without times',
+                    ),
+                    value: _isDateOnly,
+                    onChanged: _isSubmitting
+                        ? null
+                        : (value) {
+                            setState(() => _isDateOnly = value);
+                          },
+                  ),
+                  const SizedBox(height: 8),
                   _AdminEventDateField(
-                    label: 'Start (UTC)',
+                    label: _isDateOnly ? 'Start date' : 'Start date & time',
                     value: _startAt,
+                    isDateOnly: _isDateOnly,
+                    timeZone: _effectiveTimeZone,
                     onPick: _pickStartAt,
                   ),
                   const SizedBox(height: 8),
                   _AdminEventDateField(
-                    label: 'End (UTC, optional)',
+                    label: _isDateOnly
+                        ? 'End date (optional)'
+                        : 'End date & time (optional)',
                     value: _endAt,
+                    isDateOnly: _isDateOnly,
+                    timeZone: _effectiveTimeZone,
                     onPick: _pickEndAt,
                     onClear: _endAt == null
                         ? null
@@ -978,9 +1137,7 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
       ),
       child: Text(
         hasValue ? trimmed : 'Not set',
-        style: hasValue
-            ? null
-            : TextStyle(color: Theme.of(context).hintColor),
+        style: hasValue ? null : TextStyle(color: Theme.of(context).hintColor),
       ),
     );
   }
@@ -988,10 +1145,15 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
   Future<DateTime?> _pickDateTime(
     BuildContext context, {
     required DateTime initial,
+    String? timeZone,
   }) async {
+    final displayInitial = EventScheduleUtils.toDisplayDateTime(
+      initial,
+      timeZone: timeZone,
+    );
     final selectedDate = await showDatePicker(
       context: context,
-      initialDate: initial.toLocal(),
+      initialDate: displayInitial,
       firstDate: DateTime(2020),
       lastDate: DateTime(2100),
     );
@@ -999,17 +1161,20 @@ class _AdminEventEditScreenState extends State<AdminEventEditScreen> {
 
     final selectedTime = await showTimePicker(
       context: context,
-      initialTime: TimeOfDay.fromDateTime(initial.toLocal()),
+      initialTime: TimeOfDay.fromDateTime(displayInitial),
     );
     if (selectedTime == null) return null;
 
-    return DateTime(
-      selectedDate.year,
-      selectedDate.month,
-      selectedDate.day,
-      selectedTime.hour,
-      selectedTime.minute,
-    ).toUtc();
+    return EventScheduleUtils.localDateTimeToUtc(
+      DateTime(
+        selectedDate.year,
+        selectedDate.month,
+        selectedDate.day,
+        selectedTime.hour,
+        selectedTime.minute,
+      ),
+      timeZone: timeZone,
+    );
   }
 }
 
@@ -1017,12 +1182,16 @@ class _AdminEventDateField extends StatelessWidget {
   const _AdminEventDateField({
     required this.label,
     required this.value,
+    required this.isDateOnly,
+    required this.timeZone,
     required this.onPick,
     this.onClear,
   });
 
   final String label;
   final DateTime? value;
+  final bool isDateOnly;
+  final String? timeZone;
   final VoidCallback onPick;
   final VoidCallback? onClear;
 
@@ -1030,7 +1199,12 @@ class _AdminEventDateField extends StatelessWidget {
   Widget build(BuildContext context) {
     final display = value == null
         ? 'Not set'
-        : '${DateFormat.yMMMd().add_Hm().format(value!.toUtc())} UTC';
+        : EventScheduleUtils.formatSummaryLine(
+            context,
+            startAt: value!,
+            isDateOnly: isDateOnly,
+            timeZone: timeZone,
+          );
 
     return Row(
       children: [

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -16,6 +15,7 @@ import '../../services/auth_service.dart';
 import '../../services/geocoding_service.dart';
 import '../../services/spot_list_service.dart';
 import '../../services/spot_service.dart';
+import '../../utils/event_schedule_utils.dart';
 import '../../utils/image_preparation.dart';
 import '../../widgets/spot_list_selection_dialog.dart';
 import '../../widgets/spot_selection_dialog.dart';
@@ -226,6 +226,8 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
               String? websiteUrl,
               required DateTime startAt,
               DateTime? endAt,
+              required bool isDateOnly,
+              String? timeZone,
               double? latitude,
               double? longitude,
               String? address,
@@ -243,6 +245,8 @@ class _AdminEventsScreenState extends State<AdminEventsScreen> {
                 websiteUrl: websiteUrl,
                 startAt: startAt,
                 endAt: endAt,
+                isDateOnly: isDateOnly,
+                timeZone: timeZone,
                 latitude: latitude,
                 longitude: longitude,
                 address: address,
@@ -406,8 +410,20 @@ class _EventCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final startLabel = _formatUtc(event.startAt);
-    final endLabel = event.endAt == null ? null : _formatUtc(event.endAt!);
+    final startLabel = _formatScheduleMoment(
+      context,
+      event.startAt,
+      isDateOnly: event.isDateOnly,
+      timeZone: event.timeZone,
+    );
+    final endLabel = event.endAt == null
+        ? null
+        : _formatScheduleMoment(
+            context,
+            event.endAt!,
+            isDateOnly: event.isDateOnly,
+            timeZone: event.timeZone,
+          );
     final websiteUrl = event.websiteUrl?.trim();
     final hasWebsite = websiteUrl != null && websiteUrl.isNotEmpty;
     final hasLocation = event.latitude != null && event.longitude != null;
@@ -614,8 +630,23 @@ class _EventCard extends StatelessWidget {
     );
   }
 
-  String _formatUtc(DateTime value) {
-    return '${DateFormat.yMMMd().add_Hm().format(value.toUtc())} UTC';
+  String _formatScheduleMoment(
+    BuildContext context,
+    DateTime value, {
+    required bool isDateOnly,
+    String? timeZone,
+  }) {
+    final localizations = MaterialLocalizations.of(context);
+    final display = EventScheduleUtils.toDisplayDateTime(
+      value,
+      timeZone: timeZone,
+    );
+    final date = localizations.formatMediumDate(display);
+    if (isDateOnly) return date;
+    final time = localizations.formatTimeOfDay(TimeOfDay.fromDateTime(display));
+    final normalizedTimeZone = EventScheduleUtils.normalizeTimeZone(timeZone);
+    final suffix = normalizedTimeZone == null ? '' : ' ${display.timeZoneName}';
+    return '$date · $time$suffix';
   }
 
   Future<void> _openWebsite(String url) async {
@@ -770,6 +801,8 @@ class _CreateEventDialog extends StatefulWidget {
     String? websiteUrl,
     required DateTime startAt,
     DateTime? endAt,
+    required bool isDateOnly,
+    String? timeZone,
     double? latitude,
     double? longitude,
     String? address,
@@ -785,6 +818,8 @@ class _CreateEventDialog extends StatefulWidget {
 }
 
 class _CreateEventDialogState extends State<_CreateEventDialog> {
+  static const String _localTimeZoneValue = '__local__';
+
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _titleController = TextEditingController();
   final TextEditingController _descriptionController = TextEditingController();
@@ -796,6 +831,9 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
 
   DateTime _startAt = DateTime.now().toUtc().add(const Duration(hours: 1));
   DateTime? _endAt;
+  bool _isDateOnly = false;
+  String _selectedTimeZone = 'UTC';
+  late final List<String> _timeZoneOptions;
   bool _isSubmitting = false;
   bool _isGeocoding = false;
   String? _formError;
@@ -805,6 +843,15 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   final List<SpotList> _linkedLists = <SpotList>[];
   final List<Uint8List> _selectedImageBytes = <Uint8List>[];
   final List<String> _imageUrls = <String>[];
+
+  @override
+  void initState() {
+    super.initState();
+    _timeZoneOptions = <String>[
+      _localTimeZoneValue,
+      ...EventScheduleUtils.availableTimeZoneIds(),
+    ];
+  }
 
   @override
   void dispose() {
@@ -818,8 +865,59 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
     super.dispose();
   }
 
+  String? get _effectiveTimeZone {
+    if (_selectedTimeZone == _localTimeZoneValue) return null;
+    return EventScheduleUtils.normalizeTimeZone(_selectedTimeZone);
+  }
+
+  DateTime _displayInSelectedTimeZone(DateTime value) {
+    return EventScheduleUtils.toDisplayDateTime(
+      value,
+      timeZone: _effectiveTimeZone,
+    );
+  }
+
+  String _timeZoneLabel(String value) {
+    if (value == _localTimeZoneValue) {
+      return 'Viewer local timezone (legacy)';
+    }
+    return EventScheduleUtils.formatTimeZoneLabel(
+      value,
+      referenceUtc: _startAt,
+    );
+  }
+
   Future<void> _pickStartAt() async {
-    final value = await _pickDateTime(context, initial: _startAt);
+    if (_isDateOnly) {
+      final initialDate = _displayInSelectedTimeZone(_startAt);
+      final selectedDate = await showDatePicker(
+        context: context,
+        initialDate: DateTime(
+          initialDate.year,
+          initialDate.month,
+          initialDate.day,
+        ),
+        firstDate: DateTime(2020),
+        lastDate: DateTime(2100),
+      );
+      if (selectedDate == null) return;
+      final value = EventScheduleUtils.dateStartToUtc(
+        selectedDate,
+        timeZone: _effectiveTimeZone,
+      );
+      setState(() {
+        _startAt = value;
+        if (_endAt != null && _endAt!.isBefore(_startAt)) {
+          _endAt = null;
+        }
+      });
+      return;
+    }
+    final value = await _pickDateTime(
+      context,
+      initial: _startAt,
+      timeZone: _effectiveTimeZone,
+    );
     if (value == null) return;
     setState(() {
       _startAt = value.toUtc();
@@ -830,8 +928,33 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   }
 
   Future<void> _pickEndAt() async {
+    if (_isDateOnly) {
+      final initialDateTime = _displayInSelectedTimeZone(_endAt ?? _startAt);
+      final selectedDate = await showDatePicker(
+        context: context,
+        initialDate: DateTime(
+          initialDateTime.year,
+          initialDateTime.month,
+          initialDateTime.day,
+        ),
+        firstDate: DateTime(2020),
+        lastDate: DateTime(2100),
+      );
+      if (selectedDate == null) return;
+      setState(
+        () => _endAt = EventScheduleUtils.dateEndToUtc(
+          selectedDate,
+          timeZone: _effectiveTimeZone,
+        ),
+      );
+      return;
+    }
     final initial = _endAt ?? _startAt.add(const Duration(hours: 2));
-    final value = await _pickDateTime(context, initial: initial);
+    final value = await _pickDateTime(
+      context,
+      initial: initial,
+      timeZone: _effectiveTimeZone,
+    );
     if (value == null) return;
     setState(() {
       _endAt = value.toUtc();
@@ -1013,8 +1136,7 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       );
       final resolvedAddress = details['address']?.trim();
       final resolvedCity = details['city']?.trim();
-      final resolvedCountryCode =
-          details['countryCode']?.trim().toUpperCase();
+      final resolvedCountryCode = details['countryCode']?.trim().toUpperCase();
       if (!mounted) return false;
 
       if (force) {
@@ -1087,7 +1209,23 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   Future<void> _submit() async {
     final eventsService = context.read<AdminEventsService>();
     if (!_formKey.currentState!.validate()) return;
-    if (_endAt != null && _endAt!.isBefore(_startAt)) {
+    final timeZone = _effectiveTimeZone;
+    DateTime normalizedStartAt = _startAt;
+    DateTime? normalizedEndAt = _endAt;
+    if (_isDateOnly) {
+      final startDate = _displayInSelectedTimeZone(_startAt);
+      normalizedStartAt = EventScheduleUtils.dateStartToUtc(
+        startDate,
+        timeZone: timeZone,
+      );
+      final endDate = _displayInSelectedTimeZone(_endAt ?? _startAt);
+      normalizedEndAt = EventScheduleUtils.dateEndToUtc(
+        endDate,
+        timeZone: timeZone,
+      );
+    }
+    if (normalizedEndAt != null &&
+        normalizedEndAt.isBefore(normalizedStartAt)) {
       setState(() {
         _formError = 'End time cannot be before start time';
       });
@@ -1124,8 +1262,10 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
       description: _descriptionController.text.trim(),
       imageUrls: [..._imageUrls, ...uploadedImageUrls],
       websiteUrl: _websiteController.text.trim(),
-      startAt: _startAt,
-      endAt: _endAt,
+      startAt: normalizedStartAt,
+      endAt: normalizedEndAt,
+      isDateOnly: _isDateOnly,
+      timeZone: timeZone,
       latitude: double.tryParse(_latitudeController.text.trim()),
       longitude: double.tryParse(_longitudeController.text.trim()),
       address: _addressController.text.trim(),
@@ -1367,15 +1507,62 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
                   maxLines: 3,
                 ),
                 const SizedBox(height: 16),
+                Text('Schedule', style: Theme.of(context).textTheme.titleSmall),
+                const SizedBox(height: 8),
+                DropdownButtonFormField<String>(
+                  value: _selectedTimeZone,
+                  decoration: const InputDecoration(
+                    labelText: 'Timezone',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: _timeZoneOptions
+                      .map(
+                        (value) => DropdownMenuItem<String>(
+                          value: value,
+                          child: Text(
+                            _timeZoneLabel(value),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: _isSubmitting
+                      ? null
+                      : (value) {
+                          if (value == null) return;
+                          setState(() => _selectedTimeZone = value);
+                        },
+                ),
+                const SizedBox(height: 8),
+                SwitchListTile.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Date only (no times)'),
+                  subtitle: const Text(
+                    'Display this event everywhere without times',
+                  ),
+                  value: _isDateOnly,
+                  onChanged: _isSubmitting
+                      ? null
+                      : (value) {
+                          setState(() => _isDateOnly = value);
+                        },
+                ),
+                const SizedBox(height: 8),
                 _DateField(
-                  label: 'Start (UTC)',
+                  label: _isDateOnly ? 'Start date' : 'Start date & time',
                   value: _startAt,
+                  isDateOnly: _isDateOnly,
+                  timeZone: _effectiveTimeZone,
                   onPick: _pickStartAt,
                 ),
                 const SizedBox(height: 8),
                 _DateField(
-                  label: 'End (UTC, optional)',
+                  label: _isDateOnly
+                      ? 'End date (optional)'
+                      : 'End date & time (optional)',
                   value: _endAt,
+                  isDateOnly: _isDateOnly,
+                  timeZone: _effectiveTimeZone,
                   onPick: _pickEndAt,
                   onClear: _endAt == null
                       ? null
@@ -1507,29 +1694,37 @@ class _CreateEventDialogState extends State<_CreateEventDialog> {
   Future<DateTime?> _pickDateTime(
     BuildContext context, {
     required DateTime initial,
+    String? timeZone,
   }) async {
+    final displayInitial = EventScheduleUtils.toDisplayDateTime(
+      initial,
+      timeZone: timeZone,
+    );
     final selectedDate = await showDatePicker(
       context: context,
-      initialDate: initial.toLocal(),
+      initialDate: displayInitial,
       firstDate: DateTime(2020),
       lastDate: DateTime(2100),
     );
     if (selectedDate == null || !context.mounted) return null;
 
-    final initialTime = TimeOfDay.fromDateTime(initial.toLocal());
+    final initialTime = TimeOfDay.fromDateTime(displayInitial);
     final selectedTime = await showTimePicker(
       context: context,
       initialTime: initialTime,
     );
     if (selectedTime == null) return null;
 
-    return DateTime(
-      selectedDate.year,
-      selectedDate.month,
-      selectedDate.day,
-      selectedTime.hour,
-      selectedTime.minute,
-    ).toUtc();
+    return EventScheduleUtils.localDateTimeToUtc(
+      DateTime(
+        selectedDate.year,
+        selectedDate.month,
+        selectedDate.day,
+        selectedTime.hour,
+        selectedTime.minute,
+      ),
+      timeZone: timeZone,
+    );
   }
 }
 
@@ -1537,12 +1732,16 @@ class _DateField extends StatelessWidget {
   const _DateField({
     required this.label,
     required this.value,
+    required this.isDateOnly,
+    required this.timeZone,
     required this.onPick,
     this.onClear,
   });
 
   final String label;
   final DateTime? value;
+  final bool isDateOnly;
+  final String? timeZone;
   final VoidCallback onPick;
   final VoidCallback? onClear;
 
@@ -1550,7 +1749,12 @@ class _DateField extends StatelessWidget {
   Widget build(BuildContext context) {
     final display = value == null
         ? 'Not set'
-        : '${DateFormat.yMMMd().add_Hm().format(value!.toUtc())} UTC';
+        : EventScheduleUtils.formatSummaryLine(
+            context,
+            startAt: value!,
+            isDateOnly: isDateOnly,
+            timeZone: timeZone,
+          );
 
     return Row(
       children: [

--- a/lib/screens/admin/admin_events_screen.dart
+++ b/lib/screens/admin/admin_events_screen.dart
@@ -533,7 +533,7 @@ class _EventCard extends StatelessWidget {
                       Chip(
                         avatar: const Icon(Icons.update, size: 16),
                         label: Text(
-                          'Seen: ${_formatUtc(event.externalSyncLastSeenAt!)}',
+                          'Seen: ${_formatUtc(context, event.externalSyncLastSeenAt!)}',
                         ),
                         visualDensity: VisualDensity.compact,
                         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -542,7 +542,7 @@ class _EventCard extends StatelessWidget {
                       Chip(
                         avatar: const Icon(Icons.edit_calendar, size: 16),
                         label: Text(
-                          'Changed: ${_formatUtc(event.externalSyncLastChangedAt!)}',
+                          'Changed: ${_formatUtc(context, event.externalSyncLastChangedAt!)}',
                         ),
                         visualDensity: VisualDensity.compact,
                         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -647,6 +647,17 @@ class _EventCard extends StatelessWidget {
     final normalizedTimeZone = EventScheduleUtils.normalizeTimeZone(timeZone);
     final suffix = normalizedTimeZone == null ? '' : ' ${display.timeZoneName}';
     return '$date · $time$suffix';
+  }
+
+  String _formatUtc(BuildContext context, DateTime value) {
+    final localizations = MaterialLocalizations.of(context);
+    final utc = value.toUtc();
+    final date = localizations.formatMediumDate(utc);
+    final time = localizations.formatTimeOfDay(
+      TimeOfDay.fromDateTime(utc),
+      alwaysUse24HourFormat: true,
+    );
+    return '$date $time UTC';
   }
 
   Future<void> _openWebsite(String url) async {

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -337,13 +337,8 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
       tooltip: isAdmin
           ? l10n.eventDetailAdminMenuTooltip
           : l10n.eventDetailStaffMenuTooltip,
-      onSelected: (action) => _onStaffMenu(
-        context,
-        action,
-        event,
-        isAdmin,
-        isModeratorOnly,
-      ),
+      onSelected: (action) =>
+          _onStaffMenu(context, action, event, isAdmin, isModeratorOnly),
       itemBuilder: (ctx) {
         final theme = Theme.of(ctx);
         final items = <PopupMenuEntry<_EventStaffAction>>[
@@ -494,9 +489,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
           return;
         }
         if (!isAdmin && !context.read<AuthService>().isModerator) return;
-        final updated = await context.push<bool>(
-          '/admin/events/$id/edit',
-        );
+        final updated = await context.push<bool>('/admin/events/$id/edit');
         if (updated == true && mounted) {
           await _loadEvent();
         }
@@ -660,8 +653,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
     final showDuplicateCallout =
         hasDupLink || _loadingOriginal || _originalEvent != null;
     final showLinkedDuplicates =
-        !hasDupLink &&
-        (_loadingDuplicates || _duplicateEvents.isNotEmpty);
+        !hasDupLink && (_loadingDuplicates || _duplicateEvents.isNotEmpty);
 
     final contentInset = SpotDetailUi.contentHorizontalInset(context);
 
@@ -740,7 +732,9 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                           ],
                         ),
                         if (showDuplicateCallout) ...[
-                          const SizedBox(height: SpotDetailUi.detailSubsectionGap),
+                          const SizedBox(
+                            height: SpotDetailUi.detailSubsectionGap,
+                          ),
                           DetailDuplicateOfCallout(
                             bannerTitle: l10n.eventDetailDuplicateBannerTitle,
                             bannerBody: l10n.eventDetailDuplicateBannerBody,
@@ -827,6 +821,8 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
       EventDetailWhenBlock(
         startAt: event.startAt,
         endAt: event.endAt,
+        isDateOnly: event.isDateOnly,
+        timeZone: event.timeZone,
         startsLabel: l10n.eventDetailStartsLabel,
         endsLabel: l10n.eventDetailEndsLabel,
         todayLabel: l10n.spotDetailDateToday,
@@ -925,9 +921,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
           height: 200,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
-            border: Border.all(
-              color: colors.outline.withValues(alpha: 0.3),
-            ),
+            border: Border.all(color: colors.outline.withValues(alpha: 0.3)),
           ),
           clipBehavior: Clip.antiAlias,
           child: Stack(
@@ -994,7 +988,9 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                             context,
                             listen: false,
                           );
-                          searchState.setSatellite(_isSatelliteViewNotifier.value);
+                          searchState.setSatellite(
+                            _isSatelliteViewNotifier.value,
+                          );
                         },
                         heroTag: 'eventDetailMapTypeToggleFab',
                         mini: true,
@@ -1066,9 +1062,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
           decoration: BoxDecoration(
             color: colors.primaryContainer.withValues(alpha: 0.1),
             borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: colors.primary.withValues(alpha: 0.2),
-            ),
+            border: Border.all(color: colors.primary.withValues(alpha: 0.2)),
           ),
           child: GestureDetector(
             onTap: () => _copyAddressToClipboard(event.address!.trim()),
@@ -1154,7 +1148,11 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
     if (event.isNativeEvent) {
       if (!mounted) return null;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context)!.eventDetailNotExternalSource)),
+        SnackBar(
+          content: Text(
+            AppLocalizations.of(context)!.eventDetailNotExternalSource,
+          ),
+        ),
       );
       return null;
     }
@@ -1312,7 +1310,8 @@ class _LinkedSpotListsSection extends StatefulWidget {
   final String emptyLabel;
 
   @override
-  State<_LinkedSpotListsSection> createState() => _LinkedSpotListsSectionState();
+  State<_LinkedSpotListsSection> createState() =>
+      _LinkedSpotListsSectionState();
 }
 
 class _LinkedSpotListsSectionState extends State<_LinkedSpotListsSection> {
@@ -1378,7 +1377,9 @@ class _LinkedSpotListsSectionState extends State<_LinkedSpotListsSection> {
             return Padding(
               padding: const EdgeInsets.only(bottom: 8),
               child: InkWell(
-                onTap: listId == null ? null : () => context.push('/list/$listId'),
+                onTap: listId == null
+                    ? null
+                    : () => context.push('/list/$listId'),
                 borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
                 child: Container(
                   width: double.infinity,

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -37,6 +37,7 @@ import '../../services/spot_training_plan_service.dart';
 import '../../services/feature_access_service.dart';
 import '../../models/spot_list.dart';
 import '../../models/parkour_event.dart';
+import '../../utils/event_schedule_utils.dart';
 import '../../utils/marker_icon_utils.dart';
 import '../../utils/resized_spot_image_provider.dart';
 import '../../widgets/no_images_placeholder.dart';
@@ -2178,7 +2179,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
             // Content using SliverList
             SliverToBoxAdapter(
               child: Padding(
-                padding: const EdgeInsets.all(SpotDetailUi.contentHorizontalPadding),
+                padding: const EdgeInsets.all(
+                  SpotDetailUi.contentHorizontalPadding,
+                ),
                 child: Center(
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(
@@ -2201,9 +2204,9 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                             Expanded(
                               child: SelectableText(
                                 _spot.name,
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .headlineMedium,
+                                style: Theme.of(
+                                  context,
+                                ).textTheme.headlineMedium,
                               ),
                             ),
                           ],
@@ -3290,7 +3293,8 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                                           widget.spot.latitude,
                                           widget.spot.longitude,
                                         ),
-                                        icon: _spotMapPinIcon ??
+                                        icon:
+                                            _spotMapPinIcon ??
                                             BitmapDescriptor.defaultMarker,
                                         anchor: const Offset(0.5, 1.0),
                                         onTap: null,
@@ -5053,7 +5057,12 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      _formatUpcomingEventDateTime(event.startAt),
+                      _formatUpcomingEventDateTime(
+                        event.startAt,
+                        endAt: event.endAt,
+                        isDateOnly: event.isDateOnly,
+                        timeZone: event.timeZone,
+                      ),
                       style: Theme.of(context).textTheme.bodySmall,
                     ),
                   ],
@@ -5071,12 +5080,19 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
     );
   }
 
-  String _formatUpcomingEventDateTime(DateTime dateTime) {
-    final local = dateTime.toLocal();
-    final localizations = MaterialLocalizations.of(context);
-    final date = localizations.formatMediumDate(local);
-    final time = localizations.formatTimeOfDay(TimeOfDay.fromDateTime(local));
-    return '$date · $time';
+  String _formatUpcomingEventDateTime(
+    DateTime startAt, {
+    DateTime? endAt,
+    required bool isDateOnly,
+    String? timeZone,
+  }) {
+    return EventScheduleUtils.formatSummaryLine(
+      context,
+      startAt: startAt,
+      endAt: endAt,
+      isDateOnly: isDateOnly,
+      timeZone: timeZone,
+    );
   }
 
   Widget _buildFacilityChip(String facilityKey, String status) {

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -363,10 +363,15 @@ class AdminEventsService extends ChangeNotifier {
         spotListIds: normalized.spotListIds,
         updatedAt: now,
       );
-      await _firestore
-          .collection('events')
-          .doc(trimmedId)
-          .update(updated.toFirestore());
+      final updateData = updated.toFirestore();
+      updateData['isDateOnly'] = updated.isDateOnly;
+      final trimmedTimeZone = updated.timeZone?.trim();
+      if (trimmedTimeZone == null || trimmedTimeZone.isEmpty) {
+        updateData['timeZone'] = FieldValue.delete();
+      } else {
+        updateData['timeZone'] = trimmedTimeZone;
+      }
+      await _firestore.collection('events').doc(trimmedId).update(updateData);
 
       final index = _events.indexWhere((e) => e.id == trimmedId);
       if (index >= 0) {

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -103,6 +103,8 @@ class AdminEventsService extends ChangeNotifier {
     String? websiteUrl,
     required DateTime startAt,
     DateTime? endAt,
+    bool isDateOnly = false,
+    String? timeZone,
     double? latitude,
     double? longitude,
     String? address,
@@ -122,6 +124,8 @@ class AdminEventsService extends ChangeNotifier {
       spotListIds: spotListIds,
       startAt: startAt,
       endAt: endAt,
+      isDateOnly: isDateOnly,
+      timeZone: timeZone,
       latitude: latitude,
       longitude: longitude,
       city: city,
@@ -154,6 +158,8 @@ class AdminEventsService extends ChangeNotifier {
         websiteUrl: normalized.websiteUrl,
         startAt: normalized.startAt,
         endAt: normalized.endAt,
+        isDateOnly: normalized.isDateOnly,
+        timeZone: normalized.timeZone,
         latitude: normalized.latitude,
         longitude: normalized.longitude,
         address: normalized.address,
@@ -202,6 +208,8 @@ class AdminEventsService extends ChangeNotifier {
       spotListIds: sourceEvent.spotListIds,
       startAt: sourceEvent.startAt,
       endAt: sourceEvent.endAt,
+      isDateOnly: sourceEvent.isDateOnly,
+      timeZone: sourceEvent.timeZone,
       latitude: sourceEvent.latitude,
       longitude: sourceEvent.longitude,
       city: sourceEvent.city,
@@ -234,6 +242,8 @@ class AdminEventsService extends ChangeNotifier {
         websiteUrl: normalized.websiteUrl,
         startAt: normalized.startAt,
         endAt: normalized.endAt,
+        isDateOnly: normalized.isDateOnly,
+        timeZone: normalized.timeZone,
         latitude: normalized.latitude,
         longitude: normalized.longitude,
         address: normalized.address,
@@ -270,6 +280,8 @@ class AdminEventsService extends ChangeNotifier {
     String? websiteUrl,
     required DateTime startAt,
     DateTime? endAt,
+    bool isDateOnly = false,
+    String? timeZone,
     double? latitude,
     double? longitude,
     String? address,
@@ -306,6 +318,8 @@ class AdminEventsService extends ChangeNotifier {
       spotListIds: spotListIds,
       startAt: startAt,
       endAt: endAt,
+      isDateOnly: isDateOnly,
+      timeZone: timeZone,
       latitude: latitude,
       longitude: longitude,
       city: city,
@@ -338,6 +352,8 @@ class AdminEventsService extends ChangeNotifier {
         websiteUrl: normalized.websiteUrl,
         startAt: normalized.startAt,
         endAt: normalized.endAt,
+        isDateOnly: normalized.isDateOnly,
+        timeZone: normalized.timeZone,
         latitude: normalized.latitude,
         longitude: normalized.longitude,
         address: normalized.address,
@@ -488,6 +504,8 @@ class AdminEventsService extends ChangeNotifier {
     String? websiteUrl,
     DateTime startAt,
     DateTime? endAt,
+    bool isDateOnly,
+    String? timeZone,
     double? latitude,
     double? longitude,
     String? address,
@@ -503,6 +521,8 @@ class AdminEventsService extends ChangeNotifier {
     String? websiteUrl,
     required DateTime startAt,
     DateTime? endAt,
+    bool isDateOnly = false,
+    String? timeZone,
     double? latitude,
     double? longitude,
     String? address,
@@ -520,6 +540,7 @@ class AdminEventsService extends ChangeNotifier {
     final normalizedAddress = address?.trim();
     final normalizedCity = city?.trim();
     final normalizedCountryCode = countryCode?.trim().toUpperCase();
+    final normalizedTimeZone = timeZone?.trim();
     final normalizedSpotIds = spotIds
         .map((id) => id.trim())
         .where((id) => id.isNotEmpty)
@@ -531,15 +552,35 @@ class AdminEventsService extends ChangeNotifier {
         .toSet()
         .toList();
 
-    if (title.trim().isEmpty) {
+    ({
+      String? error,
+      String title,
+      String? description,
+      List<String> imageUrls,
+      String? websiteUrl,
+      DateTime startAt,
+      DateTime? endAt,
+      bool isDateOnly,
+      String? timeZone,
+      double? latitude,
+      double? longitude,
+      String? address,
+      String? city,
+      String? countryCode,
+      List<String> spotIds,
+      List<String> spotListIds,
+    })
+    invalidResult(String errorMessage) {
       return (
-        error: 'Title is required',
+        error: errorMessage,
         title: '',
         description: null,
         imageUrls: const <String>[],
         websiteUrl: null,
         startAt: startAt.toUtc(),
         endAt: null,
+        isDateOnly: false,
+        timeZone: null,
         latitude: null,
         longitude: null,
         address: null,
@@ -549,136 +590,37 @@ class AdminEventsService extends ChangeNotifier {
         spotListIds: const <String>[],
       );
     }
+
+    if (title.trim().isEmpty) {
+      return invalidResult('Title is required');
+    }
     if (normalizedSpotListIds.length > maxSpotListIds) {
-      return (
-        error: 'At most $maxSpotListIds spot lists can be linked',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
-      );
+      return invalidResult('At most $maxSpotListIds spot lists can be linked');
     }
     if (normalizedWebsiteUrl != null &&
         normalizedWebsiteUrl.isNotEmpty &&
         !_isValidHttpUrl(normalizedWebsiteUrl)) {
-      return (
-        error: 'Website URL must be a valid http(s) link',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
-      );
+      return invalidResult('Website URL must be a valid http(s) link');
     }
     final hasLatitude = latitude != null;
     final hasLongitude = longitude != null;
     if (hasLatitude != hasLongitude) {
-      return (
-        error: 'Both latitude and longitude are required for event location',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
+      return invalidResult(
+        'Both latitude and longitude are required for event location',
       );
     }
     if (latitude != null && (latitude < -90 || latitude > 90)) {
-      return (
-        error: 'Latitude must be between -90 and 90',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
-      );
+      return invalidResult('Latitude must be between -90 and 90');
     }
     if (longitude != null && (longitude < -180 || longitude > 180)) {
-      return (
-        error: 'Longitude must be between -180 and 180',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
-      );
+      return invalidResult('Longitude must be between -180 and 180');
     }
     if (latitude != null &&
         (normalizedAddress == null || normalizedAddress.isEmpty)) {
-      return (
-        error: 'Address is required when coordinates are provided',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
-      );
+      return invalidResult('Address is required when coordinates are provided');
     }
     if (endAt != null && endAt.isBefore(startAt)) {
-      return (
-        error: 'End time cannot be before start time',
-        title: '',
-        description: null,
-        imageUrls: const <String>[],
-        websiteUrl: null,
-        startAt: startAt.toUtc(),
-        endAt: null,
-        latitude: null,
-        longitude: null,
-        address: null,
-        city: null,
-        countryCode: null,
-        spotIds: const <String>[],
-        spotListIds: const <String>[],
-      );
+      return invalidResult('End time cannot be before start time');
     }
 
     return (
@@ -693,6 +635,8 @@ class AdminEventsService extends ChangeNotifier {
           : normalizedWebsiteUrl,
       startAt: startAt.toUtc(),
       endAt: endAt?.toUtc(),
+      isDateOnly: isDateOnly,
+      timeZone: normalizedTimeZone?.isEmpty == true ? null : normalizedTimeZone,
       latitude: latitude,
       longitude: longitude,
       address: normalizedAddress?.isEmpty == true ? null : normalizedAddress,

--- a/lib/utils/event_schedule_utils.dart
+++ b/lib/utils/event_schedule_utils.dart
@@ -120,7 +120,7 @@ class EventScheduleUtils {
         ? null
         : toDisplayDateTime(endAt, timeZone: timeZone);
     final sameDay =
-        end != null && isSameCalendarDay(startAt, endAt, timeZone: timeZone);
+        end != null && isSameCalendarDay(startAt, end, timeZone: timeZone);
 
     final startDate = localizations.formatMediumDate(start);
     final endDate = end == null ? null : localizations.formatMediumDate(end);

--- a/lib/utils/event_schedule_utils.dart
+++ b/lib/utils/event_schedule_utils.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+
+class EventScheduleUtils {
+  static bool _initialized = false;
+  static List<String>? _cachedTimeZoneIds;
+
+  static void ensureTimeZonesInitialized() {
+    if (_initialized) return;
+    tz_data.initializeTimeZones();
+    _initialized = true;
+  }
+
+  static List<String> availableTimeZoneIds() {
+    ensureTimeZonesInitialized();
+    final cached = _cachedTimeZoneIds;
+    if (cached != null) return cached;
+    final zones = tz.timeZoneDatabase.locations.keys.toList()..sort();
+    _cachedTimeZoneIds = zones;
+    return zones;
+  }
+
+  static String? normalizeTimeZone(String? rawValue) {
+    final trimmed = rawValue?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    ensureTimeZonesInitialized();
+    if (!tz.timeZoneDatabase.locations.containsKey(trimmed)) return null;
+    return trimmed;
+  }
+
+  static DateTime toDisplayDateTime(DateTime utcInstant, {String? timeZone}) {
+    final normalized = normalizeTimeZone(timeZone);
+    if (normalized == null) {
+      return utcInstant.toLocal();
+    }
+    final location = tz.getLocation(normalized);
+    return tz.TZDateTime.from(utcInstant.toUtc(), location);
+  }
+
+  static DateTime localDateTimeToUtc(
+    DateTime localDateTime, {
+    String? timeZone,
+  }) {
+    final normalized = normalizeTimeZone(timeZone);
+    if (normalized == null) {
+      return DateTime(
+        localDateTime.year,
+        localDateTime.month,
+        localDateTime.day,
+        localDateTime.hour,
+        localDateTime.minute,
+        localDateTime.second,
+        localDateTime.millisecond,
+        localDateTime.microsecond,
+      ).toUtc();
+    }
+    final location = tz.getLocation(normalized);
+    final zoned = tz.TZDateTime(
+      location,
+      localDateTime.year,
+      localDateTime.month,
+      localDateTime.day,
+      localDateTime.hour,
+      localDateTime.minute,
+      localDateTime.second,
+      localDateTime.millisecond,
+      localDateTime.microsecond,
+    );
+    return DateTime.fromMillisecondsSinceEpoch(
+      zoned.millisecondsSinceEpoch,
+      isUtc: true,
+    );
+  }
+
+  static DateTime dateStartToUtc(DateTime date, {String? timeZone}) {
+    return localDateTimeToUtc(
+      DateTime(date.year, date.month, date.day),
+      timeZone: timeZone,
+    );
+  }
+
+  static DateTime dateEndToUtc(DateTime date, {String? timeZone}) {
+    return localDateTimeToUtc(
+      DateTime(date.year, date.month, date.day, 23, 59, 59, 999),
+      timeZone: timeZone,
+    );
+  }
+
+  static bool isSameCalendarDay(
+    DateTime first,
+    DateTime second, {
+    String? timeZone,
+  }) {
+    final a = toDisplayDateTime(first, timeZone: timeZone);
+    final b = toDisplayDateTime(second, timeZone: timeZone);
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  static String formatTimeZoneLabel(String timeZone, {DateTime? referenceUtc}) {
+    final normalized = normalizeTimeZone(timeZone);
+    if (normalized == null) return timeZone;
+    final location = tz.getLocation(normalized);
+    final instant = (referenceUtc ?? DateTime.now()).toUtc();
+    final zoned = tz.TZDateTime.from(instant, location);
+    final offset = _formatOffset(zoned.timeZoneOffset);
+    return '$normalized (UTC$offset · ${zoned.timeZoneName})';
+  }
+
+  static String formatSummaryLine(
+    BuildContext context, {
+    required DateTime startAt,
+    DateTime? endAt,
+    required bool isDateOnly,
+    String? timeZone,
+  }) {
+    final localizations = MaterialLocalizations.of(context);
+    final start = toDisplayDateTime(startAt, timeZone: timeZone);
+    final end = endAt == null
+        ? null
+        : toDisplayDateTime(endAt, timeZone: timeZone);
+    final sameDay =
+        end != null && isSameCalendarDay(startAt, endAt, timeZone: timeZone);
+
+    final startDate = localizations.formatMediumDate(start);
+    final endDate = end == null ? null : localizations.formatMediumDate(end);
+    final startTime = localizations.formatTimeOfDay(
+      TimeOfDay.fromDateTime(start),
+    );
+    final endTime = end == null
+        ? null
+        : localizations.formatTimeOfDay(TimeOfDay.fromDateTime(end));
+    final zoneSuffix = _timeZoneSuffix(timeZone, start);
+
+    if (isDateOnly) {
+      if (end == null || sameDay) return startDate;
+      return '$startDate – $endDate';
+    }
+
+    if (end == null) return '$startDate · $startTime$zoneSuffix';
+    if (sameDay) return '$startDate · $startTime – $endTime$zoneSuffix';
+    return '$startDate $startTime – $endDate $endTime$zoneSuffix';
+  }
+
+  static String _timeZoneSuffix(String? timeZone, DateTime displayStart) {
+    final normalized = normalizeTimeZone(timeZone);
+    if (normalized == null) return '';
+    return ' ${displayStart.timeZoneName}';
+  }
+
+  static String _formatOffset(Duration offset) {
+    final totalMinutes = offset.inMinutes;
+    final sign = totalMinutes >= 0 ? '+' : '-';
+    final absoluteMinutes = totalMinutes.abs();
+    final hours = absoluteMinutes ~/ 60;
+    final minutes = absoluteMinutes % 60;
+    final hh = hours.toString().padLeft(2, '0');
+    final mm = minutes.toString().padLeft(2, '0');
+    return '$sign$hh:$mm';
+  }
+}

--- a/lib/widgets/event_card.dart
+++ b/lib/widgets/event_card.dart
@@ -10,6 +10,7 @@ import '../services/mobile_detection_service.dart';
 import '../services/snackbar_service.dart';
 import '../services/url_service.dart';
 import '../services/web_share_service.dart';
+import '../utils/event_schedule_utils.dart';
 import 'no_images_placeholder.dart';
 import 'resized_spot_image.dart';
 
@@ -57,11 +58,13 @@ class _EventCardState extends State<EventCard> {
   }
 
   String _formatWhen(BuildContext context) {
-    final local = widget.pin.startAt.toLocal();
-    final localizations = MaterialLocalizations.of(context);
-    final date = localizations.formatMediumDate(local);
-    final time = localizations.formatTimeOfDay(TimeOfDay.fromDateTime(local));
-    return '$date · $time';
+    return EventScheduleUtils.formatSummaryLine(
+      context,
+      startAt: widget.pin.startAt,
+      endAt: widget.pin.endAt,
+      isDateOnly: widget.pin.isDateOnly,
+      timeZone: widget.pin.timeZone,
+    );
   }
 
   @override

--- a/lib/widgets/event_detail_when_block.dart
+++ b/lib/widgets/event_detail_when_block.dart
@@ -58,6 +58,16 @@ class EventDetailWhenBlock extends StatelessWidget {
     );
   }
 
+  static String _zoneSuffix(DateTime dateTime, {String? timeZone}) {
+    final normalized = EventScheduleUtils.normalizeTimeZone(timeZone);
+    if (normalized == null) return '';
+    final local = EventScheduleUtils.toDisplayDateTime(
+      dateTime,
+      timeZone: normalized,
+    );
+    return ' ${local.timeZoneName}';
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -153,6 +163,10 @@ class _SingleMoment extends StatelessWidget {
       dateTime,
       timeZone: timeZone,
     );
+    final zoneSuffix = EventDetailWhenBlock._zoneSuffix(
+      dateTime,
+      timeZone: timeZone,
+    );
 
     final dotTop = _timelinePrimaryDateDotTopInset(
       context,
@@ -185,7 +199,7 @@ class _SingleMoment extends StatelessWidget {
               if (!isDateOnly) ...[
                 const SizedBox(height: 2),
                 Text(
-                  parts.time,
+                  '${parts.time}$zoneSuffix',
                   style: theme.textTheme.bodyLarge?.copyWith(
                     color: colors.onSurfaceVariant,
                   ),
@@ -237,6 +251,10 @@ class _SameDayRange extends StatelessWidget {
       endAt,
       timeZone: timeZone,
     ).time;
+    final zoneSuffix = EventDetailWhenBlock._zoneSuffix(
+      startAt,
+      timeZone: timeZone,
+    );
 
     final dotTop = _timelinePrimaryDateDotTopInset(
       context,
@@ -283,6 +301,7 @@ class _SameDayRange extends StatelessWidget {
                         ),
                       ),
                       TextSpan(text: endTime),
+                      if (zoneSuffix.isNotEmpty) TextSpan(text: zoneSuffix),
                     ],
                   ),
                 ),
@@ -430,6 +449,10 @@ class _TimelineMomentContent extends StatelessWidget {
       dateTime,
       timeZone: timeZone,
     );
+    final zoneSuffix = EventDetailWhenBlock._zoneSuffix(
+      dateTime,
+      timeZone: timeZone,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -453,7 +476,7 @@ class _TimelineMomentContent extends StatelessWidget {
         if (showTime) ...[
           const SizedBox(height: 2),
           Text(
-            parts.time,
+            '${parts.time}$zoneSuffix',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: colors.onSurfaceVariant,
             ),

--- a/lib/widgets/event_detail_when_block.dart
+++ b/lib/widgets/event_detail_when_block.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../constants/spot_detail_ui.dart';
+import '../utils/event_schedule_utils.dart';
 
 /// Start / end schedule for an event detail page (no event icon — title owns that).
 class EventDetailWhenBlock extends StatelessWidget {
@@ -8,6 +9,8 @@ class EventDetailWhenBlock extends StatelessWidget {
     super.key,
     required this.startAt,
     this.endAt,
+    this.isDateOnly = false,
+    this.timeZone,
     required this.startsLabel,
     required this.endsLabel,
     required this.todayLabel,
@@ -15,19 +18,25 @@ class EventDetailWhenBlock extends StatelessWidget {
 
   final DateTime startAt;
   final DateTime? endAt;
+  final bool isDateOnly;
+  final String? timeZone;
   final String startsLabel;
   final String endsLabel;
   final String todayLabel;
 
-  static bool _isSameCalendarDay(DateTime a, DateTime b) {
-    final la = a.toLocal();
-    final lb = b.toLocal();
-    return la.year == lb.year && la.month == lb.month && la.day == lb.day;
+  static bool _isSameCalendarDay(DateTime a, DateTime b, {String? timeZone}) {
+    return EventScheduleUtils.isSameCalendarDay(a, b, timeZone: timeZone);
   }
 
-  static bool _isToday(DateTime dateTime) {
-    final local = dateTime.toLocal();
-    final now = DateTime.now();
+  static bool _isToday(DateTime dateTime, {String? timeZone}) {
+    final local = EventScheduleUtils.toDisplayDateTime(
+      dateTime,
+      timeZone: timeZone,
+    );
+    final now = EventScheduleUtils.toDisplayDateTime(
+      DateTime.now().toUtc(),
+      timeZone: timeZone,
+    );
     return local.year == now.year &&
         local.month == now.month &&
         local.day == now.day;
@@ -35,9 +44,13 @@ class EventDetailWhenBlock extends StatelessWidget {
 
   static ({String date, String time}) _parts(
     BuildContext context,
-    DateTime dateTime,
-  ) {
-    final local = dateTime.toLocal();
+    DateTime dateTime, {
+    String? timeZone,
+  }) {
+    final local = EventScheduleUtils.toDisplayDateTime(
+      dateTime,
+      timeZone: timeZone,
+    );
     final material = MaterialLocalizations.of(context);
     return (
       date: material.formatFullDate(local),
@@ -50,14 +63,23 @@ class EventDetailWhenBlock extends StatelessWidget {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
     final end = endAt;
-    final sameDay = end != null && _isSameCalendarDay(startAt, end);
-    final showToday = _isToday(startAt) || (end != null && _isToday(end));
+    final sameDay =
+        end != null && _isSameCalendarDay(startAt, end, timeZone: timeZone);
+    final showToday =
+        _isToday(startAt, timeZone: timeZone) ||
+        (end != null && _isToday(end, timeZone: timeZone));
 
     final semanticsLabel = end == null
-        ? '${_parts(context, startAt).date}, ${_parts(context, startAt).time}'
+        ? isDateOnly
+              ? _parts(context, startAt, timeZone: timeZone).date
+              : '${_parts(context, startAt, timeZone: timeZone).date}, ${_parts(context, startAt, timeZone: timeZone).time}'
         : sameDay
-        ? '${_parts(context, startAt).date}, ${_parts(context, startAt).time} – ${_parts(context, end).time}'
-        : '${_parts(context, startAt).date} ${_parts(context, startAt).time} – ${_parts(context, end).date} ${_parts(context, end).time}';
+        ? isDateOnly
+              ? _parts(context, startAt, timeZone: timeZone).date
+              : '${_parts(context, startAt, timeZone: timeZone).date}, ${_parts(context, startAt, timeZone: timeZone).time} – ${_parts(context, end, timeZone: timeZone).time}'
+        : isDateOnly
+        ? '${_parts(context, startAt, timeZone: timeZone).date} – ${_parts(context, end, timeZone: timeZone).date}'
+        : '${_parts(context, startAt, timeZone: timeZone).date} ${_parts(context, startAt, timeZone: timeZone).time} – ${_parts(context, end, timeZone: timeZone).date} ${_parts(context, end, timeZone: timeZone).time}';
 
     return Semantics(
       container: true,
@@ -71,29 +93,35 @@ class EventDetailWhenBlock extends StatelessWidget {
           border: SpotDetailUi.outlineBorder(colors),
         ),
         child: end == null
-                ? _SingleMoment(
-                    context: context,
-                    dateTime: startAt,
-                    showToday: showToday,
-                    todayLabel: todayLabel,
-                  )
-                : sameDay
-                ? _SameDayRange(
-                    context: context,
-                    startAt: startAt,
-                    endAt: end,
-                    showToday: showToday,
-                    todayLabel: todayLabel,
-                  )
-                : _MultiDayRange(
-                    context: context,
-                    startAt: startAt,
-                    endAt: end,
-                    startsLabel: startsLabel,
-                    endsLabel: endsLabel,
-                    showToday: showToday,
-                    todayLabel: todayLabel,
-                  ),
+            ? _SingleMoment(
+                context: context,
+                dateTime: startAt,
+                isDateOnly: isDateOnly,
+                timeZone: timeZone,
+                showToday: showToday,
+                todayLabel: todayLabel,
+              )
+            : sameDay
+            ? _SameDayRange(
+                context: context,
+                startAt: startAt,
+                endAt: end,
+                isDateOnly: isDateOnly,
+                timeZone: timeZone,
+                showToday: showToday,
+                todayLabel: todayLabel,
+              )
+            : _MultiDayRange(
+                context: context,
+                startAt: startAt,
+                endAt: end,
+                isDateOnly: isDateOnly,
+                timeZone: timeZone,
+                startsLabel: startsLabel,
+                endsLabel: endsLabel,
+                showToday: showToday,
+                todayLabel: todayLabel,
+              ),
       ),
     );
   }
@@ -103,12 +131,16 @@ class _SingleMoment extends StatelessWidget {
   const _SingleMoment({
     required this.context,
     required this.dateTime,
+    required this.isDateOnly,
+    required this.timeZone,
     required this.showToday,
     required this.todayLabel,
   });
 
   final BuildContext context;
   final DateTime dateTime;
+  final bool isDateOnly;
+  final String? timeZone;
   final bool showToday;
   final String todayLabel;
 
@@ -116,7 +148,11 @@ class _SingleMoment extends StatelessWidget {
   Widget build(BuildContext _) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final parts = EventDetailWhenBlock._parts(context, dateTime);
+    final parts = EventDetailWhenBlock._parts(
+      context,
+      dateTime,
+      timeZone: timeZone,
+    );
 
     final dotTop = _timelinePrimaryDateDotTopInset(
       context,
@@ -146,13 +182,15 @@ class _SingleMoment extends StatelessWidget {
                   height: 1.25,
                 ),
               ),
-              const SizedBox(height: 2),
-              Text(
-                parts.time,
-                style: theme.textTheme.bodyLarge?.copyWith(
-                  color: colors.onSurfaceVariant,
+              if (!isDateOnly) ...[
+                const SizedBox(height: 2),
+                Text(
+                  parts.time,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
                 ),
-              ),
+              ],
             ],
           ),
         ),
@@ -166,6 +204,8 @@ class _SameDayRange extends StatelessWidget {
     required this.context,
     required this.startAt,
     required this.endAt,
+    required this.isDateOnly,
+    required this.timeZone,
     required this.showToday,
     required this.todayLabel,
   });
@@ -173,6 +213,8 @@ class _SameDayRange extends StatelessWidget {
   final BuildContext context;
   final DateTime startAt;
   final DateTime endAt;
+  final bool isDateOnly;
+  final String? timeZone;
   final bool showToday;
   final String todayLabel;
 
@@ -180,9 +222,21 @@ class _SameDayRange extends StatelessWidget {
   Widget build(BuildContext _) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final dateParts = EventDetailWhenBlock._parts(context, startAt);
-    final startTime = EventDetailWhenBlock._parts(context, startAt).time;
-    final endTime = EventDetailWhenBlock._parts(context, endAt).time;
+    final dateParts = EventDetailWhenBlock._parts(
+      context,
+      startAt,
+      timeZone: timeZone,
+    );
+    final startTime = EventDetailWhenBlock._parts(
+      context,
+      startAt,
+      timeZone: timeZone,
+    ).time;
+    final endTime = EventDetailWhenBlock._parts(
+      context,
+      endAt,
+      timeZone: timeZone,
+    ).time;
 
     final dotTop = _timelinePrimaryDateDotTopInset(
       context,
@@ -212,25 +266,27 @@ class _SameDayRange extends StatelessWidget {
                   height: 1.25,
                 ),
               ),
-              const SizedBox(height: 6),
-              Text.rich(
-                TextSpan(
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
-                  children: [
-                    TextSpan(text: startTime),
-                    TextSpan(
-                      text: ' – ',
-                      style: TextStyle(
-                        color: colors.onSurfaceVariant.withValues(alpha: 0.7),
-                        fontWeight: FontWeight.w400,
-                      ),
+              if (!isDateOnly) ...[
+                const SizedBox(height: 6),
+                Text.rich(
+                  TextSpan(
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w500,
                     ),
-                    TextSpan(text: endTime),
-                  ],
+                    children: [
+                      TextSpan(text: startTime),
+                      TextSpan(
+                        text: ' – ',
+                        style: TextStyle(
+                          color: colors.onSurfaceVariant.withValues(alpha: 0.7),
+                          fontWeight: FontWeight.w400,
+                        ),
+                      ),
+                      TextSpan(text: endTime),
+                    ],
+                  ),
                 ),
-              ),
+              ],
             ],
           ),
         ),
@@ -244,6 +300,8 @@ class _MultiDayRange extends StatelessWidget {
     required this.context,
     required this.startAt,
     required this.endAt,
+    required this.isDateOnly,
+    required this.timeZone,
     required this.startsLabel,
     required this.endsLabel,
     required this.showToday,
@@ -253,6 +311,8 @@ class _MultiDayRange extends StatelessWidget {
   final BuildContext context;
   final DateTime startAt;
   final DateTime endAt;
+  final bool isDateOnly;
+  final String? timeZone;
   final String startsLabel;
   final String endsLabel;
   final bool showToday;
@@ -265,8 +325,11 @@ class _MultiDayRange extends StatelessWidget {
     const lineWidth = 2.0;
     const lineLeft = (dotSize - lineWidth) / 2;
 
-    final blockHeight = _timelineMomentBlockHeight(context);
-    final dotTopInset = _timelineDotTopInset(context);
+    final blockHeight = _timelineMomentBlockHeight(
+      context,
+      showTime: !isDateOnly,
+    );
+    final dotTopInset = _timelineDotTopInset(context, showTime: !isDateOnly);
     final momentGap = SpotDetailUi.timelineMomentGap;
     final railHeight = 2 * blockHeight + momentGap;
     final lineTop = dotTopInset + dotSize;
@@ -321,12 +384,16 @@ class _MultiDayRange extends StatelessWidget {
                     context: context,
                     label: startsLabel,
                     dateTime: startAt,
+                    showTime: !isDateOnly,
+                    timeZone: timeZone,
                   ),
                   SizedBox(height: momentGap),
                   _TimelineMomentContent(
                     context: context,
                     label: endsLabel,
                     dateTime: endAt,
+                    showTime: !isDateOnly,
+                    timeZone: timeZone,
                   ),
                 ],
               ),
@@ -344,17 +411,25 @@ class _TimelineMomentContent extends StatelessWidget {
     required this.context,
     required this.label,
     required this.dateTime,
+    required this.showTime,
+    required this.timeZone,
   });
 
   final BuildContext context;
   final String label;
   final DateTime dateTime;
+  final bool showTime;
+  final String? timeZone;
 
   @override
   Widget build(BuildContext _) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final parts = EventDetailWhenBlock._parts(context, dateTime);
+    final parts = EventDetailWhenBlock._parts(
+      context,
+      dateTime,
+      timeZone: timeZone,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -375,20 +450,25 @@ class _TimelineMomentContent extends StatelessWidget {
             height: 1.25,
           ),
         ),
-        const SizedBox(height: 2),
-        Text(
-          parts.time,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: colors.onSurfaceVariant,
+        if (showTime) ...[
+          const SizedBox(height: 2),
+          Text(
+            parts.time,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
           ),
-        ),
+        ],
       ],
     );
   }
 }
 
 /// Height of one [_TimelineMomentContent] block (label + date + time).
-double _timelineMomentBlockHeight(BuildContext context) {
+double _timelineMomentBlockHeight(
+  BuildContext context, {
+  required bool showTime,
+}) {
   final theme = Theme.of(context);
   final direction = Directionality.of(context);
   final labelStyle = theme.textTheme.labelSmall!.copyWith(
@@ -404,6 +484,9 @@ double _timelineMomentBlockHeight(BuildContext context) {
   final labelHeight = _measureTextHeight('STARTS', labelStyle, direction);
   const gap = 4.0;
   final dateHeight = _measureTextHeight('Sun', dateStyle, direction);
+  if (!showTime) {
+    return labelHeight + gap + dateHeight;
+  }
   final timeHeight = _measureTextHeight('0:00', timeStyle, direction);
   return labelHeight + gap + dateHeight + timeHeight;
 }
@@ -414,7 +497,9 @@ double _todayChipBlockHeight(BuildContext context) {
   const gapBelowChip = 6.0;
   final theme = Theme.of(context);
   final direction = Directionality.of(context);
-  final chipStyle = theme.textTheme.labelSmall!.copyWith(fontWeight: FontWeight.w700);
+  final chipStyle = theme.textTheme.labelSmall!.copyWith(
+    fontWeight: FontWeight.w700,
+  );
   final chipTextHeight = _measureTextHeight('Today', chipStyle, direction);
   return chipTextHeight + chipVerticalPadding * 2 + gapBelowChip;
 }
@@ -436,7 +521,7 @@ double _timelinePrimaryDateDotTopInset(
 }
 
 /// Offset from the top of a [_TimelineMomentContent] to the top of its dot.
-double _timelineDotTopInset(BuildContext context) {
+double _timelineDotTopInset(BuildContext context, {required bool showTime}) {
   final theme = Theme.of(context);
   final labelStyle = theme.textTheme.labelSmall!.copyWith(
     fontWeight: FontWeight.w700,
@@ -451,9 +536,10 @@ double _timelineDotTopInset(BuildContext context) {
   final direction = Directionality.of(context);
   final labelHeight = _measureTextHeight('STARTS', labelStyle, direction);
   const gap = 4.0;
-  final dateRowHeight =
-      _measureTextHeight('Sun', dateStyle, direction) +
-      _measureTextHeight('0:00', timeStyle, direction);
+  final dateRowHeight = showTime
+      ? _measureTextHeight('Sun', dateStyle, direction) +
+            _measureTextHeight('0:00', timeStyle, direction)
+      : _measureTextHeight('Sun', dateStyle, direction);
   const dotSize = _TimelineDot.size;
   return labelHeight + gap + (dateRowHeight - dotSize) / 2;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   pointer_interceptor: ^0.10.1
   validators: ^3.0.0
   visibility_detector: ^0.4.0+2
+  timezone: ^0.10.1
 
 dev_dependencies:
   flutter_test:

--- a/test/models/event_map_pin_test.dart
+++ b/test/models/event_map_pin_test.dart
@@ -9,6 +9,8 @@ void main() {
         id: 'event-1',
         title: 'City Jam',
         startAt: DateTime.utc(2026, 6, 1, 12),
+        isDateOnly: true,
+        timeZone: 'Europe/Paris',
         latitude: 52.37,
         longitude: 4.89,
         address: 'Amsterdam',
@@ -22,6 +24,8 @@ void main() {
       expect(pin.latitude, 52.37);
       expect(pin.longitude, 4.89);
       expect(pin.title, 'City Jam');
+      expect(pin.isDateOnly, isTrue);
+      expect(pin.timeZone, 'Europe/Paris');
       expect(pin.countryCode, 'NL');
     });
 
@@ -49,10 +53,7 @@ void main() {
         address: 'Somewhere',
       );
 
-      expect(
-        () => EventMapPin.fromParkourEvent(event),
-        throwsArgumentError,
-      );
+      expect(() => EventMapPin.fromParkourEvent(event), throwsArgumentError);
     });
   });
 }

--- a/test/models/parkour_event_test.dart
+++ b/test/models/parkour_event_test.dart
@@ -18,6 +18,8 @@ void main() {
         'websiteUrl': 'https://parkour.spot/events/sunset-jam',
         'startAt': Timestamp.fromDate(startAt),
         'endAt': Timestamp.fromDate(endAt),
+        'isDateOnly': true,
+        'timeZone': 'Europe/Paris',
         'latitude': 52.3702,
         'longitude': 4.8952,
         'address': 'Amsterdam, Netherlands',
@@ -38,6 +40,8 @@ void main() {
       expect(event.websiteUrl, 'https://parkour.spot/events/sunset-jam');
       expect(event.startAt.toUtc(), startAt);
       expect(event.endAt?.toUtc(), endAt);
+      expect(event.isDateOnly, isTrue);
+      expect(event.timeZone, 'Europe/Paris');
       expect(event.latitude, 52.3702);
       expect(event.longitude, 4.8952);
       expect(event.address, 'Amsterdam, Netherlands');
@@ -50,17 +54,20 @@ void main() {
       expect(event.isNativeEvent, isTrue);
     });
 
-    test('fromMap parses duplicateOf and external source for isNativeEvent', () {
-      final event = ParkourEvent.fromMap({
-        'title': 'Synced',
-        'startAt': Timestamp.fromDate(DateTime.utc(2026, 1, 1)),
-        'spotIds': const ['spot-x'],
-        'eventSourceId': 'ics-source',
-        'duplicateOf': 'native-original',
-      });
-      expect(event.duplicateOf, 'native-original');
-      expect(event.isNativeEvent, isFalse);
-    });
+    test(
+      'fromMap parses duplicateOf and external source for isNativeEvent',
+      () {
+        final event = ParkourEvent.fromMap({
+          'title': 'Synced',
+          'startAt': Timestamp.fromDate(DateTime.utc(2026, 1, 1)),
+          'spotIds': const ['spot-x'],
+          'eventSourceId': 'ics-source',
+          'duplicateOf': 'native-original',
+        });
+        expect(event.duplicateOf, 'native-original');
+        expect(event.isNativeEvent, isFalse);
+      },
+    );
 
     test('toFirestore keeps linked spots and trims description', () {
       final event = ParkourEvent(
@@ -71,6 +78,8 @@ void main() {
         websiteUrl: ' https://event.example/info ',
         startAt: DateTime.utc(2026, 6, 1, 14, 0),
         endAt: DateTime.utc(2026, 6, 1, 16, 0),
+        isDateOnly: false,
+        timeZone: 'Europe/Paris',
         latitude: 48.8566,
         longitude: 2.3522,
         address: '  Paris, France ',
@@ -86,6 +95,7 @@ void main() {
       expect(map['description'], 'Meet and train');
       expect(map['imageUrls'], ['https://img.example/event.jpg']);
       expect(map['websiteUrl'], 'https://event.example/info');
+      expect(map['timeZone'], 'Europe/Paris');
       expect(map['spotIds'], ['spot-c', 'spot-d']);
       expect(map['spotListIds'], isEmpty);
       expect(map['startAt'], DateTime.utc(2026, 6, 1, 14, 0));
@@ -96,6 +106,7 @@ void main() {
       expect(map['createdBy'], 'admin-uid');
       expect(map['createdAt'], DateTime.utc(2026, 5, 25, 8, 0));
       expect(map['updatedAt'], DateTime.utc(2026, 5, 25, 9, 0));
+      expect(map.containsKey('isDateOnly'), isFalse);
     });
 
     test('fromMap defaults spotListIds to empty list', () {
@@ -116,6 +127,19 @@ void main() {
       );
       final map = event.toFirestore();
       expect(map['duplicateOf'], 'orig-id');
+    });
+
+    test('toFirestore includes date-only schedule fields when set', () {
+      final event = ParkourEvent(
+        title: 'Holiday Jam',
+        startAt: DateTime.utc(2026, 12, 24),
+        endAt: DateTime.utc(2026, 12, 26, 23, 59, 59, 999),
+        isDateOnly: true,
+        timeZone: 'Europe/Paris',
+      );
+      final map = event.toFirestore();
+      expect(map['isDateOnly'], isTrue);
+      expect(map['timeZone'], 'Europe/Paris');
     });
 
     test('fromMap parses createdFromCreateNative', () {

--- a/test/utils/event_schedule_utils_test.dart
+++ b/test/utils/event_schedule_utils_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/utils/event_schedule_utils.dart';
+
+void main() {
+  group('EventScheduleUtils', () {
+    test('normalizes known timezone ids', () {
+      expect(
+        EventScheduleUtils.normalizeTimeZone('Europe/Paris'),
+        'Europe/Paris',
+      );
+      expect(EventScheduleUtils.normalizeTimeZone('Invalid/Zone'), isNull);
+      expect(EventScheduleUtils.normalizeTimeZone('  '), isNull);
+    });
+
+    test('converts local timezone date-time to UTC and back', () {
+      final utc = EventScheduleUtils.localDateTimeToUtc(
+        DateTime(2026, 7, 10, 18, 30),
+        timeZone: 'Europe/Paris',
+      );
+      final display = EventScheduleUtils.toDisplayDateTime(
+        utc,
+        timeZone: 'Europe/Paris',
+      );
+      expect(display.year, 2026);
+      expect(display.month, 7);
+      expect(display.day, 10);
+      expect(display.hour, 18);
+      expect(display.minute, 30);
+    });
+
+    test('date start/end helpers create same-day boundaries', () {
+      final startUtc = EventScheduleUtils.dateStartToUtc(
+        DateTime(2026, 8, 2),
+        timeZone: 'America/New_York',
+      );
+      final endUtc = EventScheduleUtils.dateEndToUtc(
+        DateTime(2026, 8, 2),
+        timeZone: 'America/New_York',
+      );
+      final startDisplay = EventScheduleUtils.toDisplayDateTime(
+        startUtc,
+        timeZone: 'America/New_York',
+      );
+      final endDisplay = EventScheduleUtils.toDisplayDateTime(
+        endUtc,
+        timeZone: 'America/New_York',
+      );
+      expect(startDisplay.hour, 0);
+      expect(startDisplay.minute, 0);
+      expect(endDisplay.hour, 23);
+      expect(endDisplay.minute, 59);
+      expect(
+        EventScheduleUtils.isSameCalendarDay(
+          startUtc,
+          endUtc,
+          timeZone: 'America/New_York',
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add schedule metadata (`timeZone`, `isDateOnly`) to events and event-map-pin payloads
- add shared timezone/date-only conversion + formatting utilities for frontend rendering
- update admin create/edit event flows to choose timezone and toggle date-only mode
- ensure edit updates can switch date-only off and clear/replace timezone safely
- update event schedule rendering across admin list, explore cards, spot upcoming panel, and event detail timeline
- extend focused Dart and Functions tests for schedule metadata handling

## Testing
- `flutter test test/models/parkour_event_test.dart test/models/event_map_pin_test.dart test/utils/event_schedule_utils_test.dart`
- `npm test -- event-map-pins.test.js events-in-bounds.test.js`
- `flutter analyze lib/widgets/event_detail_when_block.dart lib/screens/events/event_detail_screen.dart`
- manual admin UI verification on emulator app (`localhost:8080`) for both date-only and timezone-timed flows

## Walkthrough artifacts
[event_timezone_timed_rendering_demo.mp4](https://cursor.com/agents/bc-a94e944b-d233-4dab-b1f7-62282d9d3825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_timezone_timed_rendering_demo.mp4)
[Date-only list without times](https://cursor.com/agents/bc-a94e944b-d233-4dab-b1f7-62282d9d3825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdate_only_event_list_no_times.webp)
[Date-only detail without times](https://cursor.com/agents/bc-a94e944b-d233-4dab-b1f7-62282d9d3825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdate_only_event_detail_no_times.webp)
[Timed list with timezone](https://cursor.com/agents/bc-a94e944b-d233-4dab-b1f7-62282d9d3825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimed_event_list_with_timezone_edt.webp)
[Timed detail with timezone](https://cursor.com/agents/bc-a94e944b-d233-4dab-b1f7-62282d9d3825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimed_event_detail_with_timezone_edt.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a94e944b-d233-4dab-b1f7-62282d9d3825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a94e944b-d233-4dab-b1f7-62282d9d3825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

