### PR TITLE
Add public non-duplicate events to sitemap generation

### DIFF
--- a/functions/generate-sitemaps.js
+++ b/functions/generate-sitemaps.js
@@ -7,6 +7,7 @@
  * - A sitemap for spots without country/city (sitemap-unlocated.xml)
  * - A sitemap for public spot lists (sitemap-lists.xml)
  * - A sitemap for public user profiles (sitemap-users.xml)
+ * - A sitemap for public non-duplicate events (sitemap-events.xml)
  * - A sitemap index file (sitemap.xml) that references all sitemaps
  * - Includes URLs for country pages, city pages, and individual spot pages
  */
@@ -146,8 +147,10 @@ async function uploadSitemapToStorage(filename, xmlContent) {
 function isValidSitemapFilename(filename) {
   // sitemap.xml, sitemap-{country}.xml, sitemap-{country}-{n}.xml,
   // sitemap-unlocated.xml, sitemap-unlocated-{n}.xml,
-  // sitemap-lists.xml, sitemap-lists-{n}.xml, sitemap-users.xml, sitemap-users-{n}.xml
-  if (!/^sitemap(-(unlocated(-\d+)?|lists(-\d+)?|users(-\d+)?|[a-z]{2}(-\d+)?))?\.xml$/.test(filename)) {
+  // sitemap-lists.xml, sitemap-lists-{n}.xml,
+  // sitemap-users.xml, sitemap-users-{n}.xml,
+  // sitemap-events.xml, sitemap-events-{n}.xml
+  if (!/^sitemap(-(unlocated(-\d+)?|lists(-\d+)?|users(-\d+)?|events(-\d+)?|[a-z]{2}(-\d+)?))?\.xml$/.test(filename)) {
     return false;
   }
 
@@ -427,6 +430,67 @@ async function generateAllSitemaps() {
     }
   } catch (error) {
     console.error("Error generating sitemap for user profiles:", error);
+  }
+
+  // Generate sitemap for public non-duplicate events
+  try {
+    const eventsSnapshot = await db.collection("events").get();
+    const publicEvents = eventsSnapshot.docs
+        .map((doc) => ({id: doc.id, ...doc.data()}))
+        .filter((event) => {
+          const duplicateOf = typeof event.duplicateOf === "string" ?
+            event.duplicateOf.trim() :
+            "";
+          if (duplicateOf.length > 0) {
+            return false;
+          }
+
+          if (event.isPublic === false || event.isPrivate === true || event.hidden === true) {
+            return false;
+          }
+
+          const visibility = typeof event.visibility === "string" ?
+            event.visibility.trim().toLowerCase() :
+            "";
+          if (visibility.length > 0 && visibility !== "public") {
+            return false;
+          }
+
+          return true;
+        });
+
+    if (publicEvents.length > 0) {
+      const eventUrls = publicEvents.map((event) => ({
+        loc: `${BASE_URL}/event/${event.id}`,
+        lastmod: formatDateToISO(event.updatedAt ?? event.createdAt ?? event.startAt),
+      }));
+
+      if (eventUrls.length <= MAX_URLS_PER_SITEMAP) {
+        const sitemapName = "sitemap-events.xml";
+        const xml = generateSitemapXml(eventUrls);
+        await uploadSitemapToStorage(sitemapName, xml);
+        sitemapIndexEntries.push({
+          loc: `${BASE_URL}/sitemaps/${sitemapName}`,
+          lastmod: now,
+        });
+      } else {
+        let partNumber = 1;
+        for (let i = 0; i < eventUrls.length; i += MAX_URLS_PER_SITEMAP) {
+          const chunk = eventUrls.slice(i, i + MAX_URLS_PER_SITEMAP);
+          const sitemapName = `sitemap-events-${partNumber}.xml`;
+          const xml = generateSitemapXml(chunk);
+          await uploadSitemapToStorage(sitemapName, xml);
+          sitemapIndexEntries.push({
+            loc: `${BASE_URL}/sitemaps/${sitemapName}`,
+            lastmod: now,
+          });
+          partNumber++;
+        }
+      }
+      console.log(`Generated sitemap(s) for public non-duplicate events with ${eventUrls.length} URLs`);
+    }
+  } catch (error) {
+    console.error("Error generating sitemap for public events:", error);
   }
 
   // Generate and upload sitemap index

--- a/functions/index.js
+++ b/functions/index.js
@@ -9949,6 +9949,8 @@ exports.regenerateApiClientKey = onCall({region: "europe-west1"}, async (request
  * Handles requests for:
  * - /sitemap.xml (sitemap index)
  * - /sitemaps/sitemap-{country}.xml (country sitemaps)
+ * - /sitemaps/sitemap-unlocated.xml, /sitemaps/sitemap-lists.xml,
+ *   /sitemaps/sitemap-users.xml, /sitemaps/sitemap-events.xml
  */
 exports.serveSitemap = onRequest(
     {
@@ -9972,8 +9974,10 @@ exports.serveSitemap = onRequest(
           // Validate filename to prevent path traversal attacks
           // sitemap.xml, sitemap-{country}.xml, sitemap-{country}-{n}.xml,
           // sitemap-unlocated.xml, sitemap-unlocated-{n}.xml,
-          // sitemap-lists.xml, sitemap-lists-{n}.xml, sitemap-users.xml, sitemap-users-{n}.xml
-          if (!/^sitemap(-(unlocated(-\d+)?|lists(-\d+)?|users(-\d+)?|[a-z]{2}(-\d+)?))?\.xml$/.test(sitemapName)) {
+          // sitemap-lists.xml, sitemap-lists-{n}.xml,
+          // sitemap-users.xml, sitemap-users-{n}.xml,
+          // sitemap-events.xml, sitemap-events-{n}.xml
+          if (!/^sitemap(-(unlocated(-\d+)?|lists(-\d+)?|users(-\d+)?|events(-\d+)?|[a-z]{2}(-\d+)?))?\.xml$/.test(sitemapName)) {
             res.status(400).send("Invalid sitemap filename");
             return;
           }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add event sitemap generation for all public, non-duplicate events (`/event/:id` URLs)
- include `sitemap-events.xml` (and chunked variants) in sitemap filename validation
- update sitemap serving docs/validation so event sitemap files are served from `/sitemaps/**`

## Testing
- `cd functions && npm run lint`
- `cd functions && npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fe2d402-c3ad-4a45-9cc2-13b9f49a3595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fe2d402-c3ad-4a45-9cc2-13b9f49a3595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

