### PR TITLE
Add user event submission flow and moderator queue

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -511,6 +511,12 @@ service cloud.firestore {
          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true);
     }
 
+    // Event reports - authenticated users can submit, moderators/admins can review.
+    match /eventReports/{reportId} {
+      allow create: if request.auth != null;
+      allow read, update, delete: if requestingUserIsStaff();
+    }
+
     // Comments collection - users can read all comments, authenticated users can create, owners can edit/delete
     match /comments/{commentId} {
       allow read: if true;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:parkour_spot/services/auth_service.dart';
 import 'package:parkour_spot/services/event_map_service.dart';
 import 'package:parkour_spot/services/spot_service.dart';
 import 'package:parkour_spot/services/spot_report_service.dart';
+import 'package:parkour_spot/services/event_report_service.dart';
 import 'package:parkour_spot/services/sync_source_service.dart';
 import 'package:parkour_spot/services/api_client_service.dart';
 import 'package:parkour_spot/services/search_state_service.dart';
@@ -199,6 +200,7 @@ class ParkourSpotApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => GeocodingService()),
         ChangeNotifierProvider(create: (_) => JumpflixService()),
         Provider(create: (_) => SpotReportService()),
+        Provider(create: (_) => EventReportService()),
         ChangeNotifierProxyProvider<AuthService, SpotListService>(
           create: (context) {
             final authService = Provider.of<AuthService>(

--- a/lib/models/event_report.dart
+++ b/lib/models/event_report.dart
@@ -1,0 +1,138 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+@immutable
+class EventReport {
+  const EventReport({
+    required this.id,
+    required this.title,
+    required this.status,
+    required this.startAt,
+    this.description,
+    this.websiteUrl,
+    this.endAt,
+    this.isDateOnly = false,
+    this.timeZone,
+    this.latitude,
+    this.longitude,
+    this.address,
+    this.city,
+    this.countryCode,
+    this.spotIds = const <String>[],
+    this.spotListIds = const <String>[],
+    this.linkedSpotName,
+    this.linkedSpotListName,
+    this.reporterUserId,
+    this.reporterName,
+    this.reporterEmail,
+    this.moderatorNotes,
+    this.approvedEventId,
+    this.reviewedBy,
+    this.reviewedByName,
+    this.createdAt,
+    this.updatedAt,
+    this.reviewedAt,
+  });
+
+  final String id;
+  final String title;
+  final String? description;
+  final String? websiteUrl;
+  final DateTime startAt;
+  final DateTime? endAt;
+  final bool isDateOnly;
+  final String? timeZone;
+  final double? latitude;
+  final double? longitude;
+  final String? address;
+  final String? city;
+  final String? countryCode;
+  final List<String> spotIds;
+  final List<String> spotListIds;
+  final String? linkedSpotName;
+  final String? linkedSpotListName;
+  final String? reporterUserId;
+  final String? reporterName;
+  final String? reporterEmail;
+  final String status;
+  final String? moderatorNotes;
+  final String? approvedEventId;
+  final String? reviewedBy;
+  final String? reviewedByName;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? reviewedAt;
+
+  factory EventReport.fromSnapshot(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data();
+    if (data == null) {
+      throw StateError('Missing data for event report ${snapshot.id}');
+    }
+
+    DateTime? parseDate(dynamic value) {
+      if (value is Timestamp) return value.toDate();
+      if (value is DateTime) return value;
+      if (value is num) {
+        return DateTime.fromMillisecondsSinceEpoch(value.toInt());
+      }
+      return null;
+    }
+
+    List<String> parseStringList(dynamic raw) {
+      if (raw is Iterable) {
+        return raw.whereType<String>().toList(growable: false);
+      }
+      return const <String>[];
+    }
+
+    double? parseDouble(dynamic raw) {
+      if (raw is num) return raw.toDouble();
+      return null;
+    }
+
+    final parsedStart = parseDate(data['startAt']);
+
+    return EventReport(
+      id: snapshot.id,
+      title: data['title'] as String? ?? 'Untitled event',
+      description: data['description'] as String?,
+      websiteUrl: data['websiteUrl'] as String?,
+      startAt: parsedStart ?? DateTime.now().toUtc(),
+      endAt: parseDate(data['endAt']),
+      isDateOnly: data['isDateOnly'] == true,
+      timeZone: data['timeZone'] as String?,
+      latitude: parseDouble(data['latitude']),
+      longitude: parseDouble(data['longitude']),
+      address: data['address'] as String?,
+      city: data['city'] as String?,
+      countryCode: data['countryCode'] as String?,
+      spotIds: parseStringList(data['spotIds']),
+      spotListIds: parseStringList(data['spotListIds']),
+      linkedSpotName: data['linkedSpotName'] as String?,
+      linkedSpotListName: data['linkedSpotListName'] as String?,
+      reporterUserId: data['reporterUserId'] as String?,
+      reporterName: data['reporterName'] as String?,
+      reporterEmail: data['reporterEmail'] as String?,
+      status: data['status'] as String? ?? 'New',
+      moderatorNotes: data['moderatorNotes'] as String?,
+      approvedEventId: data['approvedEventId'] as String?,
+      reviewedBy: data['reviewedBy'] as String?,
+      reviewedByName: data['reviewedByName'] as String?,
+      createdAt: parseDate(data['createdAt']),
+      updatedAt: parseDate(data['updatedAt']),
+      reviewedAt: parseDate(data['reviewedAt']),
+    );
+  }
+
+  String? get locationSummary {
+    if ((city?.isNotEmpty ?? false) && (countryCode?.isNotEmpty ?? false)) {
+      return '$city, ${countryCode!.toUpperCase()}';
+    }
+    if (city?.isNotEmpty ?? false) return city;
+    if (countryCode?.isNotEmpty ?? false) return countryCode!.toUpperCase();
+    if (address?.isNotEmpty ?? false) return address;
+    return null;
+  }
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -27,10 +27,13 @@ import '../screens/admin/device_detection_screen.dart';
 import '../screens/debug/support_debug_screen.dart';
 import '../screens/admin/api_clients_screen.dart';
 import '../screens/moderator/moderator_tools_screen.dart';
+import '../screens/moderator/event_report_queue_screen.dart';
 import '../screens/moderator/spot_report_queue_screen.dart';
+import '../screens/events/add_event_report_screen.dart';
 import '../screens/spots/spot_detail_screen.dart';
 import '../screens/events/event_detail_screen.dart';
 import '../l10n/app_localizations.dart';
+import '../screens/spots/add_spot_screen.dart';
 import '../screens/spots/edit_spot_screen.dart';
 import '../screens/spots/spot_list_detail_screen.dart';
 import '../screens/spots/spot_tracking_list_screen.dart';
@@ -227,6 +230,7 @@ class AppRouter {
         // Routes that require authentication
         final protectedRoutes = [
           '/spots/add',
+          '/events/add',
           '/moderator',
           '/profile/notifications',
         ];
@@ -234,7 +238,8 @@ class AppRouter {
             !isAuthenticated) {
           // Redirect to login with the intended destination
           String redirectTo;
-          if (state.matchedLocation == '/spots/add') {
+          if (state.matchedLocation == '/spots/add' ||
+              state.matchedLocation == '/events/add') {
             redirectTo = '/explore?tab=add';
           } else {
             redirectTo = state.matchedLocation;
@@ -297,10 +302,38 @@ class AppRouter {
             );
           },
         ),
-        // Individual tab routes that redirect to explore with tab parameter
+        // Add forms
         GoRoute(
           path: '/spots/add',
-          redirect: (context, state) => '/explore?tab=add',
+          builder: (context, state) {
+            final latParam = state.uri.queryParameters['lat'];
+            final lngParam = state.uri.queryParameters['lng'];
+            final lat = latParam != null ? double.tryParse(latParam) : null;
+            final lng = lngParam != null ? double.tryParse(lngParam) : null;
+            final initialLocation = (lat != null && lng != null)
+                ? gmaps.LatLng(lat, lng)
+                : null;
+            return AddSpotScreen(initialLocation: initialLocation);
+          },
+        ),
+        GoRoute(
+          path: '/events/add',
+          builder: (context, state) {
+            final latParam = state.uri.queryParameters['lat'];
+            final lngParam = state.uri.queryParameters['lng'];
+            final lat = latParam != null ? double.tryParse(latParam) : null;
+            final lng = lngParam != null ? double.tryParse(lngParam) : null;
+            final initialLocation = (lat != null && lng != null)
+                ? gmaps.LatLng(lat, lng)
+                : null;
+            return AddEventReportScreen(
+              initialLocation: initialLocation,
+              initialSpotId: state.uri.queryParameters['spotId'],
+              initialSpotName: state.uri.queryParameters['spotName'],
+              initialSpotListId: state.uri.queryParameters['spotListId'],
+              initialSpotListName: state.uri.queryParameters['spotListName'],
+            );
+          },
         ),
         GoRoute(
           path: '/profile',
@@ -443,6 +476,10 @@ class AppRouter {
             GoRoute(
               path: 'reports',
               builder: (context, state) => const SpotReportQueueScreen(),
+            ),
+            GoRoute(
+              path: 'event-reports',
+              builder: (context, state) => const EventReportQueueScreen(),
             ),
             GoRoute(
               path: 'duplicate-spots',

--- a/lib/screens/add/add_hub_screen.dart
+++ b/lib/screens/add/add_hub_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class AddHubScreen extends StatelessWidget {
+  const AddHubScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const SizedBox.shrink(),
+        toolbarHeight: 0,
+        elevation: 0,
+        backgroundColor: theme.colorScheme.surface,
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1000),
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                'What do you want to add?',
+                style: theme.textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Spots are published immediately. Events are reviewed by moderators first.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Add spot', style: theme.textTheme.titleLarge),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Share a new training spot with photos and details.',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 16),
+                      FilledButton.icon(
+                        onPressed: () => context.push('/spots/add'),
+                        icon: const Icon(Icons.add_location_alt_outlined),
+                        label: const Text('Create spot'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Add event', style: theme.textTheme.titleLarge),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Submit an event proposal. Moderators approve or reject it.',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 16),
+                      FilledButton.icon(
+                        onPressed: () => context.push('/events/add'),
+                        icon: const Icon(Icons.event_available_outlined),
+                        label: const Text('Create event'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/events/add_event_report_screen.dart
+++ b/lib/screens/events/add_event_report_screen.dart
@@ -221,6 +221,13 @@ class _AddEventReportScreenState extends State<AddEventReportScreen> {
     return '$date · $time';
   }
 
+  String? _effectiveAddressForSubmission() {
+    final trimmed = _address?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) return trimmed;
+    if (_pickedLocation == null) return null;
+    return 'Approx. ${_pickedLocation!.latitude.toStringAsFixed(5)}, ${_pickedLocation!.longitude.toStringAsFixed(5)}';
+  }
+
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;
     if (!_hasValidWebsiteUrl()) {
@@ -240,13 +247,12 @@ class _AddEventReportScreenState extends State<AddEventReportScreen> {
 
     final hasLinkedSpot = _linkedSpotId != null;
     final hasLinkedList = _linkedSpotListId != null;
-    final hasLocation =
-        _pickedLocation != null && (_address?.isNotEmpty ?? false);
+    final hasLocation = _pickedLocation != null;
     if (!hasLinkedSpot && !hasLinkedList && !hasLocation) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-            'Add a location, link a spot, or link a spot list before submitting.',
+            'Add a map location, link a spot, or link a spot list before submitting.',
           ),
         ),
       );
@@ -275,7 +281,7 @@ class _AddEventReportScreenState extends State<AddEventReportScreen> {
             isDateOnly: _isDateOnly,
             latitude: _pickedLocation?.latitude,
             longitude: _pickedLocation?.longitude,
-            address: _address,
+            address: _effectiveAddressForSubmission(),
             city: _city,
             countryCode: _countryCode,
             spotIds: _linkedSpotId == null

--- a/lib/screens/events/add_event_report_screen.dart
+++ b/lib/screens/events/add_event_report_screen.dart
@@ -1,0 +1,520 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/auth_service.dart';
+import '../../services/event_report_service.dart';
+import '../../services/geocoding_service.dart';
+import '../spots/location_picker_screen.dart';
+
+class AddEventReportScreen extends StatefulWidget {
+  const AddEventReportScreen({
+    super.key,
+    this.initialLocation,
+    this.initialSpotId,
+    this.initialSpotName,
+    this.initialSpotListId,
+    this.initialSpotListName,
+  });
+
+  final LatLng? initialLocation;
+  final String? initialSpotId;
+  final String? initialSpotName;
+  final String? initialSpotListId;
+  final String? initialSpotListName;
+
+  @override
+  State<AddEventReportScreen> createState() => _AddEventReportScreenState();
+}
+
+class _AddEventReportScreenState extends State<AddEventReportScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _websiteController = TextEditingController();
+
+  bool _isSubmitting = false;
+  bool _isDateOnly = false;
+  DateTime _startAt = DateTime.now().toUtc().add(const Duration(hours: 1));
+  DateTime? _endAt;
+
+  LatLng? _pickedLocation;
+  String? _address;
+  String? _city;
+  String? _countryCode;
+  bool _isGeocoding = false;
+
+  String? _linkedSpotId;
+  String? _linkedSpotName;
+  String? _linkedSpotListId;
+  String? _linkedSpotListName;
+
+  @override
+  void initState() {
+    super.initState();
+    _pickedLocation = widget.initialLocation;
+    _linkedSpotId = widget.initialSpotId;
+    _linkedSpotName = widget.initialSpotName;
+    _linkedSpotListId = widget.initialSpotListId;
+    _linkedSpotListName = widget.initialSpotListName;
+    if (_pickedLocation != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _geocodeLocation(_pickedLocation!);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _websiteController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _geocodeLocation(LatLng location) async {
+    if (!mounted) return;
+    setState(() => _isGeocoding = true);
+    try {
+      final geocodingService = context.read<GeocodingService>();
+      final result = await geocodingService.geocodeCoordinatesDetails(
+        location.latitude,
+        location.longitude,
+      );
+      if (!mounted) return;
+      setState(() {
+        _address = result['address'];
+        _city = result['city'];
+        _countryCode = result['countryCode'];
+      });
+    } catch (_) {
+      // Best-effort reverse geocoding.
+    } finally {
+      if (mounted) {
+        setState(() => _isGeocoding = false);
+      }
+    }
+  }
+
+  Future<void> _pickLocationOnMap() async {
+    final picked = await Navigator.of(context).push<LatLng>(
+      MaterialPageRoute(
+        builder: (_) => LocationPickerScreen(
+          initialLocation: _pickedLocation,
+          showUsageTip: true,
+        ),
+      ),
+    );
+    if (picked == null || !mounted) return;
+    setState(() {
+      _pickedLocation = picked;
+    });
+    await _geocodeLocation(picked);
+  }
+
+  Future<void> _pickStartDateTime() async {
+    final localStart = _startAt.toLocal();
+    final pickedDate = await showDatePicker(
+      context: context,
+      initialDate: localStart,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 3650)),
+    );
+    if (pickedDate == null || !mounted) return;
+
+    if (_isDateOnly) {
+      final newStart = DateTime(
+        pickedDate.year,
+        pickedDate.month,
+        pickedDate.day,
+      ).toUtc();
+      setState(() {
+        _startAt = newStart;
+        if (_endAt != null && _endAt!.isBefore(_startAt)) {
+          _endAt = _startAt;
+        }
+      });
+      return;
+    }
+
+    final pickedTime = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(localStart),
+    );
+    if (pickedTime == null || !mounted) return;
+
+    final localDateTime = DateTime(
+      pickedDate.year,
+      pickedDate.month,
+      pickedDate.day,
+      pickedTime.hour,
+      pickedTime.minute,
+    );
+    final utcDateTime = localDateTime.toUtc();
+    setState(() {
+      _startAt = utcDateTime;
+      if (_endAt != null && _endAt!.isBefore(_startAt)) {
+        _endAt = _startAt.add(const Duration(hours: 1));
+      }
+    });
+  }
+
+  Future<void> _pickEndDateTime() async {
+    final localInitial = (_endAt ?? _startAt).toLocal();
+    final pickedDate = await showDatePicker(
+      context: context,
+      initialDate: localInitial,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 3650)),
+    );
+    if (pickedDate == null || !mounted) return;
+
+    if (_isDateOnly) {
+      final endDay = DateTime(
+        pickedDate.year,
+        pickedDate.month,
+        pickedDate.day,
+        23,
+        59,
+        59,
+      ).toUtc();
+      setState(() {
+        _endAt = endDay;
+      });
+      return;
+    }
+
+    final pickedTime = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(localInitial),
+    );
+    if (pickedTime == null || !mounted) return;
+    final localDateTime = DateTime(
+      pickedDate.year,
+      pickedDate.month,
+      pickedDate.day,
+      pickedTime.hour,
+      pickedTime.minute,
+    );
+    setState(() {
+      _endAt = localDateTime.toUtc();
+    });
+  }
+
+  bool _hasValidWebsiteUrl() {
+    final raw = _websiteController.text.trim();
+    if (raw.isEmpty) return true;
+    final uri = Uri.tryParse(raw);
+    return uri != null &&
+        uri.hasAuthority &&
+        (uri.scheme == 'http' || uri.scheme == 'https');
+  }
+
+  String _formatDateTime(DateTime value) {
+    final local = value.toLocal();
+    final date = MaterialLocalizations.of(context).formatMediumDate(local);
+    if (_isDateOnly) return date;
+    final time = MaterialLocalizations.of(
+      context,
+    ).formatTimeOfDay(TimeOfDay.fromDateTime(local));
+    return '$date · $time';
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    if (!_hasValidWebsiteUrl()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Website URL must be a valid http(s) URL.'),
+        ),
+      );
+      return;
+    }
+    if (_endAt != null && _endAt!.isBefore(_startAt)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('End time cannot be before start time.')),
+      );
+      return;
+    }
+
+    final hasLinkedSpot = _linkedSpotId != null;
+    final hasLinkedList = _linkedSpotListId != null;
+    final hasLocation =
+        _pickedLocation != null && (_address?.isNotEmpty ?? false);
+    if (!hasLinkedSpot && !hasLinkedList && !hasLocation) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Add a location, link a spot, or link a spot list before submitting.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    final authService = context.read<AuthService>();
+    final user = authService.currentUser;
+    if (user == null) {
+      context.go('/login?redirectTo=${Uri.encodeComponent('/events/add')}');
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+    try {
+      final success = await context
+          .read<EventReportService>()
+          .submitEventReport(
+            title: _titleController.text,
+            description: _descriptionController.text,
+            websiteUrl: _websiteController.text.trim().isEmpty
+                ? null
+                : _websiteController.text.trim(),
+            startAt: _startAt,
+            endAt: _endAt,
+            isDateOnly: _isDateOnly,
+            latitude: _pickedLocation?.latitude,
+            longitude: _pickedLocation?.longitude,
+            address: _address,
+            city: _city,
+            countryCode: _countryCode,
+            spotIds: _linkedSpotId == null
+                ? const <String>[]
+                : <String>[_linkedSpotId!],
+            spotListIds: _linkedSpotListId == null
+                ? const <String>[]
+                : <String>[_linkedSpotListId!],
+            linkedSpotName: _linkedSpotName,
+            linkedSpotListName: _linkedSpotListName,
+            reporterUserId: user.uid,
+            reporterName:
+                authService.userProfile?.displayName ??
+                user.displayName ??
+                user.email,
+            reporterEmail: user.email,
+          );
+
+      if (!mounted) return;
+      if (!success) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not submit event proposal.')),
+        );
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Event submitted to the moderator queue.'),
+          backgroundColor: Colors.green,
+        ),
+      );
+
+      if (Navigator.canPop(context)) {
+        Navigator.of(context).pop(true);
+      } else {
+        context.go('/explore?tab=add');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add event')),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Text(
+                  'Event proposals are reviewed by moderators before they become public.',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'Event title',
+                border: OutlineInputBorder(),
+              ),
+              textCapitalization: TextCapitalization.words,
+              validator: (value) {
+                final trimmed = value?.trim() ?? '';
+                if (trimmed.isEmpty) return 'Title is required.';
+                if (trimmed.length > 200) return 'Title is too long.';
+                return null;
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Description (optional)',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 4,
+              textCapitalization: TextCapitalization.sentences,
+              validator: (value) {
+                final trimmed = value?.trim() ?? '';
+                if (trimmed.length > 2000) {
+                  return 'Description is too long.';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _websiteController,
+              decoration: const InputDecoration(
+                labelText: 'Website URL (optional)',
+                hintText: 'https://example.com',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.url,
+              autocorrect: false,
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              value: _isDateOnly,
+              title: const Text('All-day event'),
+              onChanged: (value) {
+                setState(() {
+                  _isDateOnly = value;
+                });
+              },
+            ),
+            const SizedBox(height: 8),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Start'),
+              subtitle: Text(_formatDateTime(_startAt)),
+              trailing: const Icon(Icons.edit_calendar),
+              onTap: _pickStartDateTime,
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('End (optional)'),
+              subtitle: Text(
+                _endAt == null ? 'Not set' : _formatDateTime(_endAt!),
+              ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (_endAt != null)
+                    IconButton(
+                      icon: const Icon(Icons.clear),
+                      tooltip: 'Clear end',
+                      onPressed: () => setState(() => _endAt = null),
+                    ),
+                  const Icon(Icons.edit_calendar),
+                ],
+              ),
+              onTap: _pickEndDateTime,
+            ),
+            const Divider(height: 24),
+            Text('Linking', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (_linkedSpotId != null)
+              Chip(
+                avatar: const Icon(Icons.location_on_outlined, size: 18),
+                label: Text(
+                  _linkedSpotName?.isNotEmpty == true
+                      ? 'Spot: ${_linkedSpotName!}'
+                      : 'Spot: $_linkedSpotId',
+                ),
+                onDeleted: () {
+                  setState(() {
+                    _linkedSpotId = null;
+                    _linkedSpotName = null;
+                  });
+                },
+              ),
+            if (_linkedSpotListId != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Chip(
+                  avatar: const Icon(Icons.list_alt_outlined, size: 18),
+                  label: Text(
+                    _linkedSpotListName?.isNotEmpty == true
+                        ? 'Spot list: ${_linkedSpotListName!}'
+                        : 'Spot list: $_linkedSpotListId',
+                  ),
+                  onDeleted: () {
+                    setState(() {
+                      _linkedSpotListId = null;
+                      _linkedSpotListName = null;
+                    });
+                  },
+                ),
+              ),
+            const SizedBox(height: 12),
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.map_outlined),
+                title: Text(
+                  _pickedLocation == null
+                      ? 'Location not set'
+                      : '${_pickedLocation!.latitude.toStringAsFixed(5)}, ${_pickedLocation!.longitude.toStringAsFixed(5)}',
+                ),
+                subtitle: Text(
+                  _isGeocoding
+                      ? 'Loading address...'
+                      : (_address?.isNotEmpty ?? false)
+                      ? _address!
+                      : 'Pick a location on the map (optional when linked spot/list exists).',
+                ),
+                trailing: Wrap(
+                  spacing: 4,
+                  children: [
+                    if (_pickedLocation != null)
+                      IconButton(
+                        tooltip: 'Clear location',
+                        onPressed: () {
+                          setState(() {
+                            _pickedLocation = null;
+                            _address = null;
+                            _city = null;
+                            _countryCode = null;
+                          });
+                        },
+                        icon: const Icon(Icons.clear),
+                      ),
+                    IconButton(
+                      tooltip: 'Pick location',
+                      onPressed: _pickLocationOnMap,
+                      icon: const Icon(Icons.edit_location_alt_outlined),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: _isSubmitting ? null : _submit,
+              icon: _isSubmitting
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.send_outlined),
+              label: Text(
+                _isSubmitting ? 'Submitting...' : 'Submit for review',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -12,7 +12,7 @@ import '../services/user_notification_service.dart';
 import '../widgets/custom_button.dart';
 import '../widgets/pwa_install_prompt.dart';
 import 'spots/search_screen.dart';
-import 'spots/add_spot_screen.dart';
+import 'add/add_hub_screen.dart';
 import 'profile/profile_screen.dart';
 
 // Countries that need "the" article prefix (e.g., "the Netherlands", not "Netherlands")
@@ -359,12 +359,12 @@ class _ExploreScreenState extends State<ExploreScreen> {
         initialLocationQuery: widget.initialLocationQuery,
         initialListId: widget.initialListId,
       ),
-      // Require profile loaded before Add spot (prevents email-as-createdByName race)
+      // Require profile loaded before showing contribution tools.
       authService.isProfileReady
-          ? AddSpotScreen(initialLocation: widget.initialAddSpotLocation)
+          ? const AddHubScreen()
           : authService.isAuthenticated
           ? _buildProfileLoadingScreen(authService)
-          : _buildLoginPromptScreen(Icons.add_location),
+          : _buildLoginPromptScreen(Icons.add),
       // Profile tab is always accessible
       const ProfileScreen(),
     ];
@@ -475,14 +475,14 @@ class _ExploreScreenState extends State<ExploreScreen> {
                         ),
                         const SizedBox(height: 16),
                         Text(
-                          l10n.exploreSignInToAddSpot,
+                          'Sign in to add spots and events',
                           style: Theme.of(context).textTheme.titleMedium
                               ?.copyWith(fontWeight: FontWeight.w600),
                           textAlign: TextAlign.center,
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          l10n.exploreAddSpotSubtitle,
+                          'Contribute new spots or submit event proposals for moderator review.',
                           textAlign: TextAlign.center,
                           style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
@@ -638,8 +638,8 @@ class _ExploreScreenState extends State<ExploreScreen> {
                       label: l10n.tabExplore,
                     ),
                     BottomNavigationBarItem(
-                      icon: const Icon(Icons.add_location),
-                      label: l10n.tabAddSpot,
+                      icon: const Icon(Icons.add),
+                      label: 'Add',
                     ),
                     BottomNavigationBarItem(
                       icon: _accountBottomNavIcon(context, unread),

--- a/lib/screens/moderator/event_report_queue_screen.dart
+++ b/lib/screens/moderator/event_report_queue_screen.dart
@@ -1,0 +1,529 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/event_report.dart';
+import '../../services/auth_service.dart';
+import '../../services/event_report_service.dart';
+import '../../widgets/page_scaffold.dart';
+
+class EventReportQueueScreen extends StatefulWidget {
+  const EventReportQueueScreen({super.key});
+
+  @override
+  State<EventReportQueueScreen> createState() => _EventReportQueueScreenState();
+}
+
+class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
+  static const String _allFilter = 'All';
+  late final List<String> _filters = <String>[
+    _allFilter,
+    ...EventReportService.statuses,
+  ];
+  String _selectedFilter = EventReportService.statuses.first;
+  final Set<String> _busyReportIds = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.read<EventReportService>();
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat.yMMMd().add_jm();
+    return PageScaffold(
+      title: 'Event Report Queue',
+      scrollable: false,
+      onBack: () {
+        if (Navigator.canPop(context)) {
+          Navigator.pop(context);
+        } else {
+          context.go('/moderator');
+        }
+      },
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Review user-submitted event proposals and decide whether to publish them.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+          ),
+          const SizedBox(height: 16),
+          StreamBuilder<List<EventReport>>(
+            stream: service.watchEventReports(),
+            builder: (context, snapshot) {
+              final allReports = snapshot.data ?? const <EventReport>[];
+              final statusCounts = <String, int>{
+                _allFilter: allReports.length,
+                for (final status in EventReportService.statuses)
+                  status: allReports.where((r) => r.status == status).length,
+              };
+
+              return Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: _filters.map((filter) {
+                  final count = statusCounts[filter] ?? 0;
+                  final isSelected = filter == _selectedFilter;
+                  return ChoiceChip(
+                    selected: isSelected,
+                    onSelected: (selected) {
+                      if (selected) setState(() => _selectedFilter = filter);
+                    },
+                    label: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(filter),
+                        if (count > 0) ...[
+                          const SizedBox(width: 6),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 6,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              color: isSelected
+                                  ? theme.colorScheme.onSecondaryContainer
+                                  : theme.colorScheme.secondaryContainer,
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Text(
+                              '$count',
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: isSelected
+                                    ? theme.colorScheme.secondaryContainer
+                                    : theme.colorScheme.onSecondaryContainer,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: StreamBuilder<List<EventReport>>(
+              stream: service.watchEventReports(),
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return _buildMessage(
+                    icon: Icons.error_outline,
+                    title: 'Failed to load event reports',
+                    message: 'Please try again shortly.',
+                  );
+                }
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                final reports =
+                    (snapshot.data ?? const <EventReport>[])
+                        .where(
+                          (report) =>
+                              _selectedFilter == _allFilter ||
+                              report.status == _selectedFilter,
+                        )
+                        .toList()
+                      ..sort((a, b) {
+                        final at =
+                            a.createdAt ??
+                            DateTime.fromMillisecondsSinceEpoch(0);
+                        final bt =
+                            b.createdAt ??
+                            DateTime.fromMillisecondsSinceEpoch(0);
+                        return bt.compareTo(at);
+                      });
+                if (reports.isEmpty) {
+                  return _buildMessage(
+                    icon: Icons.inbox_outlined,
+                    title: 'Nothing to review',
+                    message: 'Incoming event reports will appear here.',
+                  );
+                }
+
+                return ListView.separated(
+                  itemCount: reports.length,
+                  separatorBuilder: (_, _) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) {
+                    final report = reports[index];
+                    return _EventReportCard(
+                      report: report,
+                      dateFormat: dateFormat,
+                      isBusy: _busyReportIds.contains(report.id),
+                      onSetStatus: (status) => _setStatus(report, status),
+                      onApprove: () => _approve(report),
+                      onReject: () => _reject(report),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessage({
+    required IconData icon,
+    required String title,
+    required String message,
+  }) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: theme.colorScheme.primary),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: theme.textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _setStatus(EventReport report, String status) async {
+    if (_busyReportIds.contains(report.id)) return;
+    setState(() => _busyReportIds.add(report.id));
+    final auth = context.read<AuthService>();
+    final ok = await context.read<EventReportService>().updateReportStatus(
+      reportId: report.id,
+      status: status,
+      reviewedBy: auth.currentUser?.uid,
+      reviewedByName:
+          auth.userProfile?.displayName ??
+          auth.currentUser?.displayName ??
+          auth.currentUser?.email,
+    );
+    if (!mounted) return;
+    setState(() => _busyReportIds.remove(report.id));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          ok ? 'Report marked as $status.' : 'Could not set status to $status.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _approve(EventReport report) async {
+    if (_busyReportIds.contains(report.id)) return;
+    setState(() => _busyReportIds.add(report.id));
+    final auth = context.read<AuthService>();
+    final user = auth.currentUser;
+    final userId = user?.uid;
+    if (userId == null) {
+      if (mounted) {
+        setState(() => _busyReportIds.remove(report.id));
+      }
+      return;
+    }
+
+    final eventId = await context.read<EventReportService>().approveReport(
+      reportId: report.id,
+      approverUserId: userId,
+      approverName:
+          auth.userProfile?.displayName ?? user.displayName ?? user.email,
+    );
+
+    if (!mounted) return;
+    setState(() => _busyReportIds.remove(report.id));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          eventId == null
+              ? 'Could not approve this event report.'
+              : 'Approved and published as event $eventId.',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _reject(EventReport report) async {
+    if (_busyReportIds.contains(report.id)) return;
+    final notesController = TextEditingController();
+    final rejected = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Reject event report?'),
+        content: TextField(
+          controller: notesController,
+          maxLines: 4,
+          decoration: const InputDecoration(
+            labelText: 'Reason (optional)',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Reject'),
+          ),
+        ],
+      ),
+    );
+    if (rejected != true) return;
+
+    setState(() => _busyReportIds.add(report.id));
+    final auth = context.read<AuthService>();
+    final user = auth.currentUser;
+    final reviewerUserId = user?.uid;
+    if (reviewerUserId == null) {
+      if (mounted) setState(() => _busyReportIds.remove(report.id));
+      return;
+    }
+
+    final ok = await context.read<EventReportService>().rejectReport(
+      reportId: report.id,
+      reviewerUserId: reviewerUserId,
+      reviewerName:
+          auth.userProfile?.displayName ?? user?.displayName ?? user?.email,
+      moderatorNotes: notesController.text.trim().isEmpty
+          ? null
+          : notesController.text.trim(),
+    );
+
+    if (!mounted) return;
+    setState(() => _busyReportIds.remove(report.id));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          ok ? 'Report rejected.' : 'Could not reject this report.',
+        ),
+      ),
+    );
+  }
+}
+
+class _EventReportCard extends StatelessWidget {
+  const _EventReportCard({
+    required this.report,
+    required this.dateFormat,
+    required this.isBusy,
+    required this.onSetStatus,
+    required this.onApprove,
+    required this.onReject,
+  });
+
+  final EventReport report;
+  final DateFormat dateFormat;
+  final bool isBusy;
+  final ValueChanged<String> onSetStatus;
+  final VoidCallback onApprove;
+  final VoidCallback onReject;
+
+  Color _statusColor(ThemeData theme) {
+    switch (report.status) {
+      case 'Approved':
+        return theme.colorScheme.primary;
+      case 'Rejected':
+        return theme.colorScheme.error;
+      case 'Reviewing':
+        return theme.colorScheme.tertiary;
+      case 'New':
+      default:
+        return theme.colorScheme.secondary;
+    }
+  }
+
+  String _scheduleSummary(BuildContext context) {
+    final localizations = MaterialLocalizations.of(context);
+    final localStart = report.startAt.toLocal();
+    final startDate = localizations.formatMediumDate(localStart);
+    if (report.isDateOnly) {
+      if (report.endAt == null) return startDate;
+      final endDate = localizations.formatMediumDate(report.endAt!.toLocal());
+      return '$startDate – $endDate';
+    }
+    final startTime = localizations.formatTimeOfDay(
+      TimeOfDay.fromDateTime(localStart),
+    );
+    if (report.endAt == null) return '$startDate · $startTime';
+    final localEnd = report.endAt!.toLocal();
+    final endDate = localizations.formatMediumDate(localEnd);
+    final endTime = localizations.formatTimeOfDay(
+      TimeOfDay.fromDateTime(localEnd),
+    );
+    if (startDate == endDate) return '$startDate · $startTime – $endTime';
+    return '$startDate $startTime – $endDate $endTime';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _statusColor(theme);
+    final canReview = report.status == 'New' || report.status == 'Reviewing';
+    return Card(
+      margin: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: color.withValues(alpha: 0.45), width: 1.5),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(report.title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                _metaChip(
+                  context,
+                  icon: Icons.calendar_month_outlined,
+                  label: _scheduleSummary(context),
+                ),
+                _metaChip(
+                  context,
+                  icon: Icons.flag_outlined,
+                  label: report.status,
+                ),
+                if (report.reporterName?.isNotEmpty ?? false)
+                  _metaChip(
+                    context,
+                    icon: Icons.person_outline,
+                    label: report.reporterName!,
+                  ),
+                if (report.createdAt != null)
+                  _metaChip(
+                    context,
+                    icon: Icons.schedule_outlined,
+                    label: dateFormat.format(report.createdAt!.toLocal()),
+                  ),
+                if (report.linkedSpotName?.isNotEmpty ?? false)
+                  _metaChip(
+                    context,
+                    icon: Icons.location_on_outlined,
+                    label: 'Spot: ${report.linkedSpotName!}',
+                  ),
+                if (report.linkedSpotListName?.isNotEmpty ?? false)
+                  _metaChip(
+                    context,
+                    icon: Icons.list_alt_outlined,
+                    label: 'List: ${report.linkedSpotListName!}',
+                  ),
+                if (report.locationSummary != null)
+                  _metaChip(
+                    context,
+                    icon: Icons.map_outlined,
+                    label: report.locationSummary!,
+                  ),
+              ],
+            ),
+            if (report.description?.isNotEmpty ?? false) ...[
+              const SizedBox(height: 12),
+              Text(report.description!, style: theme.textTheme.bodyMedium),
+            ],
+            if (report.websiteUrl?.isNotEmpty ?? false) ...[
+              const SizedBox(height: 8),
+              SelectableText(
+                report.websiteUrl!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+            if (report.moderatorNotes?.isNotEmpty ?? false) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Moderator notes: ${report.moderatorNotes!}',
+                style: theme.textTheme.bodySmall,
+              ),
+            ],
+            const SizedBox(height: 16),
+            if (isBusy)
+              const Center(child: CircularProgressIndicator())
+            else ...[
+              if (canReview) ...[
+                SegmentedButton<String>(
+                  segments: const <ButtonSegment<String>>[
+                    ButtonSegment(value: 'New', label: Text('New')),
+                    ButtonSegment(value: 'Reviewing', label: Text('Reviewing')),
+                  ],
+                  selected: {
+                    report.status == 'Reviewing' ? 'Reviewing' : 'New',
+                  },
+                  onSelectionChanged: (selection) {
+                    if (selection.isNotEmpty) onSetStatus(selection.first);
+                  },
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: onApprove,
+                        icon: const Icon(Icons.check_circle_outline),
+                        label: const Text('Approve & publish'),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: onReject,
+                        icon: const Icon(Icons.cancel_outlined),
+                        label: const Text('Reject'),
+                      ),
+                    ),
+                  ],
+                ),
+              ] else if (report.approvedEventId != null) ...[
+                FilledButton.icon(
+                  onPressed: () =>
+                      context.push('/event/${report.approvedEventId}'),
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('Open published event'),
+                ),
+              ] else if (report.status == 'Rejected') ...[
+                OutlinedButton.icon(
+                  onPressed: () => onSetStatus('Reviewing'),
+                  icon: const Icon(Icons.replay_outlined),
+                  label: const Text('Move back to reviewing'),
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _metaChip(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+  }) {
+    final color = Theme.of(context).colorScheme.onSurfaceVariant;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 4),
+        Text(label, style: Theme.of(context).textTheme.bodySmall),
+      ],
+    );
+  }
+}

--- a/lib/screens/moderator/event_report_queue_screen.dart
+++ b/lib/screens/moderator/event_report_queue_screen.dart
@@ -240,7 +240,7 @@ class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
       reportId: report.id,
       approverUserId: userId,
       approverName:
-          auth.userProfile?.displayName ?? user.displayName ?? user.email,
+          auth.userProfile?.displayName ?? user?.displayName ?? user?.email,
     );
 
     if (!mounted) return;

--- a/lib/screens/moderator/moderator_tools_screen.dart
+++ b/lib/screens/moderator/moderator_tools_screen.dart
@@ -133,6 +133,18 @@ class ModeratorToolsScreen extends StatelessWidget {
           const SizedBox(height: 8),
           Card(
             child: ListTile(
+              leading: const Icon(Icons.event_note_outlined),
+              title: const Text('Event Report Queue'),
+              subtitle: const Text(
+                'Review user-submitted event proposals and publish approved events',
+              ),
+              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+              onTap: () => context.push('/moderator/event-reports'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
               leading: const Icon(Icons.compare_arrows),
               title: const Text('Duplicate Spot Detection'),
               subtitle: const Text(

--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -1516,7 +1516,8 @@ class SearchScreenState extends State<SearchScreen>
                               ..add(key);
                           }
                         });
-                        if (_mapController != null) _loadMapDataForCurrentView();
+                        if (_mapController != null)
+                          _loadMapDataForCurrentView();
                       },
                       child: Container(
                         padding: const EdgeInsets.symmetric(
@@ -1831,7 +1832,8 @@ class SearchScreenState extends State<SearchScreen>
                               ..add(key);
                           }
                         });
-                        if (_mapController != null) _loadMapDataForCurrentView();
+                        if (_mapController != null)
+                          _loadMapDataForCurrentView();
                       },
                       child: _buildAttributeChip(
                         label: label,
@@ -1866,7 +1868,8 @@ class SearchScreenState extends State<SearchScreen>
                             _goodFor = List<String>.from(_goodFor)..add(key);
                           }
                         });
-                        if (_mapController != null) _loadMapDataForCurrentView();
+                        if (_mapController != null)
+                          _loadMapDataForCurrentView();
                       },
                       child: _buildAttributeChip(
                         label: label,
@@ -2168,16 +2171,14 @@ class SearchScreenState extends State<SearchScreen>
           : _selectedSpot?.name == spot.name;
       final bool isHighlighted =
           spot.id != null && _highlightedSpotIds.contains(spot.id);
-      final eventPin =
-          spot.id != null ? _eventPinBySpotId[spot.id!] : null;
+      final eventPin = spot.id != null ? _eventPinBySpotId[spot.id!] : null;
       final bool hasEvent = eventPin != null;
 
       BitmapDescriptor icon;
       if (hasEvent && !isSelected && !isHighlighted) {
         icon = _eventIcon ?? BitmapDescriptor.defaultMarker;
       } else if (isSelected && isHighlighted) {
-        icon =
-            _spotSelectedHighlightedIcon ?? BitmapDescriptor.defaultMarker;
+        icon = _spotSelectedHighlightedIcon ?? BitmapDescriptor.defaultMarker;
       } else if (isSelected && hasEvent) {
         icon = _eventSelectedIcon ?? BitmapDescriptor.defaultMarker;
       } else if (isSelected) {
@@ -2228,9 +2229,8 @@ class SearchScreenState extends State<SearchScreen>
           ? 'event_venue_${pin.eventId}'
           : 'event_spot_${pin.id}';
       final isSelected = _selectedEventPin?.id == pin.id;
-      final icon = (isSelected
-              ? (_eventSelectedIcon ?? _eventIcon)
-              : _eventIcon) ??
+      final icon =
+          (isSelected ? (_eventSelectedIcon ?? _eventIcon) : _eventIcon) ??
           BitmapDescriptor.defaultMarker;
 
       pending.add(
@@ -2335,29 +2335,28 @@ class SearchScreenState extends State<SearchScreen>
       );
       final BitmapDescriptor normalSelectedPin =
           await MarkerIconUtils.loadMapPinPng(
-        MarkerIconUtils.mapPinNormalSelectedAsset,
-        fallbackFill: MarkerIconUtils.mapPinNormalFallbackFill,
-        logicalHeight: browsePinHeight,
-      );
+            MarkerIconUtils.mapPinNormalSelectedAsset,
+            fallbackFill: MarkerIconUtils.mapPinNormalFallbackFill,
+            logicalHeight: browsePinHeight,
+          );
       final BitmapDescriptor listSelectedPin =
           await MarkerIconUtils.loadMapPinPng(
-        MarkerIconUtils.mapPinListSelectedAsset,
-        fallbackFill: MarkerIconUtils.mapPinListFallbackFill,
-        logicalHeight: browsePinHeight,
-      );
+            MarkerIconUtils.mapPinListSelectedAsset,
+            fallbackFill: MarkerIconUtils.mapPinListFallbackFill,
+            logicalHeight: browsePinHeight,
+          );
       final BitmapDescriptor addPin = await MarkerIconUtils.loadMapPinPng(
         MarkerIconUtils.mapPinAddAsset,
         fallbackFill: MarkerIconUtils.mapPinAddFallbackFill,
         logicalHeight: browsePinHeight,
       );
-      final BitmapDescriptor eventPin =
-          await MarkerIconUtils.loadEventMapPin(
+      final BitmapDescriptor eventPin = await MarkerIconUtils.loadEventMapPin(
         logicalHeight: browsePinHeight,
       );
       final BitmapDescriptor eventSelectedPin =
           await MarkerIconUtils.loadEventSelectedMapPin(
-        logicalHeight: browsePinHeight,
-      );
+            logicalHeight: browsePinHeight,
+          );
       if (mounted) {
         setState(() {
           _spotDefaultIcon = normalPin;
@@ -2695,10 +2694,7 @@ class SearchScreenState extends State<SearchScreen>
     }
   }
 
-  Future<void> _selectEventPin(
-    EventMapPin pin, {
-    bool focusMap = true,
-  }) async {
+  Future<void> _selectEventPin(EventMapPin pin, {bool focusMap = true}) async {
     if (_isBottomSheetOpen) {
       await _bottomSheetAnimationController.reverse();
       if (mounted) {
@@ -2710,8 +2706,9 @@ class SearchScreenState extends State<SearchScreen>
 
     if (focusMap && _mapController != null) {
       const double desiredZoom = 15.0;
-      final double targetZoom =
-          _lastKnownZoom < desiredZoom ? desiredZoom : _lastKnownZoom;
+      final double targetZoom = _lastKnownZoom < desiredZoom
+          ? desiredZoom
+          : _lastKnownZoom;
       await _mapController!.animateCamera(
         CameraUpdate.newLatLng(LatLng(pin.latitude, pin.longitude)),
       );
@@ -2902,8 +2899,9 @@ class SearchScreenState extends State<SearchScreen>
       maxWidth: maxWidth,
       onTapWithImageIndex: (imageIndex) {
         final path = '/event/${pin.eventId}';
-        final navigationUrl =
-            imageIndex > 0 ? '$path?imageIndex=$imageIndex' : path;
+        final navigationUrl = imageIndex > 0
+            ? '$path?imageIndex=$imageIndex'
+            : path;
         context.push(navigationUrl);
       },
       onClose: () {
@@ -2923,8 +2921,9 @@ class SearchScreenState extends State<SearchScreen>
           CameraUpdate.newLatLng(LatLng(pin.latitude, pin.longitude)),
         );
         final path = '/event/${pin.eventId}';
-        final navigationUrl =
-            imageIndex > 0 ? '$path?imageIndex=$imageIndex' : path;
+        final navigationUrl = imageIndex > 0
+            ? '$path?imageIndex=$imageIndex'
+            : path;
         context.push(navigationUrl);
       },
       onLocate: () => _locateEvent(pin),
@@ -2975,10 +2974,9 @@ class SearchScreenState extends State<SearchScreen>
           Icon(
             Icons.event_busy,
             size: 64,
-            color: Theme.of(context)
-                .colorScheme
-                .onSurface
-                .withValues(alpha: 0.5),
+            color: Theme.of(
+              context,
+            ).colorScheme.onSurface.withValues(alpha: 0.5),
           ),
           const SizedBox(height: 16),
           Text(
@@ -2990,10 +2988,9 @@ class SearchScreenState extends State<SearchScreen>
             l10n.exploreNoEventsAreaHint,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.7),
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.7),
             ),
           ),
         ],
@@ -3001,8 +2998,7 @@ class SearchScreenState extends State<SearchScreen>
     );
   }
 
-  int _exploreSpotCountForHeader() =>
-      _totalSpotsInView ?? _visibleSpots.length;
+  int _exploreSpotCountForHeader() => _totalSpotsInView ?? _visibleSpots.length;
 
   int _exploreEventCountForHeader() => _visibleEvents.length;
 
@@ -3802,8 +3798,9 @@ class SearchScreenState extends State<SearchScreen>
                               spot: _selectedSpot!,
                               variant: SpotCardVariant.overlay,
                               showCheckInPresence: true,
-                              upcomingEventPin:
-                                  _upcomingEventPinForSpot(_selectedSpot!),
+                              upcomingEventPin: _upcomingEventPinForSpot(
+                                _selectedSpot!,
+                              ),
                               maxWidth: 400,
                               spotListId:
                                   (_selectedSpot!.id != null &&
@@ -3861,8 +3858,9 @@ class SearchScreenState extends State<SearchScreen>
                                 spot: _selectedSpot!,
                                 variant: SpotCardVariant.overlay,
                                 showCheckInPresence: true,
-                                upcomingEventPin:
-                                    _upcomingEventPinForSpot(_selectedSpot!),
+                                upcomingEventPin: _upcomingEventPinForSpot(
+                                  _selectedSpot!,
+                                ),
                                 maxWidth: double.infinity,
                                 spotListId:
                                     (_selectedSpot!.id != null &&
@@ -3957,7 +3955,7 @@ class SearchScreenState extends State<SearchScreen>
                             ),
                     ),
 
-                  // Add Spot Button (when long press is detected)
+                  // Add actions (when long press is detected)
                   if (_longPressedLocation != null &&
                       _selectedSpot == null &&
                       _selectedEventPin == null &&
@@ -4001,9 +3999,7 @@ class SearchScreenState extends State<SearchScreen>
                                       mainAxisSize: MainAxisSize.min,
                                       children: [
                                         Text(
-                                          AppLocalizations.of(
-                                            context,
-                                          )!.exploreAddSpotHereTitle,
+                                          'Add at this location',
                                           style: Theme.of(
                                             context,
                                           ).textTheme.titleMedium,
@@ -4033,9 +4029,8 @@ class SearchScreenState extends State<SearchScreen>
                                                 final location =
                                                     _longPressedLocation!;
                                                 final addSpotUri = Uri(
-                                                  path: '/explore',
+                                                  path: '/spots/add',
                                                   queryParameters: {
-                                                    'tab': 'add',
                                                     'lat': location.latitude
                                                         .toString(),
                                                     'lng': location.longitude
@@ -4055,7 +4050,7 @@ class SearchScreenState extends State<SearchScreen>
                                                   _markers = _rebuildMarkers();
                                                 });
 
-                                                // Require profile loaded before add spot (prevents email-as-createdByName)
+                                                // Require profile loaded before navigating to add forms.
                                                 if (!authService
                                                     .isAuthenticated) {
                                                   context.go(
@@ -4075,7 +4070,6 @@ class SearchScreenState extends State<SearchScreen>
                                                     ),
                                                   );
                                                 } else {
-                                                  // Navigate to Add Spot tab (preserves bottom navigation).
                                                   context.go(
                                                     addSpotUri.toString(),
                                                   );
@@ -4084,11 +4078,62 @@ class SearchScreenState extends State<SearchScreen>
                                               icon: const ReliableIcon(
                                                 icon: Icons.add_location,
                                               ),
-                                              label: Text(
-                                                AppLocalizations.of(
-                                                  context,
-                                                )!.tabAddSpot,
+                                              label: Text('Add spot'),
+                                            ),
+                                            const SizedBox(width: 8),
+                                            ElevatedButton.icon(
+                                              onPressed: () {
+                                                final location =
+                                                    _longPressedLocation!;
+                                                final addEventUri = Uri(
+                                                  path: '/events/add',
+                                                  queryParameters: {
+                                                    'lat': location.latitude
+                                                        .toString(),
+                                                    'lng': location.longitude
+                                                        .toString(),
+                                                  },
+                                                );
+                                                final authService =
+                                                    Provider.of<AuthService>(
+                                                      context,
+                                                      listen: false,
+                                                    );
+
+                                                setState(() {
+                                                  _longPressedLocation = null;
+                                                  _longPressHandled = false;
+                                                  _markers = _rebuildMarkers();
+                                                });
+
+                                                if (!authService
+                                                    .isAuthenticated) {
+                                                  context.go(
+                                                    '/login?redirectTo=${Uri.encodeComponent(addEventUri.toString())}',
+                                                  );
+                                                } else if (!authService
+                                                    .isProfileReady) {
+                                                  ScaffoldMessenger.of(
+                                                    context,
+                                                  ).showSnackBar(
+                                                    SnackBar(
+                                                      content: Text(
+                                                        AppLocalizations.of(
+                                                          context,
+                                                        )!.exploreLoadingProfile,
+                                                      ),
+                                                    ),
+                                                  );
+                                                } else {
+                                                  context.go(
+                                                    addEventUri.toString(),
+                                                  );
+                                                }
+                                              },
+                                              icon: const ReliableIcon(
+                                                icon: Icons.event_available,
                                               ),
+                                              label: const Text('Add event'),
                                             ),
                                           ],
                                         ),
@@ -4161,30 +4206,28 @@ class SearchScreenState extends State<SearchScreen>
                                           ),
                                           child: Builder(
                                             builder: (context) {
-                                              final l10n =
-                                                  AppLocalizations.of(
-                                                    context,
-                                                  )!;
+                                              final l10n = AppLocalizations.of(
+                                                context,
+                                              )!;
                                               return ExploreBottomSheetHeader(
                                                 mode: _exploreListMode,
                                                 spotsLabel: l10n
                                                     .exploreSpotCountShort(
-                                                  _exploreSpotCountForHeader(),
-                                                ),
+                                                      _exploreSpotCountForHeader(),
+                                                    ),
                                                 eventsLabel: l10n
                                                     .exploreEventCountShort(
-                                                  _exploreEventCountForHeader(),
-                                                ),
+                                                      _exploreEventCountForHeader(),
+                                                    ),
                                                 spotsDetailSuffix:
                                                     _exploreListMode ==
-                                                            ExploreBottomSheetHeader
-                                                                .modeSpots
-                                                        ? _exploreSpotsSegmentSuffix(
-                                                            l10n,
-                                                          )
-                                                        : null,
-                                                isSheetOpen:
-                                                    _isBottomSheetOpen,
+                                                        ExploreBottomSheetHeader
+                                                            .modeSpots
+                                                    ? _exploreSpotsSegmentSuffix(
+                                                        l10n,
+                                                      )
+                                                    : null,
+                                                isSheetOpen: _isBottomSheetOpen,
                                                 onModeChanged: (mode) {
                                                   setState(() {
                                                     _exploreListMode = mode;
@@ -4201,67 +4244,25 @@ class SearchScreenState extends State<SearchScreen>
                                           Expanded(
                                             child: _exploreListMode == 'events'
                                                 ? (_visibleEvents.isEmpty
-                                                    ? _buildExploreEventsEmptyState(
-                                                        context,
-                                                      )
-                                                    : _buildEventsList())
+                                                      ? _buildExploreEventsEmptyState(
+                                                          context,
+                                                        )
+                                                      : _buildEventsList())
                                                 : (_visibleSpots.isEmpty
-                                                ? Center(
-                                                    child: Column(
-                                                      mainAxisAlignment:
-                                                          MainAxisAlignment
-                                                              .center,
-                                                      children: [
-                                                        Icon(
-                                                          _searchQuery
-                                                                  .isNotEmpty
-                                                              ? Icons.search_off
-                                                              : Icons
-                                                                    .location_off,
-                                                          size: 64,
-                                                          color:
-                                                              Theme.of(context)
-                                                                  .colorScheme
-                                                                  .onSurface
-                                                                  .withValues(
-                                                                    alpha: 0.5,
-                                                                  ),
-                                                        ),
-                                                        const SizedBox(
-                                                          height: 16,
-                                                        ),
-                                                        Text(
-                                                          _searchQuery
-                                                                  .isNotEmpty
-                                                              ? AppLocalizations.of(
-                                                                  context,
-                                                                )!.exploreNoSpotsSearch
-                                                              : AppLocalizations.of(
-                                                                  context,
-                                                                )!.exploreNoSpotsArea,
-                                                          style:
-                                                              Theme.of(context)
-                                                                  .textTheme
-                                                                  .headlineSmall,
-                                                        ),
-                                                        const SizedBox(
-                                                          height: 8,
-                                                        ),
-                                                        Text(
-                                                          _searchQuery
-                                                                  .isNotEmpty
-                                                              ? AppLocalizations.of(
-                                                                  context,
-                                                                )!.exploreNoSpotsSearchHint
-                                                              : AppLocalizations.of(
-                                                                  context,
-                                                                )!.exploreNoSpotsMapHint,
-                                                          textAlign:
-                                                              TextAlign.center,
-                                                          style: Theme.of(context)
-                                                              .textTheme
-                                                              .bodyMedium
-                                                              ?.copyWith(
+                                                      ? Center(
+                                                          child: Column(
+                                                            mainAxisAlignment:
+                                                                MainAxisAlignment
+                                                                    .center,
+                                                            children: [
+                                                              Icon(
+                                                                _searchQuery
+                                                                        .isNotEmpty
+                                                                    ? Icons
+                                                                          .search_off
+                                                                    : Icons
+                                                                          .location_off,
+                                                                size: 64,
                                                                 color:
                                                                     Theme.of(
                                                                           context,
@@ -4270,14 +4271,57 @@ class SearchScreenState extends State<SearchScreen>
                                                                         .onSurface
                                                                         .withValues(
                                                                           alpha:
-                                                                              0.7,
+                                                                              0.5,
                                                                         ),
                                                               ),
-                                                        ),
-                                                      ],
-                                                    ),
-                                                  )
-                                                : _buildSpotsList()),
+                                                              const SizedBox(
+                                                                height: 16,
+                                                              ),
+                                                              Text(
+                                                                _searchQuery
+                                                                        .isNotEmpty
+                                                                    ? AppLocalizations.of(
+                                                                        context,
+                                                                      )!.exploreNoSpotsSearch
+                                                                    : AppLocalizations.of(
+                                                                        context,
+                                                                      )!.exploreNoSpotsArea,
+                                                                style: Theme.of(
+                                                                  context,
+                                                                ).textTheme.headlineSmall,
+                                                              ),
+                                                              const SizedBox(
+                                                                height: 8,
+                                                              ),
+                                                              Text(
+                                                                _searchQuery
+                                                                        .isNotEmpty
+                                                                    ? AppLocalizations.of(
+                                                                        context,
+                                                                      )!.exploreNoSpotsSearchHint
+                                                                    : AppLocalizations.of(
+                                                                        context,
+                                                                      )!.exploreNoSpotsMapHint,
+                                                                textAlign:
+                                                                    TextAlign
+                                                                        .center,
+                                                                style: Theme.of(context)
+                                                                    .textTheme
+                                                                    .bodyMedium
+                                                                    ?.copyWith(
+                                                                      color: Theme.of(context)
+                                                                          .colorScheme
+                                                                          .onSurface
+                                                                          .withValues(
+                                                                            alpha:
+                                                                                0.7,
+                                                                          ),
+                                                                    ),
+                                                              ),
+                                                            ],
+                                                          ),
+                                                        )
+                                                      : _buildSpotsList()),
                                           ),
                                       ],
                                     ),

--- a/lib/screens/spots/spot_detail_screen.dart
+++ b/lib/screens/spots/spot_detail_screen.dart
@@ -149,6 +149,7 @@ enum _SpotMenuAction {
   suggestPhoto,
   suggestEdit,
   report,
+  createEvent,
   edit,
   delete,
   markAsDuplicate,
@@ -1478,6 +1479,39 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
               ],
             ),
           ),
+          if (authService.isAuthenticated && _spot.id != null)
+            PopupMenuItem<_SpotMenuAction>(
+              value: _SpotMenuAction.createEvent,
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.event_available_outlined,
+                    color: theme.colorScheme.primary,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Create event at this spot',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      Text(
+                        'Submit a new event proposal linked to this spot',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.6,
+                          ),
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
         ];
 
         if (hasStaffAccess && _spot.id != null) {
@@ -1791,6 +1825,19 @@ class _SpotDetailScreenState extends State<SpotDetailScreen> {
         break;
       case _SpotMenuAction.report:
         _showReportSpotDialog();
+        break;
+      case _SpotMenuAction.createEvent:
+        final spotId = _spot.id;
+        if (spotId == null) break;
+        final query = <String, String>{
+          'spotId': spotId,
+          'spotName': _spot.name,
+          'lat': _spot.latitude.toString(),
+          'lng': _spot.longitude.toString(),
+        };
+        context.push(
+          Uri(path: '/events/add', queryParameters: query).toString(),
+        );
         break;
       case _SpotMenuAction.edit:
         final authService = Provider.of<AuthService>(context, listen: false);

--- a/lib/screens/spots/spot_list_detail_screen.dart
+++ b/lib/screens/spots/spot_list_detail_screen.dart
@@ -32,7 +32,7 @@ import '../../l10n/app_localizations.dart';
 import '../../utils/spot_list_localization.dart';
 import '../../utils/relative_date_localization.dart';
 
-enum _ListManageMenuAction { listSettings, organize, delete }
+enum _ListManageMenuAction { listSettings, organize, createEvent, delete }
 
 class SpotListDetailScreen extends StatefulWidget {
   final String listId;
@@ -88,10 +88,10 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
       );
       final BitmapDescriptor listSelectedPin =
           await MarkerIconUtils.loadMapPinPng(
-        MarkerIconUtils.mapPinListSelectedAsset,
-        fallbackFill: MarkerIconUtils.mapPinListFallbackFill,
-        logicalHeight: h,
-      );
+            MarkerIconUtils.mapPinListSelectedAsset,
+            fallbackFill: MarkerIconUtils.mapPinListFallbackFill,
+            logicalHeight: h,
+          );
       if (mounted) {
         setState(() {
           _spotHighlightedIcon = listPin;
@@ -790,7 +790,9 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
 
       await Clipboard.setData(ClipboardData(text: text));
 
-      SnackbarService.showClipboardCopied(_l10n.spotListDetailCopiedToClipboard);
+      SnackbarService.showClipboardCopied(
+        _l10n.spotListDetailCopiedToClipboard,
+      );
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -811,6 +813,18 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
         break;
       case _ListManageMenuAction.organize:
         _openAdvancedOrganizationScreen();
+        break;
+      case _ListManageMenuAction.createEvent:
+        if (_list == null || _list!.id == null) return;
+        context.push(
+          Uri(
+            path: '/events/add',
+            queryParameters: {
+              'spotListId': _list!.id!,
+              'spotListName': _list!.name,
+            },
+          ).toString(),
+        );
         break;
       case _ListManageMenuAction.delete:
         _deleteList();
@@ -1096,6 +1110,25 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
                       ),
                     ),
                     PopupMenuItem<_ListManageMenuAction>(
+                      value: _ListManageMenuAction.createEvent,
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.event_available_outlined,
+                            color: primary,
+                            size: 20,
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Text(
+                              'Create event for this list',
+                              style: theme.textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    PopupMenuItem<_ListManageMenuAction>(
                       value: _ListManageMenuAction.delete,
                       child: Row(
                         children: [
@@ -1139,10 +1172,14 @@ class _SpotListDetailScreenState extends State<SpotListDetailScreen> {
                 label: _l10n.spotDetailShareTooltip,
                 child: Material(
                   color: Colors.transparent,
-                  borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                  borderRadius: BorderRadius.circular(
+                    SpotDetailUi.surfaceRadius,
+                  ),
                   clipBehavior: Clip.antiAlias,
                   child: InkWell(
-                    borderRadius: BorderRadius.circular(SpotDetailUi.surfaceRadius),
+                    borderRadius: BorderRadius.circular(
+                      SpotDetailUi.surfaceRadius,
+                    ),
                     onTap: _copyListToClipboard,
                     child: SpotDetailQuickActionChip(
                       icon: Icons.share_outlined,

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -1,0 +1,267 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/event_report.dart';
+
+class EventReportService {
+  EventReportService({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  static const List<String> statuses = <String>[
+    'New',
+    'Reviewing',
+    'Approved',
+    'Rejected',
+  ];
+
+  Future<bool> submitEventReport({
+    required String title,
+    required DateTime startAt,
+    DateTime? endAt,
+    bool isDateOnly = false,
+    String? timeZone,
+    String? description,
+    String? websiteUrl,
+    double? latitude,
+    double? longitude,
+    String? address,
+    String? city,
+    String? countryCode,
+    List<String> spotIds = const <String>[],
+    List<String> spotListIds = const <String>[],
+    String? linkedSpotName,
+    String? linkedSpotListName,
+    String? reporterUserId,
+    String? reporterName,
+    String? reporterEmail,
+  }) async {
+    final trimmedTitle = title.trim();
+    if (trimmedTitle.isEmpty) return false;
+
+    final normalizedWebsiteUrl = websiteUrl?.trim();
+    final normalizedSpotIds = spotIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList();
+    final normalizedSpotListIds = spotListIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList();
+
+    try {
+      await _firestore.collection('eventReports').add({
+        'title': trimmedTitle,
+        if (description != null && description.trim().isNotEmpty)
+          'description': description.trim(),
+        if (normalizedWebsiteUrl != null && normalizedWebsiteUrl.isNotEmpty)
+          'websiteUrl': normalizedWebsiteUrl,
+        'startAt': Timestamp.fromDate(startAt.toUtc()),
+        if (endAt != null) 'endAt': Timestamp.fromDate(endAt.toUtc()),
+        if (isDateOnly) 'isDateOnly': true,
+        if (timeZone != null && timeZone.trim().isNotEmpty)
+          'timeZone': timeZone.trim(),
+        if (latitude != null && longitude != null) ...{
+          'latitude': latitude,
+          'longitude': longitude,
+          if (address != null && address.trim().isNotEmpty)
+            'address': address.trim(),
+          if (city != null && city.trim().isNotEmpty) 'city': city.trim(),
+          if (countryCode != null && countryCode.trim().isNotEmpty)
+            'countryCode': countryCode.trim().toUpperCase(),
+        },
+        'spotIds': normalizedSpotIds,
+        'spotListIds': normalizedSpotListIds,
+        if (linkedSpotName != null && linkedSpotName.trim().isNotEmpty)
+          'linkedSpotName': linkedSpotName.trim(),
+        if (linkedSpotListName != null && linkedSpotListName.trim().isNotEmpty)
+          'linkedSpotListName': linkedSpotListName.trim(),
+        if (reporterUserId != null && reporterUserId.isNotEmpty)
+          'reporterUserId': reporterUserId,
+        if (reporterName != null && reporterName.trim().isNotEmpty)
+          'reporterName': reporterName.trim(),
+        if (reporterEmail != null && reporterEmail.trim().isNotEmpty)
+          'reporterEmail': reporterEmail.trim(),
+        'status': statuses.first,
+        'createdAt': FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      return true;
+    } catch (e) {
+      debugPrint('Error submitting event report: $e');
+      return false;
+    }
+  }
+
+  Future<bool> updateReportStatus({
+    required String reportId,
+    required String status,
+    String? reviewedBy,
+    String? reviewedByName,
+  }) async {
+    if (!statuses.contains(status)) return false;
+
+    try {
+      await _firestore.collection('eventReports').doc(reportId).update({
+        'status': status,
+        if (reviewedBy != null && reviewedBy.isNotEmpty)
+          'reviewedBy': reviewedBy,
+        if (reviewedByName != null && reviewedByName.isNotEmpty)
+          'reviewedByName': reviewedByName,
+        if (status != statuses.first)
+          'reviewedAt': FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      return true;
+    } catch (e) {
+      debugPrint('Error updating event report status: $e');
+      return false;
+    }
+  }
+
+  Future<String?> approveReport({
+    required String reportId,
+    required String approverUserId,
+    String? approverName,
+    String? moderatorNotes,
+  }) async {
+    try {
+      final result = await _firestore.runTransaction<String?>((
+        transaction,
+      ) async {
+        final reportRef = _firestore.collection('eventReports').doc(reportId);
+        final snapshot = await transaction.get(reportRef);
+        if (!snapshot.exists || snapshot.data() == null) {
+          throw StateError('Event report not found');
+        }
+
+        final report = EventReport.fromSnapshot(snapshot);
+        if (report.status == 'Approved' && report.approvedEventId != null) {
+          return report.approvedEventId;
+        }
+
+        final eventData = _buildEventData(
+          report: report,
+          approverUserId: approverUserId,
+        );
+        if (eventData == null) {
+          throw StateError('Invalid event report data');
+        }
+
+        final eventRef = _firestore.collection('events').doc();
+        transaction.set(eventRef, eventData);
+        transaction.update(reportRef, {
+          'status': 'Approved',
+          'approvedEventId': eventRef.id,
+          'reviewedBy': approverUserId,
+          if (approverName != null && approverName.trim().isNotEmpty)
+            'reviewedByName': approverName.trim(),
+          if (moderatorNotes != null && moderatorNotes.trim().isNotEmpty)
+            'moderatorNotes': moderatorNotes.trim(),
+          'reviewedAt': FieldValue.serverTimestamp(),
+          'updatedAt': FieldValue.serverTimestamp(),
+        });
+        return eventRef.id;
+      });
+      return result;
+    } catch (e) {
+      debugPrint('Error approving event report: $e');
+      return null;
+    }
+  }
+
+  Future<bool> rejectReport({
+    required String reportId,
+    required String reviewerUserId,
+    String? reviewerName,
+    String? moderatorNotes,
+  }) async {
+    try {
+      await _firestore.collection('eventReports').doc(reportId).update({
+        'status': 'Rejected',
+        'reviewedBy': reviewerUserId,
+        if (reviewerName != null && reviewerName.trim().isNotEmpty)
+          'reviewedByName': reviewerName.trim(),
+        if (moderatorNotes != null && moderatorNotes.trim().isNotEmpty)
+          'moderatorNotes': moderatorNotes.trim(),
+        'reviewedAt': FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      return true;
+    } catch (e) {
+      debugPrint('Error rejecting event report: $e');
+      return false;
+    }
+  }
+
+  Stream<List<EventReport>> watchEventReports() {
+    return _firestore
+        .collection('eventReports')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map(
+          (snapshot) => snapshot.docs
+              .map((doc) => EventReport.fromSnapshot(doc))
+              .toList(growable: false),
+        );
+  }
+
+  Map<String, dynamic>? _buildEventData({
+    required EventReport report,
+    required String approverUserId,
+  }) {
+    final title = report.title.trim();
+    if (title.isEmpty) return null;
+    final normalizedDescription = report.description?.trim();
+    final normalizedWebsiteUrl = report.websiteUrl?.trim();
+    final normalizedSpotIds = report.spotIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .toList();
+    final normalizedSpotListIds = report.spotListIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet()
+        .take(10)
+        .toList();
+    final startAt = report.startAt.toUtc();
+    final endAt = report.endAt?.toUtc();
+    if (endAt != null && endAt.isBefore(startAt)) {
+      return null;
+    }
+
+    final hasLatLng = report.latitude != null && report.longitude != null;
+    final hasAddress = report.address?.trim().isNotEmpty == true;
+
+    return <String, dynamic>{
+      'title': title,
+      if (normalizedDescription != null && normalizedDescription.isNotEmpty)
+        'description': normalizedDescription,
+      if (normalizedWebsiteUrl != null && normalizedWebsiteUrl.isNotEmpty)
+        'websiteUrl': normalizedWebsiteUrl,
+      'startAt': Timestamp.fromDate(startAt),
+      if (endAt != null) 'endAt': Timestamp.fromDate(endAt),
+      if (report.isDateOnly) 'isDateOnly': true,
+      if (report.timeZone != null && report.timeZone!.trim().isNotEmpty)
+        'timeZone': report.timeZone!.trim(),
+      if (hasLatLng && hasAddress) ...{
+        'latitude': report.latitude,
+        'longitude': report.longitude,
+        'address': report.address!.trim(),
+        if (report.city != null && report.city!.trim().isNotEmpty)
+          'city': report.city!.trim(),
+        if (report.countryCode != null && report.countryCode!.trim().isNotEmpty)
+          'countryCode': report.countryCode!.trim().toUpperCase(),
+      },
+      'spotIds': normalizedSpotIds,
+      'spotListIds': normalizedSpotListIds,
+      'createdBy': approverUserId,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a user-facing event submission flow backed by a new `eventReports` collection
- add moderator tooling to review event reports and approve/reject proposals
- add event creation entry points from Add tab, spot detail edit menu, spot list edit menu, and Explore long-press
- fix map-coordinate submissions so event reports can be submitted even when reverse geocoding has not completed
- update Firestore rules and routing/providers to support the new workflow

## Validation
- `flutter analyze lib/main.dart lib/models/event_report.dart lib/router/app_router.dart lib/screens/add/add_hub_screen.dart lib/screens/events/add_event_report_screen.dart lib/screens/explore_screen.dart lib/screens/moderator/event_report_queue_screen.dart lib/screens/moderator/moderator_tools_screen.dart lib/screens/spots/search_screen.dart lib/screens/spots/spot_detail_screen.dart lib/screens/spots/spot_list_detail_screen.dart lib/services/event_report_service.dart` (info-level lint warnings only)
- `flutter test` (pass)
- manual emulator-backed browser walkthrough verifying:
  - Add tab presents Add spot/Add event choices
  - map long-press includes Add event action
  - event report submission succeeds from map context menu
  - submitted event appears in moderator event report queue

## Walkthrough Artifacts
[event_submission_to_moderator_queue.mp4](https://cursor.com/agents/bc-a3413534-5230-4d11-bd4a-e8de38291d59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_submission_to_moderator_queue.mp4)
[Add tab options](https://cursor.com/agents/bc-a3413534-5230-4d11-bd4a-e8de38291d59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_tab_spot_and_event_options.webp)
[Map context menu add event](https://cursor.com/agents/bc-a3413534-5230-4d11-bd4a-e8de38291d59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmap_context_menu_add_event.webp)
[Moderator queue shows submitted event](https://cursor.com/agents/bc-a3413534-5230-4d11-bd4a-e8de38291d59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmoderator_queue_new_event_report.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3413534-5230-4d11-bd4a-e8de38291d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3413534-5230-4d11-bd4a-e8de38291d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

