### PR TITLE
Extend explore autocomplete to index event names/cities and spot cities

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -93,6 +93,7 @@ const {
   buildDescription,
   getSearchQueryTokens,
   spotSearchTermDocId,
+  eventSearchTermDocId,
   cleanDescription,
   extractYoutubeVideoIdsFromDescription,
   extractImageUrls,
@@ -113,6 +114,7 @@ const {
   deleteEventMapPins,
   materializeEventMapPins,
   rematerializeEventsForSpotList,
+  isEventPast,
 } = require("./lib/event-map-pins");
 const {executeEventsInBoundsQuery} = require("./lib/events-in-bounds");
 
@@ -1280,7 +1282,8 @@ exports.onSpotCreated = onDocumentCreated(
       const spotId = event.params.spotId;
       const spotData = event.data.data();
       const name = typeof spotData?.name === "string" ? spotData.name : "";
-      const words = buildSpotSearchWords(name);
+      const city = typeof spotData?.city === "string" ? spotData.city : "";
+      const words = buildSpotSearchWords(name, city);
       if (words.length > 0) {
         const batch = db.batch();
         for (const term of words) {
@@ -1401,14 +1404,16 @@ exports.onSpotUpdated = onDocumentUpdated(
 
       const nameBefore = typeof beforeData?.name === "string" ? beforeData.name : "";
       const nameAfter = typeof afterData?.name === "string" ? afterData.name : "";
-      if (nameBefore === nameAfter) return;
+      const cityBefore = typeof beforeData?.city === "string" ? beforeData.city : "";
+      const cityAfter = typeof afterData?.city === "string" ? afterData.city : "";
+      if (nameBefore === nameAfter && cityBefore === cityAfter) return;
       const termsSnapshot = await db.collection("spotSearchTerms")
           .where("spotId", "==", spotId)
           .get();
       const batch = db.batch();
       termsSnapshot.docs.forEach((doc) => batch.delete(doc.ref));
       if (termsSnapshot.size > 0) await batch.commit();
-      const words = buildSpotSearchWords(nameAfter);
+      const words = buildSpotSearchWords(nameAfter, cityAfter);
       if (words.length === 0) return;
       const writeBatch = db.batch();
       for (const term of words) {
@@ -1435,6 +1440,60 @@ exports.onSpotDeleted = onDocumentDeleted(
       console.log("Removed spot search terms:", {spotId, count: termsSnapshot.size});
     },
 );
+
+/**
+ * Build event autocomplete index terms from title + city.
+ * @param {Object} eventData
+ * @return {string[]}
+ */
+function buildEventSearchWords(eventData) {
+  const title = typeof eventData?.title === "string" ? eventData.title : "";
+  const city = typeof eventData?.city === "string" ? eventData.city : "";
+  return buildSpotSearchWords(title, city);
+}
+
+/**
+ * Replace event search terms for a single event.
+ * @param {string} eventId
+ * @param {Object} eventData
+ * @return {Promise<number>} Number of terms written
+ */
+async function replaceEventSearchTerms(eventId, eventData) {
+  const termsSnapshot = await db.collection("eventSearchTerms")
+      .where("eventId", "==", eventId)
+      .get();
+  if (!termsSnapshot.empty) {
+    const deleteBatch = db.batch();
+    termsSnapshot.docs.forEach((doc) => deleteBatch.delete(doc.ref));
+    await deleteBatch.commit();
+  }
+
+  const terms = buildEventSearchWords(eventData);
+  if (terms.length === 0) return 0;
+  const writeBatch = db.batch();
+  for (const term of terms) {
+    const ref = db.collection("eventSearchTerms").doc(eventSearchTermDocId(eventId, term));
+    writeBatch.set(ref, {term, eventId});
+  }
+  await writeBatch.commit();
+  return terms.length;
+}
+
+/**
+ * Remove all event search terms for a single event.
+ * @param {string} eventId
+ * @return {Promise<number>} Number of terms deleted
+ */
+async function removeEventSearchTerms(eventId) {
+  const termsSnapshot = await db.collection("eventSearchTerms")
+      .where("eventId", "==", eventId)
+      .get();
+  if (termsSnapshot.empty) return 0;
+  const batch = db.batch();
+  termsSnapshot.docs.forEach((doc) => batch.delete(doc.ref));
+  await batch.commit();
+  return termsSnapshot.size;
+}
 
 
 /**
@@ -4856,10 +4915,19 @@ exports.onEventWritten = onDocumentWritten(
       const eventId = event.params.eventId;
       try {
         if (!event.data || !event.data.after.exists) {
+          const removedCount = await removeEventSearchTerms(eventId);
           await deleteEventMapPins(db, eventId);
+          console.log("Removed event search terms:", {eventId, count: removedCount});
           return;
         }
-        await materializeEventMapPins(db, eventId, event.data.after.data() || {});
+        const eventData = event.data.after.data() || {};
+        const termsWritten = await replaceEventSearchTerms(eventId, eventData);
+        await materializeEventMapPins(db, eventId, eventData);
+        console.log("Indexed event search terms:", {
+          eventId,
+          title: typeof eventData.title === "string" ? eventData.title.slice(0, 40) : "",
+          termsWritten,
+        });
       } catch (err) {
         console.error("onEventWritten error", {eventId, err});
         throw err;
@@ -5990,7 +6058,8 @@ exports.backfillSpotNameLower = onCall(
           for (const doc of snapshot.docs) {
             const data = doc.data();
             const name = typeof data.name === "string" ? data.name.trim() : "";
-            const words = buildSpotSearchWords(name);
+            const city = typeof data.city === "string" ? data.city.trim() : "";
+            const words = buildSpotSearchWords(name, city);
             for (const term of words) {
               if (termsCount >= BATCH_LIMIT) {
                 await termsBatch.commit();
@@ -6017,6 +6086,65 @@ exports.backfillSpotNameLower = onCall(
       } catch (error) {
         console.error("Error in backfillSpotNameLower:", error);
         throw new Error(`Failed to backfill: ${error.message}`);
+      }
+    },
+);
+
+// One-time backfill: populate eventSearchTerms for all existing events.
+// Admin only.
+exports.backfillEventSearchTerms = onCall(
+    {region: "europe-west1", memory: "256MiB", timeoutSeconds: 540},
+    async (request) => {
+      try {
+        await ensureAdmin(request);
+        const BATCH_SIZE = 250;
+        let lastDoc = null;
+        let totalProcessed = 0;
+        let searchTermsWritten = 0;
+        let hasMore = true;
+        while (hasMore) {
+          let query = db.collection("events").limit(BATCH_SIZE);
+          if (lastDoc) {
+            query = query.startAfter(lastDoc);
+          }
+          const snapshot = await query.get();
+          if (snapshot.empty) {
+            hasMore = false;
+            break;
+          }
+          let termsBatch = db.batch();
+          let termsCount = 0;
+          const BATCH_LIMIT = 450;
+          for (const doc of snapshot.docs) {
+            const data = doc.data();
+            const words = buildEventSearchWords(data);
+            for (const term of words) {
+              if (termsCount >= BATCH_LIMIT) {
+                await termsBatch.commit();
+                termsBatch = db.batch();
+                termsCount = 0;
+              }
+              const ref = db.collection("eventSearchTerms")
+                  .doc(eventSearchTermDocId(doc.id, term));
+              termsBatch.set(ref, {term, eventId: doc.id});
+              termsCount++;
+              searchTermsWritten++;
+            }
+          }
+          if (termsCount > 0) await termsBatch.commit();
+          totalProcessed += snapshot.size;
+          lastDoc = snapshot.docs[snapshot.docs.length - 1];
+          hasMore = snapshot.size === BATCH_SIZE;
+          console.log(`Event terms backfill: ${totalProcessed} events, ${searchTermsWritten} terms`);
+        }
+        return {
+          success: true,
+          message: "Event search terms backfill completed",
+          stats: {totalProcessed, searchTermsWritten},
+        };
+      } catch (error) {
+        console.error("Error in backfillEventSearchTerms:", error);
+        throw new Error(`Failed to backfill event search terms: ${error.message}`);
       }
     },
 );
@@ -6205,6 +6333,108 @@ async function executeSearchSpotsByTitle(params) {
   return {success: true, spots};
 }
 
+/**
+ * Shared search-by-title logic for events autocomplete.
+ * @param {Object} params - Params object.
+ * @param {string} params.query - Search query.
+ * @param {number=} params.limit - Max results (default 20).
+ * @return {Promise<Object>}
+ */
+async function executeSearchEventsByTitle(params) {
+  const {query, limit = 20} = params || {};
+  if (!query || typeof query !== "string") {
+    return {success: false, error: "query is required"};
+  }
+
+  const tokens = getSearchQueryTokens(query);
+  if (tokens.length === 0) {
+    return {success: true, events: []};
+  }
+
+  const parsedLimit = Number(limit);
+  const maxResults = Number.isFinite(parsedLimit) ?
+    Math.max(1, Math.min(Math.floor(parsedLimit), 100)) :
+    20;
+
+  const eventIdToMatchCount = new Map();
+  for (const token of tokens) {
+    const queryEnd = token + "\uf8ff";
+    const termsSnapshot = await db.collection("eventSearchTerms")
+        .where("term", ">=", token)
+        .where("term", "<", queryEnd)
+        .limit(200)
+        .get();
+    termsSnapshot.docs.forEach((doc) => {
+      const eventId = doc.data().eventId;
+      if (!eventId) return;
+      const prev = eventIdToMatchCount.get(eventId) || 0;
+      eventIdToMatchCount.set(eventId, prev + 1);
+    });
+  }
+
+  let eventIds;
+  const eventsWithAll = [...eventIdToMatchCount.entries()]
+      .filter(([, count]) => count === tokens.length)
+      .map(([id]) => id);
+  if (eventsWithAll.length > 0) {
+    eventIds = eventsWithAll;
+  } else {
+    eventIds = [...eventIdToMatchCount.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([id]) => id);
+  }
+
+  if (eventIds.length === 0) {
+    return {success: true, events: []};
+  }
+
+  const eventsToFetch = eventIds.slice(0, 80);
+  const eventRefs = eventsToFetch.map((id) => db.collection("events").doc(id));
+  const eventDocs = await db.getAll(...eventRefs);
+  const matches = [];
+  eventDocs.forEach((doc) => {
+    if (!doc.exists) return;
+    const data = doc.data();
+    if (data.duplicateOf) return;
+    if (isEventPast(data)) return;
+    const title = typeof data.title === "string" ? data.title.trim() : "";
+    if (!title) return;
+    const city = typeof data.city === "string" ? data.city.trim() : null;
+    const countryCode = typeof data.countryCode === "string" ?
+      data.countryCode.trim().toUpperCase() :
+      null;
+    const startAtDate = data.startAt &&
+      typeof data.startAt.toDate === "function" ?
+      data.startAt.toDate() :
+      null;
+    const startAt = formatDateToISO(data.startAt) || null;
+    matches.push({
+      id: doc.id,
+      title,
+      city,
+      countryCode,
+      startAt,
+      startAtMillis: startAtDate ? startAtDate.getTime() : Number.MAX_SAFE_INTEGER,
+      matchCount: eventIdToMatchCount.get(doc.id) || 0,
+    });
+  });
+
+  matches.sort((a, b) => {
+    if (a.matchCount !== b.matchCount) return b.matchCount - a.matchCount;
+    if (a.startAtMillis !== b.startAtMillis) return a.startAtMillis - b.startAtMillis;
+    return String(a.title).localeCompare(String(b.title));
+  });
+
+  const events = matches.slice(0, maxResults).map((event) => ({
+    id: event.id,
+    title: event.title,
+    city: event.city,
+    countryCode: event.countryCode,
+    startAt: event.startAt,
+  }));
+  return {success: true, events};
+}
+
 // Spot title search for Explore autocomplete.
 // Multi-word: query each token, intersect results. Rank by match count, then spot ranking.
 exports.searchSpotsByTitle = onCall(
@@ -6226,6 +6456,21 @@ exports.searchSpotsByTitle = onCall(
         return {success: true, spots};
       } catch (error) {
         console.error("Error in searchSpotsByTitle:", error);
+        return {success: false, error: error.message};
+      }
+    },
+);
+
+// Event title + city search for Explore autocomplete.
+exports.searchEventsByTitle = onCall(
+    {region: "europe-west1", memory: "256MiB", timeoutSeconds: 10},
+    async (request) => {
+      try {
+        const result = await executeSearchEventsByTitle(request.data || {});
+        if (!result.success) return {success: false, error: result.error};
+        return {success: true, events: result.events || []};
+      } catch (error) {
+        console.error("Error in searchEventsByTitle:", error);
         return {success: false, error: error.message};
       }
     },

--- a/functions/lib/spot-attributes.js
+++ b/functions/lib/spot-attributes.js
@@ -69,14 +69,25 @@ function cleanUndefinedValues(obj) {
 }
 
 /**
- * Builds unique search words from spot name: split, lowercase, remove punctuation
- * and stop words. Full words only (no prefixes) - used for spotSearchTerms collection.
- * @param {string} name - Spot name
+ * Builds unique search words from one or more text fields: split, lowercase,
+ * remove punctuation and stop words. Full words only (no prefixes).
+ * Used for spot/event search term collections.
+ * @param {...(string|Array<string>)} values - Text values to index.
  * @return {string[]}
  */
-function buildSpotSearchWords(name) {
-  if (!name || typeof name !== "string") return [];
-  const normalized = name
+function buildSpotSearchWords(...values) {
+  if (!Array.isArray(values) || values.length === 0) return [];
+  const normalizedInput = values
+      .flatMap((value) => {
+        if (Array.isArray(value)) return value;
+        return [value];
+      })
+      .filter((value) => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+      .join(" ");
+  if (!normalizedInput) return [];
+  const normalized = normalizedInput
       .replace(/[\s\p{P}\p{S}]/gu, " ")
       .split(/\s+/)
       .map((w) => w.toLowerCase().replace(/[^\p{L}\p{N}]/gu, ""))

--- a/functions/lib/text-processing.js
+++ b/functions/lib/text-processing.js
@@ -67,6 +67,16 @@ function spotSearchTermDocId(spotId, term) {
 }
 
 /**
+ * Deterministic doc ID for eventSearchTerms collection
+ * @param {string} eventId
+ * @param {string} term
+ * @return {string}
+ */
+function eventSearchTermDocId(eventId, term) {
+  return `${eventId}_${term}`;
+}
+
+/**
  * Cleans HTML from description text
  * @param {string} description - The description text to clean
  * @return {string} The cleaned description text
@@ -228,6 +238,7 @@ module.exports = {
   normalizeSearchQuery,
   getSearchQueryTokens,
   spotSearchTermDocId,
+  eventSearchTermDocId,
   cleanDescription,
   extractYoutubeVideoIdsFromDescription,
   extractImageUrls,

--- a/functions/test/spot-attributes.test.js
+++ b/functions/test/spot-attributes.test.js
@@ -40,6 +40,12 @@ describe("buildSpotSearchWords", () => {
     expect(buildSpotSearchWords("")).toEqual([]);
     expect(buildSpotSearchWords(null)).toEqual([]);
   });
+  it("indexes words across multiple text fields", () => {
+    const words = buildSpotSearchWords("Mauer Park", "Berlin");
+    expect(words).toContain("mauer");
+    expect(words).toContain("park");
+    expect(words).toContain("berlin");
+  });
 });
 
 describe("normalizeStringArray", () => {

--- a/functions/test/text-processing.test.js
+++ b/functions/test/text-processing.test.js
@@ -3,6 +3,7 @@ const {
   normalizeSearchQuery,
   getSearchQueryTokens,
   spotSearchTermDocId,
+  eventSearchTermDocId,
   cleanDescription,
   extractYoutubeVideoIdsFromDescription,
   extractImageUrls,
@@ -46,6 +47,12 @@ describe("getSearchQueryTokens", () => {
 describe("spotSearchTermDocId", () => {
   it("returns deterministic id", () => {
     expect(spotSearchTermDocId("spot1", "amsterdam")).toBe("spot1_amsterdam");
+  });
+});
+
+describe("eventSearchTermDocId", () => {
+  it("returns deterministic id", () => {
+    expect(eventSearchTermDocId("event1", "amsterdam")).toBe("event1_amsterdam");
   });
 });
 

--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -141,11 +141,14 @@ class _AutocompleteOverlayContentState
                 final option = optionsList[index];
                 final optionType = option['optionType'] as String? ?? 'place';
                 final isSpotSuggestion = optionType == 'spot';
+                final isEventSuggestion = optionType == 'event';
                 final description = option['description'] as String? ?? '';
                 final secondary = option['secondary'] as String?;
                 final isSelected = currentSelection == index;
                 final leadingIcon = isSpotSuggestion
                     ? (isSelected ? Icons.place : Icons.place_outlined)
+                    : isEventSuggestion
+                    ? (isSelected ? Icons.event : Icons.event_outlined)
                     : (isSelected ? Icons.public : Icons.public_outlined);
 
                 return Container(
@@ -858,6 +861,29 @@ class SearchScreenState extends State<SearchScreen>
     return '${spot.latitude.toStringAsFixed(4)}, ${spot.longitude.toStringAsFixed(4)}';
   }
 
+  String _formatEventSuggestionLocation(Map<String, dynamic> event) {
+    final city = (event['city'] as String?)?.trim();
+    final trimmedCountryCode = (event['countryCode'] as String?)?.trim();
+    final countryCode =
+        trimmedCountryCode != null && trimmedCountryCode.isNotEmpty
+        ? trimmedCountryCode.toUpperCase()
+        : null;
+
+    if (city != null &&
+        city.isNotEmpty &&
+        countryCode != null &&
+        countryCode.isNotEmpty) {
+      return '$city, $countryCode';
+    }
+    if (city != null && city.isNotEmpty) {
+      return city;
+    }
+    if (countryCode != null && countryCode.isNotEmpty) {
+      return countryCode;
+    }
+    return '';
+  }
+
   Future<void> _selectSpotSuggestion(Map<String, dynamic> suggestion) async {
     final spot = suggestion['spot'];
     if (spot is! Spot) return;
@@ -884,6 +910,29 @@ class SearchScreenState extends State<SearchScreen>
     }
   }
 
+  Future<void> _selectEventSuggestion(Map<String, dynamic> suggestion) async {
+    final eventId = suggestion['eventId'] as String?;
+    if (eventId == null || eventId.isEmpty) return;
+
+    final description = suggestion['description'] as String? ?? '';
+    final controllerToUpdate = _autocompleteController ?? _searchController;
+    setState(() {
+      controllerToUpdate.text = description;
+      controllerToUpdate.selection = TextSelection.fromPosition(
+        TextPosition(offset: controllerToUpdate.text.length),
+      );
+      _searchQuery = description;
+      _isSearchingLocation = false;
+    });
+
+    if (_autocompleteFocusNode != null && _autocompleteFocusNode!.hasFocus) {
+      _autocompleteFocusNode!.unfocus();
+    }
+
+    _lastAutocompleteSpotSelection = DateTime.now();
+    await _locateEventById(eventId);
+  }
+
   /// Load full spot details in background and update the card when available.
   void _loadFullSpotInBackground(String spotId) {
     _spotServiceRef ??= Provider.of<SpotService>(context, listen: false);
@@ -903,10 +952,14 @@ class SearchScreenState extends State<SearchScreen>
       await _selectSpotSuggestion(option);
       return;
     }
+    if (optionType == 'event') {
+      await _selectEventSuggestion(option);
+      return;
+    }
     await _selectPlaceSuggestion(option);
   }
 
-  /// Fetches autocomplete options from both geocoding and spot search (Future.wait).
+  /// Fetches autocomplete options from geocoding, spot search, and event search.
   Future<List<Map<String, dynamic>>> _buildAutocompleteOptions(
     String query,
   ) async {
@@ -931,6 +984,10 @@ class SearchScreenState extends State<SearchScreen>
     try {
       final geocoding = Provider.of<GeocodingService>(context, listen: false);
       final spotService = Provider.of<SpotService>(context, listen: false);
+      final eventsService = Provider.of<AdminEventsService>(
+        context,
+        listen: false,
+      );
       final shouldSearchSpotTitles = trimmedQuery.length >= 2;
 
       final results = await Future.wait([
@@ -944,12 +1001,16 @@ class SearchScreenState extends State<SearchScreen>
         shouldSearchSpotTitles
             ? spotService.searchSpotsByTitle(query: trimmedQuery, limit: 6)
             : Future.value(<Spot>[]),
+        shouldSearchSpotTitles
+            ? eventsService.searchEventsByTitle(query: trimmedQuery, limit: 6)
+            : Future.value(<Map<String, dynamic>>[]),
       ]);
 
       if (!mounted) return [];
 
       final locationSuggestions = results[0] as List<Map<String, dynamic>>;
       final matchingSpots = results[1] as List<Spot>;
+      final matchingEvents = results[2] as List<Map<String, dynamic>>;
 
       final combinedOptions = <Map<String, dynamic>>[
         ...locationSuggestions.map(
@@ -964,6 +1025,19 @@ class SearchScreenState extends State<SearchScreen>
           'description': spot.name,
           'secondary': _formatSpotSuggestionLocation(spot),
           'spot': spot,
+        });
+      }
+
+      for (final event in matchingEvents) {
+        final eventId = event['id'] as String?;
+        final title = (event['title'] as String?)?.trim() ?? '';
+        if (eventId == null || eventId.isEmpty || title.isEmpty) continue;
+        final secondary = _formatEventSuggestionLocation(event);
+        combinedOptions.add({
+          'optionType': 'event',
+          'description': title,
+          if (secondary.isNotEmpty) 'secondary': secondary,
+          'eventId': eventId,
         });
       }
 
@@ -2408,8 +2482,9 @@ class SearchScreenState extends State<SearchScreen>
         context,
         listen: false,
       );
-      final linkedEventFuture =
-          eventsService.getNextUpcomingEventForSpotList(listId);
+      final linkedEventFuture = eventsService.getNextUpcomingEventForSpotList(
+        listId,
+      );
 
       setState(() {
         _selectedList = list;
@@ -2976,8 +3051,7 @@ class SearchScreenState extends State<SearchScreen>
                   mainAxisSpacing: 12,
                 ),
                 delegate: SliverChildBuilderDelegate(
-                  (context, index) =>
-                      _buildEventCard(groups[i].events[index]),
+                  (context, index) => _buildEventCard(groups[i].events[index]),
                   childCount: groups[i].events.length,
                 ),
               ),
@@ -2988,7 +3062,15 @@ class SearchScreenState extends State<SearchScreen>
       );
     }
 
-    final entries = <({bool isHeader, DateTime? monthStart, bool isFirst, EventMapPin? pin})>[];
+    final entries =
+        <
+          ({
+            bool isHeader,
+            DateTime? monthStart,
+            bool isFirst,
+            EventMapPin? pin,
+          })
+        >[];
     for (var i = 0; i < groups.length; i++) {
       final group = groups[i];
       entries.add((

--- a/lib/services/admin_events_service.dart
+++ b/lib/services/admin_events_service.dart
@@ -440,6 +440,47 @@ class AdminEventsService extends ChangeNotifier {
     }
   }
 
+  Future<List<Map<String, dynamic>>> searchEventsByTitle({
+    required String query,
+    int limit = 6,
+  }) async {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.isEmpty) return <Map<String, dynamic>>[];
+
+    try {
+      final callable = _functions.httpsCallable('searchEventsByTitle');
+      final result = await callable.call<Map<String, dynamic>>({
+        'query': trimmedQuery,
+        'limit': limit,
+      });
+      final data = result.data;
+      if (data['success'] != true) {
+        return <Map<String, dynamic>>[];
+      }
+      final items = data['events'] as List<dynamic>? ?? <dynamic>[];
+      return items
+          .whereType<Map<String, dynamic>>()
+          .map(
+            (item) => <String, dynamic>{
+              'id': item['id'] as String?,
+              'title': item['title'] as String? ?? '',
+              'city': item['city'] as String?,
+              'countryCode': item['countryCode'] as String?,
+              'startAt': item['startAt'] as String?,
+            },
+          )
+          .where(
+            (event) =>
+                (event['id'] as String?)?.isNotEmpty == true &&
+                (event['title'] as String).trim().isNotEmpty,
+          )
+          .toList();
+    } catch (e, st) {
+      debugPrint('AdminEventsService.searchEventsByTitle error: $e\n$st');
+      return <Map<String, dynamic>>[];
+    }
+  }
+
   Future<ParkourEvent?> getNextUpcomingEventForSpot(String spotId) async {
     return _getNextUpcomingEvent(
       field: 'spotIds',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Extend spot term indexing to include both spot `name` and `city` on create/update/backfill.
- Add event term indexing lifecycle (`eventSearchTerms`) on event create/update/delete, plus admin backfill callable.
- Add new callable `searchEventsByTitle` using token-prefix matching and upcoming-event filtering.
- Wire Explore autocomplete to fetch/render/select event suggestions alongside places/spots.
- Add unit tests for multi-field tokenization and event term doc IDs.

## Testing
- `npm test -- spot-attributes.test.js text-processing.test.js`
- `npm run lint`
- `flutter --version`
- `flutter analyze lib/screens/spots/search_screen.dart lib/services/admin_events_service.dart` (info-level diagnostics only)
- `flutter test test/explore_events_utils_test.dart`
- Verified callable responses from local emulators:
  - `searchSpotsByTitle` with query `rotter` returns seeded spot
  - `searchEventsByTitle` with query `rotter` returns seeded event
- Manual UI walkthrough on `http://localhost:8080/explore` confirms dropdown shows both spot + event suggestions and event selection focuses map/event card.

## Walkthrough Artifacts
[explore_autocomplete_events_city_terms_final.mp4](https://cursor.com/agents/bc-6ca6261b-b26e-4109-b75d-73ff8a1d1864/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexplore_autocomplete_events_city_terms_final.mp4)
[Autocomplete dropdown showing spot and event suggestions](https://cursor.com/agents/bc-6ca6261b-b26e-4109-b75d-73ff8a1d1864/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fautocomplete_dropdown_spot_and_event_final.webp)
[Selected event focused on map with event card](https://cursor.com/agents/bc-6ca6261b-b26e-4109-b75d-73ff8a1d1864/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fautocomplete_event_selected_final.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ca6261b-b26e-4109-b75d-73ff8a1d1864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ca6261b-b26e-4109-b75d-73ff8a1d1864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

