### PR TITLE
Add event photo/edit suggestion moderation flow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -523,7 +523,7 @@ service cloud.firestore {
         );
       }
 
-      allow create: if request.auth != null && eventReportPhotoUrlsOk(request.resource.data);
+      allow create: if eventReportPhotoUrlsOk(request.resource.data);
       allow read, update, delete: if requestingUserIsStaff();
     }
 

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -3238,5 +3238,83 @@
         "type": "String"
       }
     }
+  },
+  "eventDetailQuickActionSuggestPhoto": "Suggest photo",
+  "@eventDetailQuickActionSuggestPhoto": {
+    "description": "Quick action label for suggesting event photos"
+  },
+  "eventDetailQuickActionSuggestEdit": "Suggest an edit",
+  "@eventDetailQuickActionSuggestEdit": {
+    "description": "Quick action label for suggesting event edits"
+  },
+  "eventDetailUnableSuggestNow": "Unable to suggest changes for this event right now.",
+  "@eventDetailUnableSuggestNow": {
+    "description": "Shown when event suggestion cannot open"
+  },
+  "eventDetailCannotSuggestForDuplicate": "Cannot suggest changes for duplicate events.",
+  "@eventDetailCannotSuggestForDuplicate": {
+    "description": "Shown when trying to suggest on duplicate events"
+  },
+  "eventDetailCannotSuggestForExternal": "Cannot suggest changes for externally sourced events. Create a native event first.",
+  "@eventDetailCannotSuggestForExternal": {
+    "description": "Shown when trying to suggest on external events"
+  },
+  "eventDetailThanksPhotoSuggestion": "Thanks! Your photo suggestion has been submitted for review.",
+  "@eventDetailThanksPhotoSuggestion": {
+    "description": "Success message after submitting event photo suggestion"
+  },
+  "eventDetailThanksEditSuggestion": "Thanks! Your edit suggestion has been submitted for review.",
+  "@eventDetailThanksEditSuggestion": {
+    "description": "Success message after submitting event edit suggestion"
+  },
+  "eventDetailSuggestPhotosTitle": "Suggest photos",
+  "@eventDetailSuggestPhotosTitle": {
+    "description": "Dialog title for event photo suggestions"
+  },
+  "eventDetailSuggestPhotosIntro": "Upload photos for this event. Moderators will review your suggestion.",
+  "@eventDetailSuggestPhotosIntro": {
+    "description": "Dialog intro for event photo suggestions"
+  },
+  "eventDetailSuggestPhotosPickRequired": "Please add at least one photo.",
+  "@eventDetailSuggestPhotosPickRequired": {
+    "description": "Validation when no photos selected for event photo suggestion"
+  },
+  "eventDetailSuggestPhotosSubmitFailed": "Failed to submit photo suggestion. Please try again.",
+  "@eventDetailSuggestPhotosSubmitFailed": {
+    "description": "General failure message for event photo suggestion submit"
+  },
+  "eventDetailSuggestPhotosSubmitError": "Error submitting photo suggestion: {error}",
+  "@eventDetailSuggestPhotosSubmitError": {
+    "description": "Error detail for event photo suggestion submit",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "eventDetailSuggestEditTitle": "Suggest an edit",
+  "@eventDetailSuggestEditTitle": {
+    "description": "Dialog title for event edit suggestions"
+  },
+  "eventDetailSuggestEditIntro": "Propose updates to this event. Moderators will review your suggestion.",
+  "@eventDetailSuggestEditIntro": {
+    "description": "Dialog intro for event edit suggestions"
+  },
+  "eventDetailSuggestEditNoChanges": "Please suggest at least one change.",
+  "@eventDetailSuggestEditNoChanges": {
+    "description": "Validation when no edit fields changed"
+  },
+  "eventDetailSuggestEditSubmitFailed": "Failed to submit edit suggestion. Please try again.",
+  "@eventDetailSuggestEditSubmitFailed": {
+    "description": "General failure message for event edit suggestion submit"
+  },
+  "eventDetailSuggestEditSubmitError": "Error submitting edit suggestion: {error}",
+  "@eventDetailSuggestEditSubmitError": {
+    "description": "Error detail for event edit suggestion submit",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/l10n/app_fr.arb
+++ b/l10n/app_fr.arb
@@ -917,5 +917,22 @@
   "eventDetailRemoveDuplicateConfirmBody": "Retirer le statut de doublon pour cet événement ? Il ne pointera plus vers un autre événement comme original.",
   "eventDetailRemoveDuplicateSuccess": "Statut de doublon retiré.",
   "eventDetailCopiedToClipboard": "Événement copié dans le presse-papiers !",
-  "eventDetailShareFailed": "Échec du partage de l’événement : {error}"
+  "eventDetailShareFailed": "Échec du partage de l’événement : {error}",
+  "eventDetailQuickActionSuggestPhoto": "Suggérer une photo",
+  "eventDetailQuickActionSuggestEdit": "Suggérer une modification",
+  "eventDetailUnableSuggestNow": "Impossible de suggérer des modifications pour cet événement pour le moment.",
+  "eventDetailCannotSuggestForDuplicate": "Impossible de suggérer des modifications pour un événement en doublon.",
+  "eventDetailCannotSuggestForExternal": "Impossible de suggérer des modifications pour un événement externe. Créez d’abord un événement natif.",
+  "eventDetailThanksPhotoSuggestion": "Merci ! Votre suggestion de photos a été soumise pour examen.",
+  "eventDetailThanksEditSuggestion": "Merci ! Votre suggestion de modification a été soumise pour examen.",
+  "eventDetailSuggestPhotosTitle": "Suggérer des photos",
+  "eventDetailSuggestPhotosIntro": "Ajoutez des photos pour cet événement. Les modérateurs examineront votre suggestion.",
+  "eventDetailSuggestPhotosPickRequired": "Ajoutez au moins une photo.",
+  "eventDetailSuggestPhotosSubmitFailed": "Échec de l’envoi de la suggestion de photo. Réessayez.",
+  "eventDetailSuggestPhotosSubmitError": "Erreur lors de l’envoi de la suggestion de photo : {error}",
+  "eventDetailSuggestEditTitle": "Suggérer une modification",
+  "eventDetailSuggestEditIntro": "Proposez des modifications pour cet événement. Les modérateurs examineront votre suggestion.",
+  "eventDetailSuggestEditNoChanges": "Veuillez suggérer au moins une modification.",
+  "eventDetailSuggestEditSubmitFailed": "Échec de l’envoi de la suggestion de modification. Réessayez.",
+  "eventDetailSuggestEditSubmitError": "Erreur lors de l’envoi de la suggestion de modification : {error}"
 }

--- a/l10n/untranslated_messages.json
+++ b/l10n/untranslated_messages.json
@@ -8,7 +8,24 @@
     "profilePushNotificationsEnabled",
     "profilePushNotificationsPermissionGrantedButOff",
     "profilePushNotificationsUnknown",
-    "profilePushNotificationsError"
+    "profilePushNotificationsError",
+    "eventDetailQuickActionSuggestPhoto",
+    "eventDetailQuickActionSuggestEdit",
+    "eventDetailUnableSuggestNow",
+    "eventDetailCannotSuggestForDuplicate",
+    "eventDetailCannotSuggestForExternal",
+    "eventDetailThanksPhotoSuggestion",
+    "eventDetailThanksEditSuggestion",
+    "eventDetailSuggestPhotosTitle",
+    "eventDetailSuggestPhotosIntro",
+    "eventDetailSuggestPhotosPickRequired",
+    "eventDetailSuggestPhotosSubmitFailed",
+    "eventDetailSuggestPhotosSubmitError",
+    "eventDetailSuggestEditTitle",
+    "eventDetailSuggestEditIntro",
+    "eventDetailSuggestEditNoChanges",
+    "eventDetailSuggestEditSubmitFailed",
+    "eventDetailSuggestEditSubmitError"
   ],
 
   "es": [
@@ -20,7 +37,24 @@
     "profilePushNotificationsEnabled",
     "profilePushNotificationsPermissionGrantedButOff",
     "profilePushNotificationsUnknown",
-    "profilePushNotificationsError"
+    "profilePushNotificationsError",
+    "eventDetailQuickActionSuggestPhoto",
+    "eventDetailQuickActionSuggestEdit",
+    "eventDetailUnableSuggestNow",
+    "eventDetailCannotSuggestForDuplicate",
+    "eventDetailCannotSuggestForExternal",
+    "eventDetailThanksPhotoSuggestion",
+    "eventDetailThanksEditSuggestion",
+    "eventDetailSuggestPhotosTitle",
+    "eventDetailSuggestPhotosIntro",
+    "eventDetailSuggestPhotosPickRequired",
+    "eventDetailSuggestPhotosSubmitFailed",
+    "eventDetailSuggestPhotosSubmitError",
+    "eventDetailSuggestEditTitle",
+    "eventDetailSuggestEditIntro",
+    "eventDetailSuggestEditNoChanges",
+    "eventDetailSuggestEditSubmitFailed",
+    "eventDetailSuggestEditSubmitError"
   ],
 
   "fr": [
@@ -46,7 +80,24 @@
     "profilePushNotificationsUnknown",
     "profilePushNotificationsError",
     "spotTrainingPlanTooltipPublicUntil",
-    "spotTrainingPlanTooltipPrivateUntil"
+    "spotTrainingPlanTooltipPrivateUntil",
+    "eventDetailQuickActionSuggestPhoto",
+    "eventDetailQuickActionSuggestEdit",
+    "eventDetailUnableSuggestNow",
+    "eventDetailCannotSuggestForDuplicate",
+    "eventDetailCannotSuggestForExternal",
+    "eventDetailThanksPhotoSuggestion",
+    "eventDetailThanksEditSuggestion",
+    "eventDetailSuggestPhotosTitle",
+    "eventDetailSuggestPhotosIntro",
+    "eventDetailSuggestPhotosPickRequired",
+    "eventDetailSuggestPhotosSubmitFailed",
+    "eventDetailSuggestPhotosSubmitError",
+    "eventDetailSuggestEditTitle",
+    "eventDetailSuggestEditIntro",
+    "eventDetailSuggestEditNoChanges",
+    "eventDetailSuggestEditSubmitFailed",
+    "eventDetailSuggestEditSubmitError"
   ],
 
   "pt": [
@@ -58,6 +109,23 @@
     "profilePushNotificationsEnabled",
     "profilePushNotificationsPermissionGrantedButOff",
     "profilePushNotificationsUnknown",
-    "profilePushNotificationsError"
+    "profilePushNotificationsError",
+    "eventDetailQuickActionSuggestPhoto",
+    "eventDetailQuickActionSuggestEdit",
+    "eventDetailUnableSuggestNow",
+    "eventDetailCannotSuggestForDuplicate",
+    "eventDetailCannotSuggestForExternal",
+    "eventDetailThanksPhotoSuggestion",
+    "eventDetailThanksEditSuggestion",
+    "eventDetailSuggestPhotosTitle",
+    "eventDetailSuggestPhotosIntro",
+    "eventDetailSuggestPhotosPickRequired",
+    "eventDetailSuggestPhotosSubmitFailed",
+    "eventDetailSuggestPhotosSubmitError",
+    "eventDetailSuggestEditTitle",
+    "eventDetailSuggestEditIntro",
+    "eventDetailSuggestEditNoChanges",
+    "eventDetailSuggestEditSubmitFailed",
+    "eventDetailSuggestEditSubmitError"
   ]
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5624,6 +5624,108 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to share event: {error}'**
   String eventDetailShareFailed(String error);
+
+  /// Quick action label for suggesting event photos
+  ///
+  /// In en, this message translates to:
+  /// **'Suggest photo'**
+  String get eventDetailQuickActionSuggestPhoto;
+
+  /// Quick action label for suggesting event edits
+  ///
+  /// In en, this message translates to:
+  /// **'Suggest an edit'**
+  String get eventDetailQuickActionSuggestEdit;
+
+  /// Shown when event suggestion cannot open
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to suggest changes for this event right now.'**
+  String get eventDetailUnableSuggestNow;
+
+  /// Shown when trying to suggest on duplicate events
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot suggest changes for duplicate events.'**
+  String get eventDetailCannotSuggestForDuplicate;
+
+  /// Shown when trying to suggest on external events
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot suggest changes for externally sourced events. Create a native event first.'**
+  String get eventDetailCannotSuggestForExternal;
+
+  /// Success message after submitting event photo suggestion
+  ///
+  /// In en, this message translates to:
+  /// **'Thanks! Your photo suggestion has been submitted for review.'**
+  String get eventDetailThanksPhotoSuggestion;
+
+  /// Success message after submitting event edit suggestion
+  ///
+  /// In en, this message translates to:
+  /// **'Thanks! Your edit suggestion has been submitted for review.'**
+  String get eventDetailThanksEditSuggestion;
+
+  /// Dialog title for event photo suggestions
+  ///
+  /// In en, this message translates to:
+  /// **'Suggest photos'**
+  String get eventDetailSuggestPhotosTitle;
+
+  /// Dialog intro for event photo suggestions
+  ///
+  /// In en, this message translates to:
+  /// **'Upload photos for this event. Moderators will review your suggestion.'**
+  String get eventDetailSuggestPhotosIntro;
+
+  /// Validation when no photos selected for event photo suggestion
+  ///
+  /// In en, this message translates to:
+  /// **'Please add at least one photo.'**
+  String get eventDetailSuggestPhotosPickRequired;
+
+  /// General failure message for event photo suggestion submit
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to submit photo suggestion. Please try again.'**
+  String get eventDetailSuggestPhotosSubmitFailed;
+
+  /// Error detail for event photo suggestion submit
+  ///
+  /// In en, this message translates to:
+  /// **'Error submitting photo suggestion: {error}'**
+  String eventDetailSuggestPhotosSubmitError(String error);
+
+  /// Dialog title for event edit suggestions
+  ///
+  /// In en, this message translates to:
+  /// **'Suggest an edit'**
+  String get eventDetailSuggestEditTitle;
+
+  /// Dialog intro for event edit suggestions
+  ///
+  /// In en, this message translates to:
+  /// **'Propose updates to this event. Moderators will review your suggestion.'**
+  String get eventDetailSuggestEditIntro;
+
+  /// Validation when no edit fields changed
+  ///
+  /// In en, this message translates to:
+  /// **'Please suggest at least one change.'**
+  String get eventDetailSuggestEditNoChanges;
+
+  /// General failure message for event edit suggestion submit
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to submit edit suggestion. Please try again.'**
+  String get eventDetailSuggestEditSubmitFailed;
+
+  /// Error detail for event edit suggestion submit
+  ///
+  /// In en, this message translates to:
+  /// **'Error submitting edit suggestion: {error}'**
+  String eventDetailSuggestEditSubmitError(String error);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3363,4 +3363,70 @@ class AppLocalizationsDe extends AppLocalizations {
   String eventDetailShareFailed(String error) {
     return 'Teilen fehlgeschlagen: $error';
   }
+
+  @override
+  String get eventDetailQuickActionSuggestPhoto => 'Suggest photo';
+
+  @override
+  String get eventDetailQuickActionSuggestEdit => 'Suggest an edit';
+
+  @override
+  String get eventDetailUnableSuggestNow =>
+      'Unable to suggest changes for this event right now.';
+
+  @override
+  String get eventDetailCannotSuggestForDuplicate =>
+      'Cannot suggest changes for duplicate events.';
+
+  @override
+  String get eventDetailCannotSuggestForExternal =>
+      'Cannot suggest changes for externally sourced events. Create a native event first.';
+
+  @override
+  String get eventDetailThanksPhotoSuggestion =>
+      'Thanks! Your photo suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailThanksEditSuggestion =>
+      'Thanks! Your edit suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailSuggestPhotosTitle => 'Suggest photos';
+
+  @override
+  String get eventDetailSuggestPhotosIntro =>
+      'Upload photos for this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestPhotosPickRequired =>
+      'Please add at least one photo.';
+
+  @override
+  String get eventDetailSuggestPhotosSubmitFailed =>
+      'Failed to submit photo suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestPhotosSubmitError(String error) {
+    return 'Error submitting photo suggestion: $error';
+  }
+
+  @override
+  String get eventDetailSuggestEditTitle => 'Suggest an edit';
+
+  @override
+  String get eventDetailSuggestEditIntro =>
+      'Propose updates to this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestEditNoChanges =>
+      'Please suggest at least one change.';
+
+  @override
+  String get eventDetailSuggestEditSubmitFailed =>
+      'Failed to submit edit suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestEditSubmitError(String error) {
+    return 'Error submitting edit suggestion: $error';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3306,4 +3306,70 @@ class AppLocalizationsEn extends AppLocalizations {
   String eventDetailShareFailed(String error) {
     return 'Failed to share event: $error';
   }
+
+  @override
+  String get eventDetailQuickActionSuggestPhoto => 'Suggest photo';
+
+  @override
+  String get eventDetailQuickActionSuggestEdit => 'Suggest an edit';
+
+  @override
+  String get eventDetailUnableSuggestNow =>
+      'Unable to suggest changes for this event right now.';
+
+  @override
+  String get eventDetailCannotSuggestForDuplicate =>
+      'Cannot suggest changes for duplicate events.';
+
+  @override
+  String get eventDetailCannotSuggestForExternal =>
+      'Cannot suggest changes for externally sourced events. Create a native event first.';
+
+  @override
+  String get eventDetailThanksPhotoSuggestion =>
+      'Thanks! Your photo suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailThanksEditSuggestion =>
+      'Thanks! Your edit suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailSuggestPhotosTitle => 'Suggest photos';
+
+  @override
+  String get eventDetailSuggestPhotosIntro =>
+      'Upload photos for this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestPhotosPickRequired =>
+      'Please add at least one photo.';
+
+  @override
+  String get eventDetailSuggestPhotosSubmitFailed =>
+      'Failed to submit photo suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestPhotosSubmitError(String error) {
+    return 'Error submitting photo suggestion: $error';
+  }
+
+  @override
+  String get eventDetailSuggestEditTitle => 'Suggest an edit';
+
+  @override
+  String get eventDetailSuggestEditIntro =>
+      'Propose updates to this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestEditNoChanges =>
+      'Please suggest at least one change.';
+
+  @override
+  String get eventDetailSuggestEditSubmitFailed =>
+      'Failed to submit edit suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestEditSubmitError(String error) {
+    return 'Error submitting edit suggestion: $error';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3342,4 +3342,70 @@ class AppLocalizationsEs extends AppLocalizations {
   String eventDetailShareFailed(String error) {
     return 'Error al compartir evento: $error';
   }
+
+  @override
+  String get eventDetailQuickActionSuggestPhoto => 'Suggest photo';
+
+  @override
+  String get eventDetailQuickActionSuggestEdit => 'Suggest an edit';
+
+  @override
+  String get eventDetailUnableSuggestNow =>
+      'Unable to suggest changes for this event right now.';
+
+  @override
+  String get eventDetailCannotSuggestForDuplicate =>
+      'Cannot suggest changes for duplicate events.';
+
+  @override
+  String get eventDetailCannotSuggestForExternal =>
+      'Cannot suggest changes for externally sourced events. Create a native event first.';
+
+  @override
+  String get eventDetailThanksPhotoSuggestion =>
+      'Thanks! Your photo suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailThanksEditSuggestion =>
+      'Thanks! Your edit suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailSuggestPhotosTitle => 'Suggest photos';
+
+  @override
+  String get eventDetailSuggestPhotosIntro =>
+      'Upload photos for this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestPhotosPickRequired =>
+      'Please add at least one photo.';
+
+  @override
+  String get eventDetailSuggestPhotosSubmitFailed =>
+      'Failed to submit photo suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestPhotosSubmitError(String error) {
+    return 'Error submitting photo suggestion: $error';
+  }
+
+  @override
+  String get eventDetailSuggestEditTitle => 'Suggest an edit';
+
+  @override
+  String get eventDetailSuggestEditIntro =>
+      'Propose updates to this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestEditNoChanges =>
+      'Please suggest at least one change.';
+
+  @override
+  String get eventDetailSuggestEditSubmitFailed =>
+      'Failed to submit edit suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestEditSubmitError(String error) {
+    return 'Error submitting edit suggestion: $error';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3370,4 +3370,70 @@ class AppLocalizationsFr extends AppLocalizations {
   String eventDetailShareFailed(String error) {
     return 'Échec du partage de l’événement : $error';
   }
+
+  @override
+  String get eventDetailQuickActionSuggestPhoto => 'Suggérer une photo';
+
+  @override
+  String get eventDetailQuickActionSuggestEdit => 'Suggérer une modification';
+
+  @override
+  String get eventDetailUnableSuggestNow =>
+      'Impossible de suggérer des modifications pour cet événement pour le moment.';
+
+  @override
+  String get eventDetailCannotSuggestForDuplicate =>
+      'Impossible de suggérer des modifications pour un événement en doublon.';
+
+  @override
+  String get eventDetailCannotSuggestForExternal =>
+      'Impossible de suggérer des modifications pour un événement externe. Créez d’abord un événement natif.';
+
+  @override
+  String get eventDetailThanksPhotoSuggestion =>
+      'Merci ! Votre suggestion de photos a été soumise pour examen.';
+
+  @override
+  String get eventDetailThanksEditSuggestion =>
+      'Merci ! Votre suggestion de modification a été soumise pour examen.';
+
+  @override
+  String get eventDetailSuggestPhotosTitle => 'Suggérer des photos';
+
+  @override
+  String get eventDetailSuggestPhotosIntro =>
+      'Ajoutez des photos pour cet événement. Les modérateurs examineront votre suggestion.';
+
+  @override
+  String get eventDetailSuggestPhotosPickRequired =>
+      'Ajoutez au moins une photo.';
+
+  @override
+  String get eventDetailSuggestPhotosSubmitFailed =>
+      'Échec de l’envoi de la suggestion de photo. Réessayez.';
+
+  @override
+  String eventDetailSuggestPhotosSubmitError(String error) {
+    return 'Erreur lors de l’envoi de la suggestion de photo : $error';
+  }
+
+  @override
+  String get eventDetailSuggestEditTitle => 'Suggérer une modification';
+
+  @override
+  String get eventDetailSuggestEditIntro =>
+      'Proposez des modifications pour cet événement. Les modérateurs examineront votre suggestion.';
+
+  @override
+  String get eventDetailSuggestEditNoChanges =>
+      'Veuillez suggérer au moins une modification.';
+
+  @override
+  String get eventDetailSuggestEditSubmitFailed =>
+      'Échec de l’envoi de la suggestion de modification. Réessayez.';
+
+  @override
+  String eventDetailSuggestEditSubmitError(String error) {
+    return 'Erreur lors de l’envoi de la suggestion de modification : $error';
+  }
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3330,4 +3330,70 @@ class AppLocalizationsNl extends AppLocalizations {
   String eventDetailShareFailed(String error) {
     return 'Delen mislukt: $error';
   }
+
+  @override
+  String get eventDetailQuickActionSuggestPhoto => 'Suggest photo';
+
+  @override
+  String get eventDetailQuickActionSuggestEdit => 'Suggest an edit';
+
+  @override
+  String get eventDetailUnableSuggestNow =>
+      'Unable to suggest changes for this event right now.';
+
+  @override
+  String get eventDetailCannotSuggestForDuplicate =>
+      'Cannot suggest changes for duplicate events.';
+
+  @override
+  String get eventDetailCannotSuggestForExternal =>
+      'Cannot suggest changes for externally sourced events. Create a native event first.';
+
+  @override
+  String get eventDetailThanksPhotoSuggestion =>
+      'Thanks! Your photo suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailThanksEditSuggestion =>
+      'Thanks! Your edit suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailSuggestPhotosTitle => 'Suggest photos';
+
+  @override
+  String get eventDetailSuggestPhotosIntro =>
+      'Upload photos for this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestPhotosPickRequired =>
+      'Please add at least one photo.';
+
+  @override
+  String get eventDetailSuggestPhotosSubmitFailed =>
+      'Failed to submit photo suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestPhotosSubmitError(String error) {
+    return 'Error submitting photo suggestion: $error';
+  }
+
+  @override
+  String get eventDetailSuggestEditTitle => 'Suggest an edit';
+
+  @override
+  String get eventDetailSuggestEditIntro =>
+      'Propose updates to this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestEditNoChanges =>
+      'Please suggest at least one change.';
+
+  @override
+  String get eventDetailSuggestEditSubmitFailed =>
+      'Failed to submit edit suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestEditSubmitError(String error) {
+    return 'Error submitting edit suggestion: $error';
+  }
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3351,4 +3351,70 @@ class AppLocalizationsPt extends AppLocalizations {
   String eventDetailShareFailed(String error) {
     return 'Falha ao partilhar evento: $error';
   }
+
+  @override
+  String get eventDetailQuickActionSuggestPhoto => 'Suggest photo';
+
+  @override
+  String get eventDetailQuickActionSuggestEdit => 'Suggest an edit';
+
+  @override
+  String get eventDetailUnableSuggestNow =>
+      'Unable to suggest changes for this event right now.';
+
+  @override
+  String get eventDetailCannotSuggestForDuplicate =>
+      'Cannot suggest changes for duplicate events.';
+
+  @override
+  String get eventDetailCannotSuggestForExternal =>
+      'Cannot suggest changes for externally sourced events. Create a native event first.';
+
+  @override
+  String get eventDetailThanksPhotoSuggestion =>
+      'Thanks! Your photo suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailThanksEditSuggestion =>
+      'Thanks! Your edit suggestion has been submitted for review.';
+
+  @override
+  String get eventDetailSuggestPhotosTitle => 'Suggest photos';
+
+  @override
+  String get eventDetailSuggestPhotosIntro =>
+      'Upload photos for this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestPhotosPickRequired =>
+      'Please add at least one photo.';
+
+  @override
+  String get eventDetailSuggestPhotosSubmitFailed =>
+      'Failed to submit photo suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestPhotosSubmitError(String error) {
+    return 'Error submitting photo suggestion: $error';
+  }
+
+  @override
+  String get eventDetailSuggestEditTitle => 'Suggest an edit';
+
+  @override
+  String get eventDetailSuggestEditIntro =>
+      'Propose updates to this event. Moderators will review your suggestion.';
+
+  @override
+  String get eventDetailSuggestEditNoChanges =>
+      'Please suggest at least one change.';
+
+  @override
+  String get eventDetailSuggestEditSubmitFailed =>
+      'Failed to submit edit suggestion. Please try again.';
+
+  @override
+  String eventDetailSuggestEditSubmitError(String error) {
+    return 'Error submitting edit suggestion: $error';
+  }
 }

--- a/lib/models/event_report.dart
+++ b/lib/models/event_report.dart
@@ -22,6 +22,8 @@ class EventReport {
     this.spotListIds = const <String>[],
     this.linkedSpotName,
     this.linkedSpotListName,
+    this.targetEventId,
+    this.targetEventTitle,
     this.reporterUserId,
     this.reporterName,
     this.reporterEmail,
@@ -29,6 +31,9 @@ class EventReport {
     this.approvedEventId,
     this.reviewedBy,
     this.reviewedByName,
+    this.suggestedTitle,
+    this.suggestedDescription,
+    this.suggestedWebsiteUrl,
     this.suggestedPhotoUrls = const <String>[],
     this.rejectedPhotoUrls = const <String>[],
     this.createdAt,
@@ -53,6 +58,8 @@ class EventReport {
   final List<String> spotListIds;
   final String? linkedSpotName;
   final String? linkedSpotListName;
+  final String? targetEventId;
+  final String? targetEventTitle;
   final String? reporterUserId;
   final String? reporterName;
   final String? reporterEmail;
@@ -61,6 +68,9 @@ class EventReport {
   final String? approvedEventId;
   final String? reviewedBy;
   final String? reviewedByName;
+  final String? suggestedTitle;
+  final String? suggestedDescription;
+  final String? suggestedWebsiteUrl;
   final List<String> suggestedPhotoUrls;
   final List<String> rejectedPhotoUrls;
   final DateTime? createdAt;
@@ -116,6 +126,8 @@ class EventReport {
       spotListIds: parseStringList(data['spotListIds']),
       linkedSpotName: data['linkedSpotName'] as String?,
       linkedSpotListName: data['linkedSpotListName'] as String?,
+      targetEventId: data['targetEventId'] as String?,
+      targetEventTitle: data['targetEventTitle'] as String?,
       reporterUserId: data['reporterUserId'] as String?,
       reporterName: data['reporterName'] as String?,
       reporterEmail: data['reporterEmail'] as String?,
@@ -124,12 +136,26 @@ class EventReport {
       approvedEventId: data['approvedEventId'] as String?,
       reviewedBy: data['reviewedBy'] as String?,
       reviewedByName: data['reviewedByName'] as String?,
+      suggestedTitle: data['suggestedTitle'] as String?,
+      suggestedDescription: data['suggestedDescription'] as String?,
+      suggestedWebsiteUrl: data['suggestedWebsiteUrl'] as String?,
       suggestedPhotoUrls: parseStringList(data['suggestedPhotoUrls']),
       rejectedPhotoUrls: parseStringList(data['rejectedPhotoUrls']),
       createdAt: parseDate(data['createdAt']),
       updatedAt: parseDate(data['updatedAt']),
       reviewedAt: parseDate(data['reviewedAt']),
     );
+  }
+
+  bool get isSuggestionForExistingEvent {
+    final id = targetEventId?.trim();
+    return id != null && id.isNotEmpty;
+  }
+
+  bool get hasSuggestedEdits {
+    return (suggestedTitle?.trim().isNotEmpty ?? false) ||
+        (suggestedDescription?.trim().isNotEmpty ?? false) ||
+        (suggestedWebsiteUrl?.trim().isNotEmpty ?? false);
   }
 
   String? get locationSummary {

--- a/lib/models/parkour_event.dart
+++ b/lib/models/parkour_event.dart
@@ -27,6 +27,7 @@ class ParkourEvent {
   final String? externalEventKey;
   final DateTime? externalSyncLastSeenAt;
   final DateTime? externalSyncLastChangedAt;
+  final List<Map<String, String>> contributors;
 
   /// When set, this event is a duplicate of the canonical native event [duplicateOf].
   final String? duplicateOf;
@@ -61,6 +62,7 @@ class ParkourEvent {
     this.externalEventKey,
     this.externalSyncLastSeenAt,
     this.externalSyncLastChangedAt,
+    this.contributors = const <Map<String, String>>[],
     this.duplicateOf,
     this.createdFromCreateNative = false,
   });
@@ -114,6 +116,11 @@ class ParkourEvent {
       externalSyncLastChangedAt: data['externalSyncLastChangedAt'] is Timestamp
           ? (data['externalSyncLastChangedAt'] as Timestamp).toDate()
           : null,
+      contributors: data['contributors'] is List
+          ? (data['contributors'] as List)
+                .map((e) => Map<String, String>.from(e as Map))
+                .toList()
+          : const <Map<String, String>>[],
       duplicateOf: data['duplicateOf'] as String?,
       createdFromCreateNative: data['createdFromCreateNative'] == true,
     );
@@ -161,6 +168,11 @@ class ParkourEvent {
       externalEventKey: data['externalEventKey'] as String?,
       externalSyncLastSeenAt: parseDate(data['externalSyncLastSeenAt']),
       externalSyncLastChangedAt: parseDate(data['externalSyncLastChangedAt']),
+      contributors: data['contributors'] is List
+          ? (data['contributors'] as List)
+                .map((e) => Map<String, String>.from(e as Map))
+                .toList()
+          : const <Map<String, String>>[],
       duplicateOf: data['duplicateOf'] as String?,
       createdFromCreateNative: data['createdFromCreateNative'] == true,
     );
@@ -206,6 +218,7 @@ class ParkourEvent {
         'externalSyncLastSeenAt': externalSyncLastSeenAt!.toUtc(),
       if (externalSyncLastChangedAt != null)
         'externalSyncLastChangedAt': externalSyncLastChangedAt!.toUtc(),
+      if (contributors.isNotEmpty) 'contributors': contributors,
       if (duplicateOf != null && duplicateOf!.trim().isNotEmpty)
         'duplicateOf': duplicateOf!.trim(),
       if (createdFromCreateNative) 'createdFromCreateNative': true,
@@ -239,6 +252,7 @@ class ParkourEvent {
     Object? externalEventKey = _unset,
     Object? externalSyncLastSeenAt = _unset,
     Object? externalSyncLastChangedAt = _unset,
+    List<Map<String, String>>? contributors,
     Object? duplicateOf = _unset,
     bool? createdFromCreateNative,
   }) {
@@ -299,6 +313,7 @@ class ParkourEvent {
       externalSyncLastChangedAt: identical(externalSyncLastChangedAt, _unset)
           ? this.externalSyncLastChangedAt
           : externalSyncLastChangedAt as DateTime?,
+      contributors: contributors ?? this.contributors,
       duplicateOf: identical(duplicateOf, _unset)
           ? this.duplicateOf
           : duplicateOf as String?,

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -1,8 +1,11 @@
+import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:provider/provider.dart';
 
@@ -18,7 +21,9 @@ import '../../services/snackbar_service.dart';
 import '../../services/spot_service.dart';
 import '../../services/search_state_service.dart';
 import '../../services/mobile_detection_service.dart';
+import '../../services/event_report_service.dart';
 import '../../utils/marker_icon_utils.dart';
+import '../../utils/image_preparation.dart';
 import '../../widgets/location_info_box.dart';
 import '../../services/web_share_service.dart';
 import '../../widgets/detail_image_carousel.dart';
@@ -269,6 +274,79 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
     }
   }
 
+  String? _eventSuggestionBlockedReason(
+    ParkourEvent event,
+    AppLocalizations l10n,
+  ) {
+    final duplicateOf = event.duplicateOf?.trim();
+    if (duplicateOf != null && duplicateOf.isNotEmpty) {
+      return l10n.eventDetailCannotSuggestForDuplicate;
+    }
+    if (!event.isNativeEvent) {
+      return l10n.eventDetailCannotSuggestForExternal;
+    }
+    if (event.id == null || event.id!.trim().isEmpty) {
+      return l10n.eventDetailUnableSuggestNow;
+    }
+    return null;
+  }
+
+  Future<void> _showSuggestPhotoDialog() async {
+    final event = _event;
+    if (event == null || !mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+    final blockedReason = _eventSuggestionBlockedReason(event, l10n);
+    if (blockedReason != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(blockedReason), backgroundColor: Colors.red),
+      );
+      return;
+    }
+
+    final submitted = await showDialog<bool>(
+      context: context,
+      barrierDismissible: true,
+      builder: (dialogContext) => _SuggestEventPhotoDialog(event: event),
+    );
+    if (!mounted) return;
+    if (submitted == true) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.eventDetailThanksPhotoSuggestion),
+          backgroundColor: Colors.green,
+        ),
+      );
+    }
+  }
+
+  Future<void> _showSuggestEditDialog() async {
+    final event = _event;
+    if (event == null || !mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+    final blockedReason = _eventSuggestionBlockedReason(event, l10n);
+    if (blockedReason != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(blockedReason), backgroundColor: Colors.red),
+      );
+      return;
+    }
+
+    final submitted = await showDialog<bool>(
+      context: context,
+      barrierDismissible: true,
+      builder: (dialogContext) => _SuggestEventEditDialog(event: event),
+    );
+    if (!mounted) return;
+    if (submitted == true) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.eventDetailThanksEditSuggestion),
+          backgroundColor: Colors.green,
+        ),
+      );
+    }
+  }
+
   Widget _buildShareActionRow(AppLocalizations l10n) {
     return Padding(
       padding: const EdgeInsets.only(top: 6, bottom: 2),
@@ -298,6 +376,62 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
                         context,
                       ).colorScheme.onSurface.withValues(alpha: 0.75),
                       label: l10n.spotDetailQuickActionShare,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Tooltip(
+              message: l10n.eventDetailQuickActionSuggestPhoto,
+              child: Semantics(
+                button: true,
+                label: l10n.eventDetailQuickActionSuggestPhoto,
+                child: Material(
+                  color: Colors.transparent,
+                  borderRadius: BorderRadius.circular(
+                    SpotDetailUi.surfaceRadius,
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(
+                      SpotDetailUi.surfaceRadius,
+                    ),
+                    onTap: _showSuggestPhotoDialog,
+                    child: SpotDetailQuickActionChip(
+                      icon: Icons.add_photo_alternate_outlined,
+                      iconColor: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.75),
+                      label: l10n.eventDetailQuickActionSuggestPhoto,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Tooltip(
+              message: l10n.eventDetailQuickActionSuggestEdit,
+              child: Semantics(
+                button: true,
+                label: l10n.eventDetailQuickActionSuggestEdit,
+                child: Material(
+                  color: Colors.transparent,
+                  borderRadius: BorderRadius.circular(
+                    SpotDetailUi.surfaceRadius,
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(
+                      SpotDetailUi.surfaceRadius,
+                    ),
+                    onTap: _showSuggestEditDialog,
+                    child: SpotDetailQuickActionChip(
+                      icon: Icons.edit_note_outlined,
+                      iconColor: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.75),
+                      label: l10n.eventDetailQuickActionSuggestEdit,
                     ),
                   ),
                 ),
@@ -1297,6 +1431,512 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
   }
 }
 
+class _SuggestEventPhotoDialog extends StatefulWidget {
+  const _SuggestEventPhotoDialog({required this.event});
+
+  final ParkourEvent event;
+
+  @override
+  State<_SuggestEventPhotoDialog> createState() =>
+      _SuggestEventPhotoDialogState();
+}
+
+class _SuggestEventPhotoDialogState extends State<_SuggestEventPhotoDialog> {
+  final TextEditingController _emailController = TextEditingController();
+  final List<Uint8List> _selectedImageBytes = <Uint8List>[];
+  bool _submitting = false;
+  String? _error;
+
+  static final RegExp _emailRegex = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthService>();
+    _emailController.text = auth.currentUser?.email?.trim() ?? '';
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  bool _validEmail(String value) => _emailRegex.hasMatch(value);
+
+  Future<void> _pickImagesFromGallery() async {
+    try {
+      final picker = ImagePicker();
+      final pickedFiles = await picker.pickMultiImage(
+        maxWidth: 2048,
+        maxHeight: 2048,
+        imageQuality: 85,
+      );
+      if (pickedFiles.isEmpty || !mounted) return;
+
+      for (final pickedFile in pickedFiles) {
+        if (_selectedImageBytes.length >=
+            EventReportService.maxSuggestedPhotos) {
+          break;
+        }
+        final bytes = await pickedFile.readAsBytes();
+        final prepared = await prepareImageForUpload(bytes);
+        _selectedImageBytes.add(prepared.bytes);
+      }
+      if (mounted) setState(() {});
+    } on ImagePreparationException catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e.message);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = '$e');
+    }
+  }
+
+  Future<void> _takePhoto() async {
+    try {
+      if (_selectedImageBytes.length >= EventReportService.maxSuggestedPhotos) {
+        return;
+      }
+      final picker = ImagePicker();
+      final pickedFile = await picker.pickImage(
+        source: ImageSource.camera,
+        maxWidth: 2048,
+        maxHeight: 2048,
+        imageQuality: 85,
+      );
+      if (pickedFile == null || !mounted) return;
+      final bytes = await pickedFile.readAsBytes();
+      final prepared = await prepareImageForUpload(bytes);
+      setState(() => _selectedImageBytes.add(prepared.bytes));
+    } on ImagePreparationException catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e.message);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = '$e');
+    }
+  }
+
+  Future<void> _submit() async {
+    final l10n = AppLocalizations.of(context)!;
+    final email = _emailController.text.trim();
+    if (!_validEmail(email)) {
+      setState(() => _error = l10n.spotDetailEmailInvalid);
+      return;
+    }
+    if (_selectedImageBytes.isEmpty) {
+      setState(() => _error = l10n.eventDetailSuggestPhotosPickRequired);
+      return;
+    }
+
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+
+    try {
+      final eventService = context.read<EventReportService>();
+      final auth = context.read<AuthService>();
+      final uploadedUrls = await eventService.uploadSuggestedEventPhotos(
+        _selectedImageBytes,
+      );
+      final ok = await eventService.submitEventPhotoSuggestion(
+        targetEventId: widget.event.id!,
+        targetEventTitle: widget.event.title,
+        startAt: widget.event.startAt,
+        endAt: widget.event.endAt,
+        isDateOnly: widget.event.isDateOnly,
+        timeZone: widget.event.timeZone,
+        existingSpotIds: widget.event.spotIds,
+        existingSpotListIds: widget.event.spotListIds,
+        suggestedPhotoUrls: uploadedUrls,
+        reporterUserId: auth.currentUser?.uid,
+        reporterName:
+            auth.userProfile?.displayName ??
+            auth.currentUser?.displayName ??
+            auth.currentUser?.email,
+        reporterEmail: email,
+      );
+
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _error = l10n.eventDetailSuggestPhotosSubmitFailed);
+        return;
+      }
+      Navigator.of(context).pop(true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = l10n.eventDetailSuggestPhotosSubmitError('$e'));
+    } finally {
+      if (mounted) {
+        setState(() => _submitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(l10n.eventDetailSuggestPhotosTitle),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(l10n.eventDetailSuggestPhotosIntro),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                enabled: !_submitting,
+                decoration: InputDecoration(
+                  labelText: l10n.spotDetailReportEmailLabel,
+                  helperText: l10n.spotDetailSuggestPhotosEmailHelper,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              if (_selectedImageBytes.isNotEmpty)
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: List.generate(_selectedImageBytes.length, (index) {
+                    final bytes = _selectedImageBytes[index];
+                    return Stack(
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Image.memory(
+                            bytes,
+                            width: 96,
+                            height: 96,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                        Positioned(
+                          top: 4,
+                          right: 4,
+                          child: Material(
+                            color: Colors.black.withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(16),
+                            child: InkWell(
+                              onTap: _submitting
+                                  ? null
+                                  : () => setState(
+                                      () => _selectedImageBytes.removeAt(index),
+                                    ),
+                              borderRadius: BorderRadius.circular(16),
+                              child: const Padding(
+                                padding: EdgeInsets.all(2),
+                                child: Icon(
+                                  Icons.close,
+                                  color: Colors.white,
+                                  size: 16,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  }),
+                ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _submitting ? null : _pickImagesFromGallery,
+                      icon: const Icon(Icons.photo_library_outlined),
+                      label: Text(l10n.addSpotGalleryButton),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _submitting ? null : _takePhoto,
+                      icon: const Icon(Icons.photo_camera_outlined),
+                      label: Text(l10n.addSpotCameraButton),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                l10n.addEventMaxPhotos(EventReportService.maxSuggestedPhotos),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 10),
+                Text(
+                  _error!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting
+              ? null
+              : () => Navigator.of(context).pop(false),
+          child: Text(l10n.profileCancel),
+        ),
+        FilledButton(
+          onPressed: _submitting ? null : _submit,
+          child: _submitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(l10n.spotDetailSubmit),
+        ),
+      ],
+    );
+  }
+}
+
+class _SuggestEventEditDialog extends StatefulWidget {
+  const _SuggestEventEditDialog({required this.event});
+
+  final ParkourEvent event;
+
+  @override
+  State<_SuggestEventEditDialog> createState() =>
+      _SuggestEventEditDialogState();
+}
+
+class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
+  final TextEditingController _emailController = TextEditingController();
+  late final TextEditingController _titleController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _websiteController;
+  bool _submitting = false;
+  String? _error;
+
+  static final RegExp _emailRegex = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthService>();
+    _emailController.text = auth.currentUser?.email?.trim() ?? '';
+    _titleController = TextEditingController(text: widget.event.title.trim());
+    _descriptionController = TextEditingController(
+      text: widget.event.description?.trim() ?? '',
+    );
+    _websiteController = TextEditingController(
+      text: widget.event.websiteUrl?.trim() ?? '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _titleController.dispose();
+    _descriptionController.dispose();
+    _websiteController.dispose();
+    super.dispose();
+  }
+
+  bool _validEmail(String value) => _emailRegex.hasMatch(value);
+
+  bool _validWebsite(String value) {
+    final parsed = Uri.tryParse(value);
+    return parsed != null &&
+        parsed.hasAuthority &&
+        (parsed.scheme == 'http' || parsed.scheme == 'https');
+  }
+
+  Future<void> _submit() async {
+    final l10n = AppLocalizations.of(context)!;
+    final email = _emailController.text.trim();
+    if (!_validEmail(email)) {
+      setState(() => _error = l10n.spotDetailEmailInvalid);
+      return;
+    }
+
+    final title = _titleController.text.trim();
+    if (title.isEmpty) {
+      setState(() => _error = l10n.addEventTitleRequired);
+      return;
+    }
+    final description = _descriptionController.text.trim();
+    final website = _websiteController.text.trim();
+    if (website.isNotEmpty && !_validWebsite(website)) {
+      setState(() => _error = l10n.addEventWebsiteInvalid);
+      return;
+    }
+
+    final originalTitle = widget.event.title.trim();
+    final originalDescription = widget.event.description?.trim() ?? '';
+    final originalWebsite = widget.event.websiteUrl?.trim() ?? '';
+
+    final suggestedTitle = title != originalTitle ? title : null;
+    final suggestedDescription =
+        description.isNotEmpty && description != originalDescription
+        ? description
+        : null;
+    final suggestedWebsiteUrl = website.isNotEmpty && website != originalWebsite
+        ? website
+        : null;
+
+    if (suggestedTitle == null &&
+        suggestedDescription == null &&
+        suggestedWebsiteUrl == null) {
+      setState(() => _error = l10n.eventDetailSuggestEditNoChanges);
+      return;
+    }
+
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+
+    try {
+      final auth = context.read<AuthService>();
+      final ok = await context
+          .read<EventReportService>()
+          .submitEventEditSuggestion(
+            targetEventId: widget.event.id!,
+            targetEventTitle: widget.event.title,
+            startAt: widget.event.startAt,
+            endAt: widget.event.endAt,
+            isDateOnly: widget.event.isDateOnly,
+            timeZone: widget.event.timeZone,
+            existingSpotIds: widget.event.spotIds,
+            existingSpotListIds: widget.event.spotListIds,
+            suggestedTitle: suggestedTitle,
+            suggestedDescription: suggestedDescription,
+            suggestedWebsiteUrl: suggestedWebsiteUrl,
+            reporterUserId: auth.currentUser?.uid,
+            reporterName:
+                auth.userProfile?.displayName ??
+                auth.currentUser?.displayName ??
+                auth.currentUser?.email,
+            reporterEmail: email,
+          );
+
+      if (!mounted) return;
+      if (!ok) {
+        setState(() => _error = l10n.eventDetailSuggestEditSubmitFailed);
+        return;
+      }
+      Navigator.of(context).pop(true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = l10n.eventDetailSuggestEditSubmitError('$e'));
+    } finally {
+      if (mounted) {
+        setState(() => _submitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(l10n.eventDetailSuggestEditTitle),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(l10n.eventDetailSuggestEditIntro),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                enabled: !_submitting,
+                decoration: InputDecoration(
+                  labelText: l10n.spotDetailReportEmailLabel,
+                  helperText: l10n.spotDetailSuggestEditEmailHelper,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _titleController,
+                enabled: !_submitting,
+                textCapitalization: TextCapitalization.words,
+                decoration: InputDecoration(
+                  labelText: l10n.addEventTitleLabel,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 10),
+              TextField(
+                controller: _descriptionController,
+                enabled: !_submitting,
+                maxLines: 4,
+                textCapitalization: TextCapitalization.sentences,
+                decoration: InputDecoration(
+                  labelText: l10n.addEventDescriptionLabel,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 10),
+              TextField(
+                controller: _websiteController,
+                enabled: !_submitting,
+                keyboardType: TextInputType.url,
+                decoration: InputDecoration(
+                  labelText: l10n.addEventWebsiteLabel,
+                  hintText: l10n.addEventWebsiteHint,
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 10),
+                Text(
+                  _error!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting
+              ? null
+              : () => Navigator.of(context).pop(false),
+          child: Text(l10n.profileCancel),
+        ),
+        FilledButton(
+          onPressed: _submitting ? null : _submit,
+          child: _submitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(l10n.spotDetailSubmit),
+        ),
+      ],
+    );
+  }
+}
+
 enum _EventStaffAction {
   editEvent,
   createNativeEvent,
@@ -1770,8 +2410,7 @@ class _EventLinkedSpotCard extends StatelessWidget {
                   label: Text(l10n.eventDetailEventSpotViewDetails),
                 ),
                 OutlinedButton.icon(
-                  onPressed: () =>
-                      context.go('/explore?locateSpotId=$spotId'),
+                  onPressed: () => context.go('/explore?locateSpotId=$spotId'),
                   icon: const Icon(Icons.map_outlined, size: 18),
                   label: Text(l10n.eventDetailEventSpotListSeeOnMap),
                 ),

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/screens/moderator/event_report_queue_screen.dart
+++ b/lib/screens/moderator/event_report_queue_screen.dart
@@ -287,9 +287,11 @@ class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
       ),
     );
     if (rejected != true) return;
+    if (!mounted) return;
 
     setState(() => _busyReportIds.add(report.id));
     final auth = context.read<AuthService>();
+    final eventReportService = context.read<EventReportService>();
     final user = auth.currentUser;
     final reviewerUserId = user?.uid;
     if (reviewerUserId == null) {
@@ -297,7 +299,7 @@ class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
       return;
     }
 
-    final ok = await context.read<EventReportService>().rejectReport(
+    final ok = await eventReportService.rejectReport(
       reportId: report.id,
       reviewerUserId: reviewerUserId,
       reviewerName:

--- a/lib/screens/moderator/event_report_queue_screen.dart
+++ b/lib/screens/moderator/event_report_queue_screen.dart
@@ -44,7 +44,7 @@ class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Review user-submitted event proposals and decide whether to publish them.',
+            'Review user-submitted event proposals and suggestions.',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
             ),
@@ -251,6 +251,8 @@ class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
         content: Text(
           eventId == null
               ? 'Could not approve this event report.'
+              : report.isSuggestionForExistingEvent
+              ? 'Approved and applied to event $eventId.'
               : 'Approved and published as event $eventId.',
         ),
       ),
@@ -363,6 +365,8 @@ class _EventReportCard extends StatelessWidget {
     final theme = Theme.of(context);
     final color = _statusColor(theme);
     final canReview = report.status == 'New' || report.status == 'Reviewing';
+    final isSuggestion = report.isSuggestionForExistingEvent;
+    final hasSuggestedEdits = report.hasSuggestedEdits;
     return Card(
       margin: EdgeInsets.zero,
       shape: RoundedRectangleBorder(
@@ -375,6 +379,16 @@ class _EventReportCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(report.title, style: theme.textTheme.titleMedium),
+            if (isSuggestion) ...[
+              const SizedBox(height: 4),
+              Text(
+                'Suggestion for event: ${report.targetEventTitle?.trim().isNotEmpty == true ? report.targetEventTitle!.trim() : report.targetEventId!}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
             const SizedBox(height: 8),
             Wrap(
               spacing: 12,
@@ -420,6 +434,16 @@ class _EventReportCard extends StatelessWidget {
                     icon: Icons.map_outlined,
                     label: report.locationSummary!,
                   ),
+                if (isSuggestion)
+                  _metaChip(
+                    context,
+                    icon: hasSuggestedEdits
+                        ? Icons.edit_note_outlined
+                        : Icons.add_photo_alternate_outlined,
+                    label: hasSuggestedEdits
+                        ? 'Edit suggestion'
+                        : 'Photo suggestion',
+                  ),
               ],
             ),
             if (report.description?.isNotEmpty ?? false) ...[
@@ -434,6 +458,26 @@ class _EventReportCard extends StatelessWidget {
                   color: theme.colorScheme.primary,
                 ),
               ),
+            ],
+            if (hasSuggestedEdits) ...[
+              const SizedBox(height: 12),
+              Text(
+                'Suggested edits',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: theme.colorScheme.secondary,
+                ),
+              ),
+              const SizedBox(height: 8),
+              if (report.suggestedTitle?.isNotEmpty ?? false)
+                Text('Title: ${report.suggestedTitle!}'),
+              if (report.suggestedDescription?.isNotEmpty ?? false) ...[
+                const SizedBox(height: 4),
+                Text('Description: ${report.suggestedDescription!}'),
+              ],
+              if (report.suggestedWebsiteUrl?.isNotEmpty ?? false) ...[
+                const SizedBox(height: 4),
+                Text('Website: ${report.suggestedWebsiteUrl!}'),
+              ],
             ],
             if (report.suggestedPhotoUrls.isNotEmpty) ...[
               const SizedBox(height: 12),
@@ -460,9 +504,10 @@ class _EventReportCard extends StatelessWidget {
                       child: Image.network(
                         photoUrl,
                         fit: BoxFit.cover,
-                        errorBuilder: (context, error, stackTrace) => const Center(
-                          child: Icon(Icons.broken_image_outlined),
-                        ),
+                        errorBuilder: (context, error, stackTrace) =>
+                            const Center(
+                              child: Icon(Icons.broken_image_outlined),
+                            ),
                       ),
                     ),
                   );
@@ -500,7 +545,11 @@ class _EventReportCard extends StatelessWidget {
                       child: FilledButton.icon(
                         onPressed: onApprove,
                         icon: const Icon(Icons.check_circle_outline),
-                        label: const Text('Approve & publish'),
+                        label: Text(
+                          isSuggestion
+                              ? 'Approve suggestion'
+                              : 'Approve & publish',
+                        ),
                       ),
                     ),
                     const SizedBox(width: 8),
@@ -518,7 +567,11 @@ class _EventReportCard extends StatelessWidget {
                   onPressed: () =>
                       context.push('/event/${report.approvedEventId}'),
                   icon: const Icon(Icons.open_in_new),
-                  label: const Text('Open published event'),
+                  label: Text(
+                    isSuggestion
+                        ? 'Open updated event'
+                        : 'Open published event',
+                  ),
                 ),
               ] else if (report.status == 'Rejected') ...[
                 OutlinedButton.icon(

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -7,11 +7,9 @@ import '../models/event_report.dart';
 import '../utils/image_preparation.dart';
 
 class EventReportService {
-  EventReportService({
-    FirebaseFirestore? firestore,
-    FirebaseStorage? storage,
-  })  : _firestore = firestore ?? FirebaseFirestore.instance,
-        _storage = storage ?? FirebaseStorage.instance;
+  EventReportService({FirebaseFirestore? firestore, FirebaseStorage? storage})
+    : _firestore = firestore ?? FirebaseFirestore.instance,
+      _storage = storage ?? FirebaseStorage.instance;
 
   final FirebaseFirestore _firestore;
   final FirebaseStorage _storage;
@@ -72,9 +70,14 @@ class EventReportService {
     List<String> spotListIds = const <String>[],
     String? linkedSpotName,
     String? linkedSpotListName,
+    String? targetEventId,
+    String? targetEventTitle,
     String? reporterUserId,
     String? reporterName,
     String? reporterEmail,
+    String? suggestedTitle,
+    String? suggestedDescription,
+    String? suggestedWebsiteUrl,
     List<String> suggestedPhotoUrls = const <String>[],
   }) async {
     final trimmedTitle = title.trim();
@@ -96,6 +99,11 @@ class EventReportService {
         .where((url) => url.isNotEmpty)
         .take(maxSuggestedPhotos)
         .toList(growable: false);
+    final normalizedTargetEventId = targetEventId?.trim();
+    final normalizedTargetEventTitle = targetEventTitle?.trim();
+    final normalizedSuggestedTitle = suggestedTitle?.trim();
+    final normalizedSuggestedDescription = suggestedDescription?.trim();
+    final normalizedSuggestedWebsiteUrl = suggestedWebsiteUrl?.trim();
 
     try {
       await _firestore.collection('eventReports').add({
@@ -124,12 +132,27 @@ class EventReportService {
           'linkedSpotName': linkedSpotName.trim(),
         if (linkedSpotListName != null && linkedSpotListName.trim().isNotEmpty)
           'linkedSpotListName': linkedSpotListName.trim(),
+        if (normalizedTargetEventId != null &&
+            normalizedTargetEventId.isNotEmpty)
+          'targetEventId': normalizedTargetEventId,
+        if (normalizedTargetEventTitle != null &&
+            normalizedTargetEventTitle.isNotEmpty)
+          'targetEventTitle': normalizedTargetEventTitle,
         if (reporterUserId != null && reporterUserId.isNotEmpty)
           'reporterUserId': reporterUserId,
         if (reporterName != null && reporterName.trim().isNotEmpty)
           'reporterName': reporterName.trim(),
         if (reporterEmail != null && reporterEmail.trim().isNotEmpty)
           'reporterEmail': reporterEmail.trim(),
+        if (normalizedSuggestedTitle != null &&
+            normalizedSuggestedTitle.isNotEmpty)
+          'suggestedTitle': normalizedSuggestedTitle,
+        if (normalizedSuggestedDescription != null &&
+            normalizedSuggestedDescription.isNotEmpty)
+          'suggestedDescription': normalizedSuggestedDescription,
+        if (normalizedSuggestedWebsiteUrl != null &&
+            normalizedSuggestedWebsiteUrl.isNotEmpty)
+          'suggestedWebsiteUrl': normalizedSuggestedWebsiteUrl,
         if (normalizedPhotoUrls.isNotEmpty)
           'suggestedPhotoUrls': normalizedPhotoUrls,
         'status': statuses.first,
@@ -141,6 +164,72 @@ class EventReportService {
       debugPrint('Error submitting event report: $e');
       return false;
     }
+  }
+
+  Future<bool> submitEventPhotoSuggestion({
+    required String targetEventId,
+    required String targetEventTitle,
+    required DateTime startAt,
+    DateTime? endAt,
+    bool isDateOnly = false,
+    String? timeZone,
+    List<String> existingSpotIds = const <String>[],
+    List<String> existingSpotListIds = const <String>[],
+    List<String> suggestedPhotoUrls = const <String>[],
+    String? reporterUserId,
+    String? reporterName,
+    String? reporterEmail,
+  }) async {
+    return submitEventReport(
+      title: targetEventTitle,
+      startAt: startAt,
+      endAt: endAt,
+      isDateOnly: isDateOnly,
+      timeZone: timeZone,
+      spotIds: existingSpotIds,
+      spotListIds: existingSpotListIds,
+      targetEventId: targetEventId,
+      targetEventTitle: targetEventTitle,
+      reporterUserId: reporterUserId,
+      reporterName: reporterName,
+      reporterEmail: reporterEmail,
+      suggestedPhotoUrls: suggestedPhotoUrls,
+    );
+  }
+
+  Future<bool> submitEventEditSuggestion({
+    required String targetEventId,
+    required String targetEventTitle,
+    required DateTime startAt,
+    DateTime? endAt,
+    bool isDateOnly = false,
+    String? timeZone,
+    List<String> existingSpotIds = const <String>[],
+    List<String> existingSpotListIds = const <String>[],
+    String? suggestedTitle,
+    String? suggestedDescription,
+    String? suggestedWebsiteUrl,
+    String? reporterUserId,
+    String? reporterName,
+    String? reporterEmail,
+  }) async {
+    return submitEventReport(
+      title: targetEventTitle,
+      startAt: startAt,
+      endAt: endAt,
+      isDateOnly: isDateOnly,
+      timeZone: timeZone,
+      spotIds: existingSpotIds,
+      spotListIds: existingSpotListIds,
+      targetEventId: targetEventId,
+      targetEventTitle: targetEventTitle,
+      reporterUserId: reporterUserId,
+      reporterName: reporterName,
+      reporterEmail: reporterEmail,
+      suggestedTitle: suggestedTitle,
+      suggestedDescription: suggestedDescription,
+      suggestedWebsiteUrl: suggestedWebsiteUrl,
+    );
   }
 
   Future<bool> updateReportStatus({
@@ -211,6 +300,47 @@ class EventReportService {
           return txReport.approvedEventId;
         }
 
+        final txTargetEventId = txReport.targetEventId?.trim();
+        final txIsSuggestionForExistingEvent =
+            txTargetEventId != null && txTargetEventId.isNotEmpty;
+
+        if (txIsSuggestionForExistingEvent) {
+          final eventRef = _firestore.collection('events').doc(txTargetEventId);
+          final eventSnapshot = await transaction.get(eventRef);
+          if (!eventSnapshot.exists || eventSnapshot.data() == null) {
+            throw StateError('Target event not found');
+          }
+
+          final updates = _buildExistingEventSuggestionUpdate(
+            report: txReport,
+            existingEventData: eventSnapshot.data()!,
+            promotedImageUrls: promotedImageUrls,
+          );
+          if (updates == null) {
+            throw StateError('Invalid existing event suggestion payload');
+          }
+
+          if (updates.isNotEmpty) {
+            updates['updatedAt'] = FieldValue.serverTimestamp();
+            transaction.update(eventRef, updates);
+          }
+
+          transaction.update(reportRef, {
+            'status': 'Approved',
+            'approvedEventId': txTargetEventId,
+            'reviewedBy': approverUserId,
+            if (approverName != null && approverName.trim().isNotEmpty)
+              'reviewedByName': approverName.trim(),
+            if (moderatorNotes != null && moderatorNotes.trim().isNotEmpty)
+              'moderatorNotes': moderatorNotes.trim(),
+            if (promotedImageUrls != null && promotedImageUrls.isNotEmpty)
+              'suggestedPhotoUrls': <String>[],
+            'reviewedAt': FieldValue.serverTimestamp(),
+            'updatedAt': FieldValue.serverTimestamp(),
+          });
+          return txTargetEventId;
+        }
+
         final eventData = _buildEventData(
           report: txReport,
           approverUserId: approverUserId,
@@ -260,7 +390,9 @@ class EventReportService {
       final report = EventReport.fromSnapshot(snapshot);
       var rejectedUrls = const <String>[];
       if (report.suggestedPhotoUrls.isNotEmpty) {
-        rejectedUrls = await _moveEventPhotosToRejected(report.suggestedPhotoUrls);
+        rejectedUrls = await _moveEventPhotosToRejected(
+          report.suggestedPhotoUrls,
+        );
       }
 
       await reportRef.update({
@@ -329,7 +461,9 @@ class EventReportService {
 
         final response = await http.get(Uri.parse(photoUrl));
         if (response.statusCode != 200 || response.bodyBytes.isEmpty) {
-          debugPrint('Failed to fetch event suggestion photo: ${response.statusCode}');
+          debugPrint(
+            'Failed to fetch event suggestion photo: ${response.statusCode}',
+          );
           continue;
         }
 
@@ -359,7 +493,55 @@ class EventReportService {
     return finalPhotoUrls;
   }
 
-  Future<List<String>> _moveEventPhotosToRejected(List<String> photoUrls) async {
+  Map<String, dynamic>? _buildExistingEventSuggestionUpdate({
+    required EventReport report,
+    required Map<String, dynamic> existingEventData,
+    List<String>? promotedImageUrls,
+  }) {
+    final updates = <String, dynamic>{};
+
+    final suggestedTitle = report.suggestedTitle?.trim();
+    if (suggestedTitle != null && suggestedTitle.isNotEmpty) {
+      updates['title'] = suggestedTitle;
+    }
+
+    final suggestedDescription = report.suggestedDescription?.trim();
+    if (suggestedDescription != null && suggestedDescription.isNotEmpty) {
+      updates['description'] = suggestedDescription;
+    }
+
+    final suggestedWebsiteUrl = report.suggestedWebsiteUrl?.trim();
+    if (suggestedWebsiteUrl != null && suggestedWebsiteUrl.isNotEmpty) {
+      updates['websiteUrl'] = suggestedWebsiteUrl;
+    }
+
+    if (promotedImageUrls != null && promotedImageUrls.isNotEmpty) {
+      final existingImageUrls = (existingEventData['imageUrls'] is Iterable)
+          ? (existingEventData['imageUrls'] as Iterable)
+                .whereType<String>()
+                .where((url) => url.trim().isNotEmpty)
+                .toList(growable: true)
+          : <String>[];
+      for (final url in promotedImageUrls) {
+        if (!existingImageUrls.contains(url)) {
+          existingImageUrls.add(url);
+        }
+      }
+      if (existingImageUrls.length > maxSuggestedPhotos) {
+        debugPrint(
+          'Existing event already has too many photos (${existingImageUrls.length})',
+        );
+        return null;
+      }
+      updates['imageUrls'] = existingImageUrls;
+    }
+
+    return updates;
+  }
+
+  Future<List<String>> _moveEventPhotosToRejected(
+    List<String> photoUrls,
+  ) async {
     final rejectedUrls = <String>[];
 
     for (final photoUrl in photoUrls) {
@@ -397,7 +579,10 @@ class EventReportService {
     return rejectedUrls;
   }
 
-  String? _storagePathFromUrl(String photoUrl, {required String expectedPrefix}) {
+  String? _storagePathFromUrl(
+    String photoUrl, {
+    required String expectedPrefix,
+  }) {
     try {
       final uri = Uri.parse(photoUrl);
       String? filePath;

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -536,6 +536,28 @@ class EventReportService {
       updates['imageUrls'] = existingImageUrls;
     }
 
+    final reporterUserId = report.reporterUserId?.trim();
+    final reporterUserName = report.reporterName?.trim();
+    if (reporterUserId != null &&
+        reporterUserId.isNotEmpty &&
+        reporterUserName != null &&
+        reporterUserName.isNotEmpty) {
+      final contributors = (existingEventData['contributors'] is Iterable)
+          ? (existingEventData['contributors'] as Iterable)
+                .whereType<Map>()
+                .map((e) => Map<String, String>.from(e))
+                .toList(growable: true)
+          : <Map<String, String>>[];
+      final exists = contributors.any((c) => c['userId'] == reporterUserId);
+      if (!exists) {
+        contributors.add(<String, String>{
+          'userId': reporterUserId,
+          'userName': reporterUserName,
+        });
+      }
+      updates['contributors'] = contributors;
+    }
+
     return updates;
   }
 

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -538,10 +538,7 @@ class EventReportService {
 
     final reporterUserId = report.reporterUserId?.trim();
     final reporterUserName = report.reporterName?.trim();
-    if (reporterUserId != null &&
-        reporterUserId.isNotEmpty &&
-        reporterUserName != null &&
-        reporterUserName.isNotEmpty) {
+    if (reporterUserId != null && reporterUserId.isNotEmpty) {
       final contributors = (existingEventData['contributors'] is Iterable)
           ? (existingEventData['contributors'] as Iterable)
                 .whereType<Map>()
@@ -550,9 +547,13 @@ class EventReportService {
           : <Map<String, String>>[];
       final exists = contributors.any((c) => c['userId'] == reporterUserId);
       if (!exists) {
+        final contributorName =
+            (reporterUserName != null && reporterUserName.isNotEmpty)
+            ? reporterUserName
+            : reporterUserId;
         contributors.add(<String, String>{
           'userId': reporterUserId,
-          'userName': reporterUserName,
+          'userName': contributorName,
         });
       }
       updates['contributors'] = contributors;

--- a/lib/widgets/event_detail_provenance_line.dart
+++ b/lib/widgets/event_detail_provenance_line.dart
@@ -60,15 +60,14 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
     }
     setState(() => _loadingCreator = true);
     try {
-      final profile = await context
-          .read<UserProfileService>()
-          .getUserProfile(createdBy);
+      final profile = await context.read<UserProfileService>().getUserProfile(
+        createdBy,
+      );
       if (!mounted) return;
       final displayName = profile?.displayName?.trim();
       final username = profile?.username?.trim();
       setState(() {
-        _creatorDisplayName =
-            (displayName != null && displayName.isNotEmpty)
+        _creatorDisplayName = (displayName != null && displayName.isNotEmpty)
             ? displayName
             : (username != null && username.isNotEmpty)
             ? username
@@ -114,6 +113,7 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
         !_event.createdFromCreateNative &&
         createdBy != null &&
         createdBy.isNotEmpty;
+    final hasContributors = _event.contributors.isNotEmpty;
     final hasSource =
         !_event.isNativeEvent &&
         ((_event.eventSourceId?.trim().isNotEmpty ?? false) ||
@@ -123,10 +123,19 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
         _event.updatedAt != null &&
         (_event.createdAt == null || _event.updatedAt != _event.createdAt);
     return hasCreator ||
+        hasContributors ||
         hasSource ||
         hasCreatedDate ||
         hasUpdatedDate ||
         _loadingCreator;
+  }
+
+  String _trimLeadingContributorPrefix(String value) {
+    final trimmed = value.trimLeft();
+    if (trimmed.startsWith(',')) {
+      return trimmed.substring(1).trimLeft();
+    }
+    return trimmed;
   }
 
   @override
@@ -154,7 +163,9 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
             : SpotDetailUi.detailSectionGap,
       ),
       child: widget.footerStyle
-          ? RichText(text: TextSpan(style: textStyle, children: spans))
+          ? RichText(
+              text: TextSpan(style: textStyle, children: spans),
+            )
           : Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -186,6 +197,9 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
     final spans = <TextSpan>[];
     var hasPreviousContent = false;
     final createdById = _event.createdBy?.trim();
+    final willHaveUpdatedDate =
+        _event.updatedAt != null &&
+        (_event.createdAt == null || _event.updatedAt != _event.createdAt);
 
     if (_event.isNativeEvent &&
         !_event.createdFromCreateNative &&
@@ -226,10 +240,7 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
 
       hasPreviousContent = true;
     } else if (_event.isNativeEvent && _event.createdAt != null) {
-      final createdDateText = formatRelativeDateInDays(
-        _event.createdAt!,
-        l10n,
-      );
+      final createdDateText = formatRelativeDateInDays(_event.createdAt!, l10n);
       spans.add(
         TextSpan(
           text: l10n.eventDetailEventCreatedOnDate(createdDateText),
@@ -243,8 +254,7 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
       final sourceName =
           _event.eventSourceName?.trim() ?? l10n.spotDetailUnknownSource;
       final sourceId = _event.eventSourceId?.trim();
-      final canOpenSourceDetails =
-          sourceId != null && sourceId.isNotEmpty;
+      final canOpenSourceDetails = sourceId != null && sourceId.isNotEmpty;
 
       if (hasPreviousContent) {
         spans.add(TextSpan(text: ' / ', style: textStyle));
@@ -278,6 +288,54 @@ class _EventDetailProvenanceLineState extends State<EventDetailProvenanceLine> {
               : null,
         ),
       );
+      hasPreviousContent = true;
+    }
+
+    final filteredContributors = _event.contributors.where((c) {
+      final userId = c['userId']?.trim();
+      return userId == null || userId != createdById;
+    }).toList();
+    if (filteredContributors.isNotEmpty) {
+      final improvedByPrefix = hasPreviousContent
+          ? (willHaveUpdatedDate
+                ? l10n.spotDetailImprovedByAfterComma
+                : l10n.spotDetailImprovedByAfterAnd)
+          : _trimLeadingContributorPrefix(l10n.spotDetailImprovedByAfterComma);
+      spans.add(TextSpan(text: improvedByPrefix, style: textStyle));
+
+      for (var i = 0; i < filteredContributors.length; i++) {
+        final contributor = filteredContributors[i];
+        final userName = contributor['userName']?.trim();
+        final userId = contributor['userId']?.trim();
+        final label = userName != null && userName.isNotEmpty
+            ? userName
+            : l10n.spotDetailUnknownUser;
+
+        if (i > 0) {
+          spans.add(
+            TextSpan(
+              text: i == filteredContributors.length - 1
+                  ? l10n.spotDetailListJoinAnd
+                  : l10n.spotDetailListJoinComma,
+              style: textStyle,
+            ),
+          );
+        }
+
+        if (userId != null && userId.isNotEmpty) {
+          spans.add(
+            TextSpan(
+              text: label,
+              style: textStyle?.copyWith(color: theme.colorScheme.primary),
+              recognizer: TapGestureRecognizer()
+                ..onTap = () => _navigateToUserProfile(userId),
+            ),
+          );
+        } else {
+          spans.add(TextSpan(text: label, style: textStyle));
+        }
+      }
+
       hasPreviousContent = true;
     }
 

--- a/storage.rules
+++ b/storage.rules
@@ -52,7 +52,10 @@ service firebase.storage {
     // Staging for user-submitted event photos (moderated before publish)
     match /eventSuggestions/{allPaths=**} {
       allow read: if true;
-      allow write: if request.auth != null;
+      allow write: if request.auth != null
+        || (request.resource.size > 0
+            && request.resource.size < 10 * 1024 * 1024
+            && request.resource.contentType.matches('image/.*'));
     }
 
     // Rejected event photo suggestions

--- a/test/models/parkour_event_test.dart
+++ b/test/models/parkour_event_test.dart
@@ -28,6 +28,9 @@ void main() {
         'createdBy': 'admin-uid',
         'createdAt': Timestamp.fromDate(createdAt),
         'updatedAt': Timestamp.fromDate(updatedAt),
+        'contributors': [
+          {'userId': 'user-1', 'userName': 'Alice'},
+        ],
       });
 
       expect(event.id, 'event-1');
@@ -50,6 +53,9 @@ void main() {
       expect(event.createdBy, 'admin-uid');
       expect(event.createdAt?.toUtc(), createdAt);
       expect(event.updatedAt?.toUtc(), updatedAt);
+      expect(event.contributors, [
+        {'userId': 'user-1', 'userName': 'Alice'},
+      ]);
       expect(event.duplicateOf, isNull);
       expect(event.isNativeEvent, isTrue);
     });
@@ -140,6 +146,20 @@ void main() {
       final map = event.toFirestore();
       expect(map['isDateOnly'], isTrue);
       expect(map['timeZone'], 'Europe/Paris');
+    });
+
+    test('toFirestore includes contributors when present', () {
+      final event = ParkourEvent(
+        title: 'Contributed event',
+        startAt: DateTime.utc(2026, 7, 10, 12, 0),
+        contributors: const [
+          {'userId': 'user-2', 'userName': 'Bob'},
+        ],
+      );
+      final map = event.toFirestore();
+      expect(map['contributors'], [
+        {'userId': 'user-2', 'userName': 'Bob'},
+      ]);
     });
 
     test('fromMap parses createdFromCreateNative', () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `Suggest photo` and `Suggest an edit` quick actions on event detail pages for guests and logged-in users
- add event suggestion dialogs that submit moderation reports (with reporter email, edited event fields, and optional suggested photos)
- extend `eventReports` model/service so reports can target an existing event (`targetEventId`) with `suggestedTitle`/`suggestedDescription`/`suggestedWebsiteUrl`
- update moderation approval flow to apply approved suggestions directly onto the target event (including promoted suggested photos)
- attribute approved event edit suggestions to the suggester by appending them to event `contributors` (not the approving moderator)
- render event contributors in event provenance as “improved by …”, mirroring spots
- update moderator Event Report Queue copy/actions to distinguish proposal vs suggestion and show suggested edit/photo context
- allow guest event suggestion submissions in security rules (`eventReports` create and `eventSuggestions/` storage write)

## Testing
- `flutter analyze lib/services/event_report_service.dart lib/widgets/event_detail_provenance_line.dart lib/models/parkour_event.dart`
- `flutter test test/models/parkour_event_test.dart`
- manual web verification in emulator: logged-in user submits event edit suggestion, moderator approves, event provenance shows suggester in `improved by` (not moderator)
- emulator document verification: `events/7HFSEcwf8m235zTVZ29W` contains contributor `{ userId: a7kzO7RNc28Trh4g0xDe1RYMHTfl, userName: Hank the User }`

## Walkthrough Artifacts
[event_suggestion_attribution_to_suggester_demo.mp4](https://cursor.com/agents/bc-e9858157-1d60-400a-bf55-9ee322f1d2f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_suggestion_attribution_to_suggester_demo.mp4)
[Moderator approving the attribution test suggestion](https://cursor.com/agents/bc-e9858157-1d60-400a-bf55-9ee322f1d2f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_queue_approve_suggestion.webp)
[Event provenance showing improved by suggester](https://cursor.com/agents/bc-e9858157-1d60-400a-bf55-9ee322f1d2f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_provenance_improved_by_suggester.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9858157-1d60-400a-bf55-9ee322f1d2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9858157-1d60-400a-bf55-9ee322f1d2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

