### PR TITLE
Add start/end datetime suggestions to event edit reports

### DIFF
--- a/lib/models/event_report.dart
+++ b/lib/models/event_report.dart
@@ -34,6 +34,8 @@ class EventReport {
     this.suggestedTitle,
     this.suggestedDescription,
     this.suggestedWebsiteUrl,
+    this.suggestedIsDateOnly,
+    this.suggestedTimeZone,
     this.suggestedStartAt,
     this.suggestedEndAt,
     this.suggestedPhotoUrls = const <String>[],
@@ -73,6 +75,8 @@ class EventReport {
   final String? suggestedTitle;
   final String? suggestedDescription;
   final String? suggestedWebsiteUrl;
+  final bool? suggestedIsDateOnly;
+  final String? suggestedTimeZone;
   final DateTime? suggestedStartAt;
   final DateTime? suggestedEndAt;
   final List<String> suggestedPhotoUrls;
@@ -143,6 +147,10 @@ class EventReport {
       suggestedTitle: data['suggestedTitle'] as String?,
       suggestedDescription: data['suggestedDescription'] as String?,
       suggestedWebsiteUrl: data['suggestedWebsiteUrl'] as String?,
+      suggestedIsDateOnly: data['suggestedIsDateOnly'] is bool
+          ? data['suggestedIsDateOnly'] as bool
+          : null,
+      suggestedTimeZone: data['suggestedTimeZone'] as String?,
       suggestedStartAt: parseDate(data['suggestedStartAt']),
       suggestedEndAt: parseDate(data['suggestedEndAt']),
       suggestedPhotoUrls: parseStringList(data['suggestedPhotoUrls']),
@@ -162,6 +170,8 @@ class EventReport {
     return (suggestedTitle?.trim().isNotEmpty ?? false) ||
         (suggestedDescription?.trim().isNotEmpty ?? false) ||
         (suggestedWebsiteUrl?.trim().isNotEmpty ?? false) ||
+        suggestedIsDateOnly != null ||
+        (suggestedTimeZone?.trim().isNotEmpty ?? false) ||
         suggestedStartAt != null ||
         suggestedEndAt != null;
   }

--- a/lib/models/event_report.dart
+++ b/lib/models/event_report.dart
@@ -34,6 +34,8 @@ class EventReport {
     this.suggestedTitle,
     this.suggestedDescription,
     this.suggestedWebsiteUrl,
+    this.suggestedStartAt,
+    this.suggestedEndAt,
     this.suggestedPhotoUrls = const <String>[],
     this.rejectedPhotoUrls = const <String>[],
     this.createdAt,
@@ -71,6 +73,8 @@ class EventReport {
   final String? suggestedTitle;
   final String? suggestedDescription;
   final String? suggestedWebsiteUrl;
+  final DateTime? suggestedStartAt;
+  final DateTime? suggestedEndAt;
   final List<String> suggestedPhotoUrls;
   final List<String> rejectedPhotoUrls;
   final DateTime? createdAt;
@@ -139,6 +143,8 @@ class EventReport {
       suggestedTitle: data['suggestedTitle'] as String?,
       suggestedDescription: data['suggestedDescription'] as String?,
       suggestedWebsiteUrl: data['suggestedWebsiteUrl'] as String?,
+      suggestedStartAt: parseDate(data['suggestedStartAt']),
+      suggestedEndAt: parseDate(data['suggestedEndAt']),
       suggestedPhotoUrls: parseStringList(data['suggestedPhotoUrls']),
       rejectedPhotoUrls: parseStringList(data['rejectedPhotoUrls']),
       createdAt: parseDate(data['createdAt']),
@@ -155,7 +161,9 @@ class EventReport {
   bool get hasSuggestedEdits {
     return (suggestedTitle?.trim().isNotEmpty ?? false) ||
         (suggestedDescription?.trim().isNotEmpty ?? false) ||
-        (suggestedWebsiteUrl?.trim().isNotEmpty ?? false);
+        (suggestedWebsiteUrl?.trim().isNotEmpty ?? false) ||
+        suggestedStartAt != null ||
+        suggestedEndAt != null;
   }
 
   String? get locationSummary {

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -20,6 +20,7 @@ import '../../services/spot_service.dart';
 import '../../services/search_state_service.dart';
 import '../../services/mobile_detection_service.dart';
 import '../../services/event_report_service.dart';
+import '../../utils/browser_timezone_utils.dart';
 import '../../utils/event_schedule_utils.dart';
 import '../../utils/event_suggestion_utils.dart';
 import '../../utils/marker_icon_utils.dart';
@@ -1819,6 +1820,12 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
   late final TextEditingController _titleController;
   late final TextEditingController _descriptionController;
   late final TextEditingController _websiteController;
+  late final List<String> _timeZoneOptions;
+  late final String _originalTimeZoneSelection;
+  String? _originalNormalizedTimeZone;
+  bool _timeZoneDirty = false;
+  late bool _suggestedIsDateOnly;
+  late String _selectedTimeZone;
   late DateTime _suggestedStartAt;
   DateTime? _suggestedEndAt;
   bool _submitting = false;
@@ -1839,6 +1846,17 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     _websiteController = TextEditingController(
       text: widget.event.websiteUrl?.trim() ?? '',
     );
+    _timeZoneOptions = EventScheduleUtils.availableTimeZoneIds();
+    _originalNormalizedTimeZone = EventScheduleUtils.normalizeTimeZone(
+      widget.event.timeZone,
+    );
+    _originalTimeZoneSelection =
+        _originalNormalizedTimeZone ?? detectIanaTimeZone();
+    _selectedTimeZone = _originalTimeZoneSelection;
+    if (!_timeZoneOptions.contains(_selectedTimeZone)) {
+      _timeZoneOptions.insert(0, _selectedTimeZone);
+    }
+    _suggestedIsDateOnly = widget.event.isDateOnly;
     _suggestedStartAt = widget.event.startAt;
     _suggestedEndAt = widget.event.endAt;
   }
@@ -1864,7 +1882,14 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
   DateTime _displayInEventTimeZone(DateTime value) {
     return EventScheduleUtils.toDisplayDateTime(
       value,
-      timeZone: widget.event.timeZone,
+      timeZone: _selectedTimeZone,
+    );
+  }
+
+  String _timeZoneLabel(String value) {
+    return EventScheduleUtils.formatTimeZoneLabel(
+      value,
+      referenceUtc: _suggestedStartAt,
     );
   }
 
@@ -1872,8 +1897,8 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     return EventScheduleUtils.formatSummaryLine(
       context,
       startAt: value,
-      isDateOnly: widget.event.isDateOnly,
-      timeZone: widget.event.timeZone,
+      isDateOnly: _suggestedIsDateOnly,
+      timeZone: _selectedTimeZone,
     );
   }
 
@@ -1901,12 +1926,12 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
         pickedTime.hour,
         pickedTime.minute,
       ),
-      timeZone: widget.event.timeZone,
+      timeZone: _selectedTimeZone,
     );
   }
 
   Future<void> _pickStartDateTime() async {
-    if (widget.event.isDateOnly) {
+    if (_suggestedIsDateOnly) {
       final initialDate = _displayInEventTimeZone(_suggestedStartAt);
       final pickedDate = await showDatePicker(
         context: context,
@@ -1921,7 +1946,7 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
       if (pickedDate == null || !mounted) return;
       final pickedStart = EventScheduleUtils.dateStartToUtc(
         pickedDate,
-        timeZone: widget.event.timeZone,
+        timeZone: _selectedTimeZone,
       );
       setState(() {
         _suggestedStartAt = pickedStart;
@@ -1945,7 +1970,7 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
   }
 
   Future<void> _pickEndDateTime() async {
-    if (widget.event.isDateOnly) {
+    if (_suggestedIsDateOnly) {
       final initialDate = _displayInEventTimeZone(
         _suggestedEndAt ?? _suggestedStartAt,
       );
@@ -1963,7 +1988,7 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
       setState(() {
         _suggestedEndAt = EventScheduleUtils.dateEndToUtc(
           pickedDate,
-          timeZone: widget.event.timeZone,
+          timeZone: _selectedTimeZone,
         );
         _error = null;
       });
@@ -2011,6 +2036,7 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     final originalTitle = widget.event.title.trim();
     final originalDescription = widget.event.description?.trim() ?? '';
     final originalWebsite = widget.event.websiteUrl?.trim() ?? '';
+    final originalTimeZone = _originalNormalizedTimeZone;
 
     final suggestedTitle = title != originalTitle ? title : null;
     final suggestedDescription =
@@ -2020,19 +2046,53 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     final suggestedWebsiteUrl = website.isNotEmpty && website != originalWebsite
         ? website
         : null;
+    final suggestedIsDateOnly = _suggestedIsDateOnly != widget.event.isDateOnly
+        ? _suggestedIsDateOnly
+        : null;
+    final suggestedTimeZone =
+        _timeZoneDirty && _selectedTimeZone != originalTimeZone
+        ? _selectedTimeZone
+        : null;
+
+    var normalizedSuggestedStartAt = _suggestedStartAt.toUtc();
+    var normalizedSuggestedEndAt = _suggestedEndAt?.toUtc();
+    final effectiveIsDateOnly = suggestedIsDateOnly ?? widget.event.isDateOnly;
+    final effectiveTimeZone =
+        suggestedTimeZone ?? originalTimeZone ?? _originalTimeZoneSelection;
+    if (effectiveIsDateOnly) {
+      final displayStart = EventScheduleUtils.toDisplayDateTime(
+        normalizedSuggestedStartAt,
+        timeZone: effectiveTimeZone,
+      );
+      normalizedSuggestedStartAt = EventScheduleUtils.dateStartToUtc(
+        displayStart,
+        timeZone: effectiveTimeZone,
+      );
+      if (normalizedSuggestedEndAt != null) {
+        final displayEnd = EventScheduleUtils.toDisplayDateTime(
+          normalizedSuggestedEndAt,
+          timeZone: effectiveTimeZone,
+        );
+        normalizedSuggestedEndAt = EventScheduleUtils.dateEndToUtc(
+          displayEnd,
+          timeZone: effectiveTimeZone,
+        );
+      }
+    }
+
     final suggestedStartAt =
-        !_suggestedStartAt.toUtc().isAtSameMomentAs(
+        !normalizedSuggestedStartAt.isAtSameMomentAs(
           widget.event.startAt.toUtc(),
         )
-        ? _suggestedStartAt.toUtc()
+        ? normalizedSuggestedStartAt
         : null;
     final suggestedEndAt =
-        (_suggestedEndAt != null &&
+        (normalizedSuggestedEndAt != null &&
             !(widget.event.endAt != null &&
-                _suggestedEndAt!.toUtc().isAtSameMomentAs(
+                normalizedSuggestedEndAt.isAtSameMomentAs(
                   widget.event.endAt!.toUtc(),
                 )))
-        ? _suggestedEndAt!.toUtc()
+        ? normalizedSuggestedEndAt
         : null;
 
     final effectiveStartAt = suggestedStartAt ?? widget.event.startAt.toUtc();
@@ -2045,6 +2105,8 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     if (suggestedTitle == null &&
         suggestedDescription == null &&
         suggestedWebsiteUrl == null &&
+        suggestedIsDateOnly == null &&
+        suggestedTimeZone == null &&
         suggestedStartAt == null &&
         suggestedEndAt == null) {
       setState(() => _error = l10n.eventDetailSuggestEditNoChanges);
@@ -2076,6 +2138,8 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
             suggestedTitle: suggestedTitle,
             suggestedDescription: suggestedDescription,
             suggestedWebsiteUrl: suggestedWebsiteUrl,
+            suggestedIsDateOnly: suggestedIsDateOnly,
+            suggestedTimeZone: suggestedTimeZone,
             suggestedStartAt: suggestedStartAt,
             suggestedEndAt: suggestedEndAt,
             reporterUserId: auth.currentUser?.uid,
@@ -2214,6 +2278,49 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
                   hintText: l10n.addEventWebsiteHint,
                   border: const OutlineInputBorder(),
                 ),
+              ),
+              const SizedBox(height: 10),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                value: _suggestedIsDateOnly,
+                title: Text(l10n.addEventAllDay),
+                onChanged: _submitting
+                    ? null
+                    : (value) {
+                        setState(() {
+                          _suggestedIsDateOnly = value;
+                          _error = null;
+                        });
+                      },
+              ),
+              const SizedBox(height: 8),
+              DropdownButtonFormField<String>(
+                initialValue: _selectedTimeZone,
+                decoration: InputDecoration(
+                  labelText: l10n.addEventTimezoneLabel,
+                  border: const OutlineInputBorder(),
+                ),
+                items: _timeZoneOptions
+                    .map(
+                      (value) => DropdownMenuItem<String>(
+                        value: value,
+                        child: Text(
+                          _timeZoneLabel(value),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    )
+                    .toList(),
+                onChanged: _submitting
+                    ? null
+                    : (value) {
+                        if (value == null) return;
+                        setState(() {
+                          _selectedTimeZone = value;
+                          _timeZoneDirty = true;
+                          _error = null;
+                        });
+                      },
               ),
               const SizedBox(height: 10),
               ListTile(

--- a/lib/screens/events/event_detail_screen.dart
+++ b/lib/screens/events/event_detail_screen.dart
@@ -20,6 +20,7 @@ import '../../services/spot_service.dart';
 import '../../services/search_state_service.dart';
 import '../../services/mobile_detection_service.dart';
 import '../../services/event_report_service.dart';
+import '../../utils/event_schedule_utils.dart';
 import '../../utils/event_suggestion_utils.dart';
 import '../../utils/marker_icon_utils.dart';
 import '../../utils/image_preparation.dart';
@@ -408,12 +409,14 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
     required bool isPhoto,
   }) {
     return switch (eventSuggestionBlockedReasonKey(event)) {
-      null => isPhoto
-          ? l10n.eventDetailMenuSuggestPhotoSubtitleYes
-          : l10n.eventDetailMenuSuggestEditSubtitleYes,
-      'eventDetailCannotSuggestForDuplicate' => isPhoto
-          ? l10n.eventDetailMenuSuggestPhotoSubtitleNo
-          : l10n.eventDetailMenuSuggestEditSubtitleNo,
+      null =>
+        isPhoto
+            ? l10n.eventDetailMenuSuggestPhotoSubtitleYes
+            : l10n.eventDetailMenuSuggestEditSubtitleYes,
+      'eventDetailCannotSuggestForDuplicate' =>
+        isPhoto
+            ? l10n.eventDetailMenuSuggestPhotoSubtitleNo
+            : l10n.eventDetailMenuSuggestEditSubtitleNo,
       _ => l10n.eventDetailMenuSuggestBlockedUnavailable,
     };
   }
@@ -1816,6 +1819,8 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
   late final TextEditingController _titleController;
   late final TextEditingController _descriptionController;
   late final TextEditingController _websiteController;
+  late DateTime _suggestedStartAt;
+  DateTime? _suggestedEndAt;
   bool _submitting = false;
   String? _error;
 
@@ -1834,6 +1839,8 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     _websiteController = TextEditingController(
       text: widget.event.websiteUrl?.trim() ?? '',
     );
+    _suggestedStartAt = widget.event.startAt;
+    _suggestedEndAt = widget.event.endAt;
   }
 
   @override
@@ -1852,6 +1859,125 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     return parsed != null &&
         parsed.hasAuthority &&
         (parsed.scheme == 'http' || parsed.scheme == 'https');
+  }
+
+  DateTime _displayInEventTimeZone(DateTime value) {
+    return EventScheduleUtils.toDisplayDateTime(
+      value,
+      timeZone: widget.event.timeZone,
+    );
+  }
+
+  String _formatDateTime(DateTime value) {
+    return EventScheduleUtils.formatSummaryLine(
+      context,
+      startAt: value,
+      isDateOnly: widget.event.isDateOnly,
+      timeZone: widget.event.timeZone,
+    );
+  }
+
+  Future<DateTime?> _pickDateTime({required DateTime initial}) async {
+    final displayInitial = _displayInEventTimeZone(initial);
+    final pickedDate = await showDatePicker(
+      context: context,
+      initialDate: displayInitial,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 3650)),
+    );
+    if (pickedDate == null || !mounted) return null;
+
+    final pickedTime = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(displayInitial),
+    );
+    if (pickedTime == null || !mounted) return null;
+
+    return EventScheduleUtils.localDateTimeToUtc(
+      DateTime(
+        pickedDate.year,
+        pickedDate.month,
+        pickedDate.day,
+        pickedTime.hour,
+        pickedTime.minute,
+      ),
+      timeZone: widget.event.timeZone,
+    );
+  }
+
+  Future<void> _pickStartDateTime() async {
+    if (widget.event.isDateOnly) {
+      final initialDate = _displayInEventTimeZone(_suggestedStartAt);
+      final pickedDate = await showDatePicker(
+        context: context,
+        initialDate: DateTime(
+          initialDate.year,
+          initialDate.month,
+          initialDate.day,
+        ),
+        firstDate: DateTime.now().subtract(const Duration(days: 365)),
+        lastDate: DateTime.now().add(const Duration(days: 3650)),
+      );
+      if (pickedDate == null || !mounted) return;
+      final pickedStart = EventScheduleUtils.dateStartToUtc(
+        pickedDate,
+        timeZone: widget.event.timeZone,
+      );
+      setState(() {
+        _suggestedStartAt = pickedStart;
+        if (_suggestedEndAt != null && _suggestedEndAt!.isBefore(pickedStart)) {
+          _suggestedEndAt = pickedStart;
+        }
+        _error = null;
+      });
+      return;
+    }
+
+    final value = await _pickDateTime(initial: _suggestedStartAt);
+    if (value == null || !mounted) return;
+    setState(() {
+      _suggestedStartAt = value;
+      if (_suggestedEndAt != null && _suggestedEndAt!.isBefore(value)) {
+        _suggestedEndAt = value.add(const Duration(hours: 1));
+      }
+      _error = null;
+    });
+  }
+
+  Future<void> _pickEndDateTime() async {
+    if (widget.event.isDateOnly) {
+      final initialDate = _displayInEventTimeZone(
+        _suggestedEndAt ?? _suggestedStartAt,
+      );
+      final pickedDate = await showDatePicker(
+        context: context,
+        initialDate: DateTime(
+          initialDate.year,
+          initialDate.month,
+          initialDate.day,
+        ),
+        firstDate: DateTime.now().subtract(const Duration(days: 365)),
+        lastDate: DateTime.now().add(const Duration(days: 3650)),
+      );
+      if (pickedDate == null || !mounted) return;
+      setState(() {
+        _suggestedEndAt = EventScheduleUtils.dateEndToUtc(
+          pickedDate,
+          timeZone: widget.event.timeZone,
+        );
+        _error = null;
+      });
+      return;
+    }
+
+    final value = await _pickDateTime(
+      initial: _suggestedEndAt ?? _suggestedStartAt,
+    );
+    if (value == null || !mounted) return;
+    setState(() {
+      _suggestedEndAt = value;
+      _error = null;
+    });
   }
 
   Future<void> _submit() async {
@@ -1894,10 +2020,33 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
     final suggestedWebsiteUrl = website.isNotEmpty && website != originalWebsite
         ? website
         : null;
+    final suggestedStartAt =
+        !_suggestedStartAt.toUtc().isAtSameMomentAs(
+          widget.event.startAt.toUtc(),
+        )
+        ? _suggestedStartAt.toUtc()
+        : null;
+    final suggestedEndAt =
+        (_suggestedEndAt != null &&
+            !(widget.event.endAt != null &&
+                _suggestedEndAt!.toUtc().isAtSameMomentAs(
+                  widget.event.endAt!.toUtc(),
+                )))
+        ? _suggestedEndAt!.toUtc()
+        : null;
+
+    final effectiveStartAt = suggestedStartAt ?? widget.event.startAt.toUtc();
+    final effectiveEndAt = suggestedEndAt ?? widget.event.endAt?.toUtc();
+    if (effectiveEndAt != null && effectiveEndAt.isBefore(effectiveStartAt)) {
+      setState(() => _error = l10n.addEventEndBeforeStart);
+      return;
+    }
 
     if (suggestedTitle == null &&
         suggestedDescription == null &&
-        suggestedWebsiteUrl == null) {
+        suggestedWebsiteUrl == null &&
+        suggestedStartAt == null &&
+        suggestedEndAt == null) {
       setState(() => _error = l10n.eventDetailSuggestEditNoChanges);
       return;
     }
@@ -1927,6 +2076,8 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
             suggestedTitle: suggestedTitle,
             suggestedDescription: suggestedDescription,
             suggestedWebsiteUrl: suggestedWebsiteUrl,
+            suggestedStartAt: suggestedStartAt,
+            suggestedEndAt: suggestedEndAt,
             reporterUserId: auth.currentUser?.uid,
             reporterName:
                 auth.userProfile?.displayName ??
@@ -2053,10 +2204,40 @@ class _SuggestEventEditDialogState extends State<_SuggestEventEditDialog> {
                 controller: _websiteController,
                 enabled: !_submitting,
                 keyboardType: TextInputType.url,
+                onChanged: (_) {
+                  if (_error != null) {
+                    setState(() => _error = null);
+                  }
+                },
                 decoration: InputDecoration(
                   labelText: l10n.addEventWebsiteLabel,
                   hintText: l10n.addEventWebsiteHint,
                   border: const OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 10),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.play_arrow_outlined),
+                title: Text(l10n.addEventStartLabel),
+                subtitle: Text(_formatDateTime(_suggestedStartAt)),
+                trailing: TextButton(
+                  onPressed: _submitting ? null : _pickStartDateTime,
+                  child: Text(l10n.spotDetailQuickActionEdit),
+                ),
+              ),
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.stop_outlined),
+                title: Text(l10n.addEventEndLabel),
+                subtitle: Text(
+                  _suggestedEndAt == null
+                      ? l10n.addEventEndNotSet
+                      : _formatDateTime(_suggestedEndAt!),
+                ),
+                trailing: TextButton(
+                  onPressed: _submitting ? null : _pickEndDateTime,
+                  child: Text(l10n.spotDetailQuickActionEdit),
                 ),
               ),
               if (_error != null) ...[

--- a/lib/screens/moderator/event_report_queue_screen.dart
+++ b/lib/screens/moderator/event_report_queue_screen.dart
@@ -548,6 +548,18 @@ class _EventReportCard extends StatelessWidget {
                 const SizedBox(height: 4),
                 Text('Website: ${report.suggestedWebsiteUrl!}'),
               ],
+              if (report.suggestedIsDateOnly != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  '${l10n.addEventAllDay}: ${report.suggestedIsDateOnly! ? 'Yes' : 'No'}',
+                ),
+              ],
+              if (report.suggestedTimeZone?.trim().isNotEmpty ?? false) ...[
+                const SizedBox(height: 4),
+                Text(
+                  '${l10n.addEventTimezoneLabel}: ${report.suggestedTimeZone!}',
+                ),
+              ],
               if (report.suggestedStartAt != null) ...[
                 const SizedBox(height: 4),
                 Text(

--- a/lib/screens/moderator/event_report_queue_screen.dart
+++ b/lib/screens/moderator/event_report_queue_screen.dart
@@ -272,8 +272,7 @@ class _EventReportQueueScreenState extends State<EventReportQueueScreen> {
 
     final approvedEventId = await showDialog<String?>(
       context: context,
-      builder: (dialogContext) =>
-          EventSuggestionApprovalDialog(report: report),
+      builder: (dialogContext) => EventSuggestionApprovalDialog(report: report),
     );
 
     if (!mounted) return;
@@ -392,9 +391,19 @@ class _EventReportCard extends StatelessWidget {
     );
   }
 
+  String _formatSuggestedDateTime(BuildContext context, DateTime value) {
+    return EventScheduleUtils.formatSummaryLine(
+      context,
+      startAt: value,
+      isDateOnly: report.isDateOnly,
+      timeZone: report.timeZone,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
     final color = _statusColor(theme);
     final canReview = report.status == 'New' || report.status == 'Reviewing';
     final isSuggestion = report.isSuggestionForExistingEvent;
@@ -412,7 +421,8 @@ class _EventReportCard extends StatelessWidget {
           children: [
             if (isSuggestion && report.targetEventId?.trim().isNotEmpty == true)
               InkWell(
-                onTap: () => context.push('/event/${report.targetEventId!.trim()}'),
+                onTap: () =>
+                    context.push('/event/${report.targetEventId!.trim()}'),
                 borderRadius: BorderRadius.circular(4),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 4),
@@ -537,6 +547,18 @@ class _EventReportCard extends StatelessWidget {
               if (report.suggestedWebsiteUrl?.isNotEmpty ?? false) ...[
                 const SizedBox(height: 4),
                 Text('Website: ${report.suggestedWebsiteUrl!}'),
+              ],
+              if (report.suggestedStartAt != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  '${l10n.eventDetailStartsLabel}: ${_formatSuggestedDateTime(context, report.suggestedStartAt!)}',
+                ),
+              ],
+              if (report.suggestedEndAt != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  '${l10n.eventDetailEndsLabel}: ${_formatSuggestedDateTime(context, report.suggestedEndAt!)}',
+                ),
               ],
             ],
             if (report.suggestedPhotoUrls.isNotEmpty) ...[

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -79,6 +79,8 @@ class EventReportService {
     String? suggestedTitle,
     String? suggestedDescription,
     String? suggestedWebsiteUrl,
+    bool? suggestedIsDateOnly,
+    String? suggestedTimeZone,
     DateTime? suggestedStartAt,
     DateTime? suggestedEndAt,
     List<String> suggestedPhotoUrls = const <String>[],
@@ -107,6 +109,7 @@ class EventReportService {
     final normalizedSuggestedTitle = suggestedTitle?.trim();
     final normalizedSuggestedDescription = suggestedDescription?.trim();
     final normalizedSuggestedWebsiteUrl = suggestedWebsiteUrl?.trim();
+    final normalizedSuggestedTimeZone = suggestedTimeZone?.trim();
     final normalizedSuggestedStartAt = suggestedStartAt?.toUtc();
     final normalizedSuggestedEndAt = suggestedEndAt?.toUtc();
     if (normalizedSuggestedStartAt != null &&
@@ -163,6 +166,11 @@ class EventReportService {
         if (normalizedSuggestedWebsiteUrl != null &&
             normalizedSuggestedWebsiteUrl.isNotEmpty)
           'suggestedWebsiteUrl': normalizedSuggestedWebsiteUrl,
+        if (suggestedIsDateOnly != null)
+          'suggestedIsDateOnly': suggestedIsDateOnly,
+        if (normalizedSuggestedTimeZone != null &&
+            normalizedSuggestedTimeZone.isNotEmpty)
+          'suggestedTimeZone': normalizedSuggestedTimeZone,
         if (normalizedSuggestedStartAt != null)
           'suggestedStartAt': Timestamp.fromDate(normalizedSuggestedStartAt),
         if (normalizedSuggestedEndAt != null)
@@ -223,6 +231,8 @@ class EventReportService {
     String? suggestedTitle,
     String? suggestedDescription,
     String? suggestedWebsiteUrl,
+    bool? suggestedIsDateOnly,
+    String? suggestedTimeZone,
     DateTime? suggestedStartAt,
     DateTime? suggestedEndAt,
     String? reporterUserId,
@@ -245,6 +255,8 @@ class EventReportService {
       suggestedTitle: suggestedTitle,
       suggestedDescription: suggestedDescription,
       suggestedWebsiteUrl: suggestedWebsiteUrl,
+      suggestedIsDateOnly: suggestedIsDateOnly,
+      suggestedTimeZone: suggestedTimeZone,
       suggestedStartAt: suggestedStartAt,
       suggestedEndAt: suggestedEndAt,
     );
@@ -556,6 +568,15 @@ class EventReportService {
     final suggestedWebsiteUrl = report.suggestedWebsiteUrl?.trim();
     if (suggestedWebsiteUrl != null && suggestedWebsiteUrl.isNotEmpty) {
       updates['websiteUrl'] = suggestedWebsiteUrl;
+    }
+
+    if (report.suggestedIsDateOnly != null) {
+      updates['isDateOnly'] = report.suggestedIsDateOnly;
+    }
+
+    final suggestedTimeZone = report.suggestedTimeZone?.trim();
+    if (suggestedTimeZone != null && suggestedTimeZone.isNotEmpty) {
+      updates['timeZone'] = suggestedTimeZone;
     }
 
     if (report.suggestedStartAt != null) {

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -119,7 +119,7 @@ class EventReportService {
     }
 
     try {
-      await _firestore.collection('eventReports').add({
+      final reportData = <String, dynamic>{
         'title': trimmedTitle,
         if (description != null && description.trim().isNotEmpty)
           'description': description.trim(),
@@ -166,8 +166,6 @@ class EventReportService {
         if (normalizedSuggestedWebsiteUrl != null &&
             normalizedSuggestedWebsiteUrl.isNotEmpty)
           'suggestedWebsiteUrl': normalizedSuggestedWebsiteUrl,
-        if (suggestedIsDateOnly != null)
-          'suggestedIsDateOnly': suggestedIsDateOnly,
         if (normalizedSuggestedTimeZone != null &&
             normalizedSuggestedTimeZone.isNotEmpty)
           'suggestedTimeZone': normalizedSuggestedTimeZone,
@@ -180,7 +178,11 @@ class EventReportService {
         'status': statuses.first,
         'createdAt': FieldValue.serverTimestamp(),
         'updatedAt': FieldValue.serverTimestamp(),
-      });
+      };
+      if (suggestedIsDateOnly != null) {
+        reportData['suggestedIsDateOnly'] = suggestedIsDateOnly;
+      }
+      await _firestore.collection('eventReports').add(reportData);
       return true;
     } catch (e) {
       debugPrint('Error submitting event report: $e');

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -79,6 +79,8 @@ class EventReportService {
     String? suggestedTitle,
     String? suggestedDescription,
     String? suggestedWebsiteUrl,
+    DateTime? suggestedStartAt,
+    DateTime? suggestedEndAt,
     List<String> suggestedPhotoUrls = const <String>[],
   }) async {
     final trimmedTitle = title.trim();
@@ -105,6 +107,13 @@ class EventReportService {
     final normalizedSuggestedTitle = suggestedTitle?.trim();
     final normalizedSuggestedDescription = suggestedDescription?.trim();
     final normalizedSuggestedWebsiteUrl = suggestedWebsiteUrl?.trim();
+    final normalizedSuggestedStartAt = suggestedStartAt?.toUtc();
+    final normalizedSuggestedEndAt = suggestedEndAt?.toUtc();
+    if (normalizedSuggestedStartAt != null &&
+        normalizedSuggestedEndAt != null &&
+        normalizedSuggestedEndAt.isBefore(normalizedSuggestedStartAt)) {
+      return false;
+    }
 
     try {
       await _firestore.collection('eventReports').add({
@@ -154,6 +163,10 @@ class EventReportService {
         if (normalizedSuggestedWebsiteUrl != null &&
             normalizedSuggestedWebsiteUrl.isNotEmpty)
           'suggestedWebsiteUrl': normalizedSuggestedWebsiteUrl,
+        if (normalizedSuggestedStartAt != null)
+          'suggestedStartAt': Timestamp.fromDate(normalizedSuggestedStartAt),
+        if (normalizedSuggestedEndAt != null)
+          'suggestedEndAt': Timestamp.fromDate(normalizedSuggestedEndAt),
         if (normalizedPhotoUrls.isNotEmpty)
           'suggestedPhotoUrls': normalizedPhotoUrls,
         'status': statuses.first,
@@ -210,6 +223,8 @@ class EventReportService {
     String? suggestedTitle,
     String? suggestedDescription,
     String? suggestedWebsiteUrl,
+    DateTime? suggestedStartAt,
+    DateTime? suggestedEndAt,
     String? reporterUserId,
     String? reporterName,
     String? reporterEmail,
@@ -230,6 +245,8 @@ class EventReportService {
       suggestedTitle: suggestedTitle,
       suggestedDescription: suggestedDescription,
       suggestedWebsiteUrl: suggestedWebsiteUrl,
+      suggestedStartAt: suggestedStartAt,
+      suggestedEndAt: suggestedEndAt,
     );
   }
 
@@ -539,6 +556,44 @@ class EventReportService {
     final suggestedWebsiteUrl = report.suggestedWebsiteUrl?.trim();
     if (suggestedWebsiteUrl != null && suggestedWebsiteUrl.isNotEmpty) {
       updates['websiteUrl'] = suggestedWebsiteUrl;
+    }
+
+    if (report.suggestedStartAt != null) {
+      updates['startAt'] = Timestamp.fromDate(report.suggestedStartAt!.toUtc());
+    }
+
+    if (report.suggestedEndAt != null) {
+      final effectiveStartAt = (updates['startAt'] is Timestamp)
+          ? (updates['startAt'] as Timestamp).toDate()
+          : (existingEventData['startAt'] is Timestamp)
+          ? (existingEventData['startAt'] as Timestamp).toDate()
+          : null;
+      final suggestedEndAt = report.suggestedEndAt!.toUtc();
+      if (effectiveStartAt != null &&
+          suggestedEndAt.isBefore(effectiveStartAt)) {
+        debugPrint('Suggested event end time is before start time');
+        return null;
+      }
+      updates['endAt'] = Timestamp.fromDate(suggestedEndAt);
+    }
+
+    final effectiveStartAt = (updates['startAt'] is Timestamp)
+        ? (updates['startAt'] as Timestamp).toDate()
+        : (existingEventData['startAt'] is Timestamp)
+        ? (existingEventData['startAt'] as Timestamp).toDate()
+        : null;
+    final effectiveEndAt = (updates['endAt'] is Timestamp)
+        ? (updates['endAt'] as Timestamp).toDate()
+        : (existingEventData['endAt'] is Timestamp)
+        ? (existingEventData['endAt'] as Timestamp).toDate()
+        : null;
+    if (effectiveStartAt != null &&
+        effectiveEndAt != null &&
+        effectiveEndAt.isBefore(effectiveStartAt)) {
+      debugPrint(
+        'Existing event end time would become invalid after suggestion',
+      );
+      return null;
     }
 
     if (promotedImageUrls != null && promotedImageUrls.isNotEmpty) {

--- a/lib/widgets/event_suggestion_approval_dialog.dart
+++ b/lib/widgets/event_suggestion_approval_dialog.dart
@@ -7,12 +7,10 @@ import '../models/parkour_event.dart';
 import '../services/admin_events_service.dart';
 import '../services/auth_service.dart';
 import '../services/event_report_service.dart';
+import '../utils/event_schedule_utils.dart';
 
 class EventSuggestionApprovalDialog extends StatefulWidget {
-  const EventSuggestionApprovalDialog({
-    super.key,
-    required this.report,
-  });
+  const EventSuggestionApprovalDialog({super.key, required this.report});
 
   final EventReport report;
 
@@ -54,8 +52,10 @@ class _EventSuggestionApprovalDialogState
     }
 
     try {
-      final adminEventsService =
-          Provider.of<AdminEventsService>(context, listen: false);
+      final adminEventsService = Provider.of<AdminEventsService>(
+        context,
+        listen: false,
+      );
       final currentEvent = await adminEventsService.getEventById(targetEventId);
       if (currentEvent == null || !mounted) {
         if (mounted) setState(() => _isLoading = false);
@@ -129,14 +129,18 @@ class _EventSuggestionApprovalDialogState
 
     try {
       final authService = Provider.of<AuthService>(context, listen: false);
-      final reportService =
-          Provider.of<EventReportService>(context, listen: false);
+      final reportService = Provider.of<EventReportService>(
+        context,
+        listen: false,
+      );
       final user = authService.currentUser;
       final userId = user?.uid;
       if (userId == null) {
         if (mounted) {
           setState(() {
-            _error = AppLocalizations.of(context)!.eventSuggestionApprovalFailed;
+            _error = AppLocalizations.of(
+              context,
+            )!.eventSuggestionApprovalFailed;
             _isApproving = false;
           });
         }
@@ -147,7 +151,8 @@ class _EventSuggestionApprovalDialogState
       final approvedEventId = await reportService.approveReport(
         reportId: widget.report.id,
         approverUserId: userId,
-        approverName: authService.userProfile?.displayName ??
+        approverName:
+            authService.userProfile?.displayName ??
             user?.displayName ??
             user?.email,
         moderatorNotes: notes.isEmpty ? null : notes,
@@ -174,6 +179,15 @@ class _EventSuggestionApprovalDialogState
         });
       }
     }
+  }
+
+  String _formatSuggestedDateTime(DateTime value) {
+    return EventScheduleUtils.formatSummaryLine(
+      context,
+      startAt: value,
+      isDateOnly: widget.report.isDateOnly,
+      timeZone: widget.report.timeZone,
+    );
   }
 
   Widget _buildWarningBanner({
@@ -241,8 +255,7 @@ class _EventSuggestionApprovalDialogState
       );
     }
 
-    final sourceName =
-        targetEvent.eventSourceName?.trim().isNotEmpty == true
+    final sourceName = targetEvent.eventSourceName?.trim().isNotEmpty == true
         ? targetEvent.eventSourceName!.trim()
         : 'external source';
 
@@ -266,7 +279,9 @@ class _EventSuggestionApprovalDialogState
                 _buildWarningBanner(
                   theme: theme,
                   title: l10n.eventSuggestionCannotApproveExternalTitle,
-                  body: l10n.eventSuggestionCannotApproveExternalBody(sourceName),
+                  body: l10n.eventSuggestionCannotApproveExternalBody(
+                    sourceName,
+                  ),
                 ),
                 const SizedBox(height: 16),
               ],
@@ -289,7 +304,8 @@ class _EventSuggestionApprovalDialogState
                 RadioGroup<String>(
                   groupValue: _targetEventId,
                   onChanged: (String? value) {
-                    final isCurrentDisabled = _isApproving ||
+                    final isCurrentDisabled =
+                        _isApproving ||
                         (_currentEvent?.duplicateOf?.trim().isNotEmpty ??
                             false) ||
                         !_currentEvent!.isNativeEvent;
@@ -323,7 +339,9 @@ class _EventSuggestionApprovalDialogState
                                 )
                               : !_currentEvent!.isNativeEvent
                               ? l10n.eventSuggestionReportedEventExternalSubtitle(
-                                  _currentEvent!.eventSourceName?.trim().isNotEmpty ==
+                                  _currentEvent!.eventSourceName
+                                              ?.trim()
+                                              .isNotEmpty ==
                                           true
                                       ? _currentEvent!.eventSourceName!.trim()
                                       : sourceName,
@@ -331,7 +349,8 @@ class _EventSuggestionApprovalDialogState
                               : l10n.eventSuggestionReportedEventSubtitle,
                         ),
                         value: widget.report.targetEventId!,
-                        enabled: !_isApproving &&
+                        enabled:
+                            !_isApproving &&
                             !(_currentEvent?.duplicateOf?.trim().isNotEmpty ??
                                 false) &&
                             _currentEvent!.isNativeEvent,
@@ -346,7 +365,9 @@ class _EventSuggestionApprovalDialogState
                         subtitle: Text(
                           !_originalEvent!.isNativeEvent
                               ? l10n.eventSuggestionOriginalEventExternalSubtitle(
-                                  _originalEvent!.eventSourceName?.trim().isNotEmpty ==
+                                  _originalEvent!.eventSourceName
+                                              ?.trim()
+                                              .isNotEmpty ==
                                           true
                                       ? _originalEvent!.eventSourceName!.trim()
                                       : sourceName,
@@ -371,8 +392,11 @@ class _EventSuggestionApprovalDialogState
                 ),
                 const SizedBox(height: 8),
                 if (report.suggestedTitle?.trim().isNotEmpty ?? false)
-                  Text('${l10n.eventDetailSuggestEditTitle}: ${report.suggestedTitle!}'),
-                if (report.suggestedDescription?.trim().isNotEmpty ?? false) ...[
+                  Text(
+                    '${l10n.eventDetailSuggestEditTitle}: ${report.suggestedTitle!}',
+                  ),
+                if (report.suggestedDescription?.trim().isNotEmpty ??
+                    false) ...[
                   const SizedBox(height: 4),
                   Text(report.suggestedDescription!),
                 ],
@@ -383,6 +407,18 @@ class _EventSuggestionApprovalDialogState
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.primary,
                     ),
+                  ),
+                ],
+                if (report.suggestedStartAt != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    '${l10n.eventDetailStartsLabel}: ${_formatSuggestedDateTime(report.suggestedStartAt!)}',
+                  ),
+                ],
+                if (report.suggestedEndAt != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    '${l10n.eventDetailEndsLabel}: ${_formatSuggestedDateTime(report.suggestedEndAt!)}',
                   ),
                 ],
                 const SizedBox(height: 12),
@@ -457,7 +493,9 @@ class _EventSuggestionApprovalDialogState
       ),
       actions: [
         TextButton(
-          onPressed: _isApproving ? null : () => Navigator.of(context).pop(null),
+          onPressed: _isApproving
+              ? null
+              : () => Navigator.of(context).pop(null),
           child: const Text('Cancel'),
         ),
         FilledButton(

--- a/lib/widgets/event_suggestion_approval_dialog.dart
+++ b/lib/widgets/event_suggestion_approval_dialog.dart
@@ -409,6 +409,18 @@ class _EventSuggestionApprovalDialogState
                     ),
                   ),
                 ],
+                if (report.suggestedIsDateOnly != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    '${l10n.addEventAllDay}: ${report.suggestedIsDateOnly! ? 'Yes' : 'No'}',
+                  ),
+                ],
+                if (report.suggestedTimeZone?.trim().isNotEmpty ?? false) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    '${l10n.addEventTimezoneLabel}: ${report.suggestedTimeZone!}',
+                  ),
+                ],
                 if (report.suggestedStartAt != null) ...[
                   const SizedBox(height: 4),
                   Text(

--- a/test/models/event_report_test.dart
+++ b/test/models/event_report_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/models/event_report.dart';
+
+void main() {
+  group('EventReport.hasSuggestedEdits', () {
+    EventReport buildReport({
+      DateTime? suggestedStartAt,
+      DateTime? suggestedEndAt,
+    }) {
+      return EventReport(
+        id: 'report-1',
+        title: 'Jam session',
+        status: 'New',
+        startAt: DateTime.utc(2026, 5, 28, 18),
+        suggestedStartAt: suggestedStartAt,
+        suggestedEndAt: suggestedEndAt,
+      );
+    }
+
+    test('returns true when suggested start datetime exists', () {
+      final report = buildReport(
+        suggestedStartAt: DateTime.utc(2026, 5, 28, 19),
+      );
+
+      expect(report.hasSuggestedEdits, isTrue);
+    });
+
+    test('returns true when suggested end datetime exists', () {
+      final report = buildReport(suggestedEndAt: DateTime.utc(2026, 5, 28, 20));
+
+      expect(report.hasSuggestedEdits, isTrue);
+    });
+
+    test('returns false when no suggested fields are set', () {
+      final report = buildReport();
+
+      expect(report.hasSuggestedEdits, isFalse);
+    });
+  });
+}

--- a/test/models/event_report_test.dart
+++ b/test/models/event_report_test.dart
@@ -6,12 +6,16 @@ void main() {
     EventReport buildReport({
       DateTime? suggestedStartAt,
       DateTime? suggestedEndAt,
+      bool? suggestedIsDateOnly,
+      String? suggestedTimeZone,
     }) {
       return EventReport(
         id: 'report-1',
         title: 'Jam session',
         status: 'New',
         startAt: DateTime.utc(2026, 5, 28, 18),
+        suggestedIsDateOnly: suggestedIsDateOnly,
+        suggestedTimeZone: suggestedTimeZone,
         suggestedStartAt: suggestedStartAt,
         suggestedEndAt: suggestedEndAt,
       );
@@ -27,6 +31,18 @@ void main() {
 
     test('returns true when suggested end datetime exists', () {
       final report = buildReport(suggestedEndAt: DateTime.utc(2026, 5, 28, 20));
+
+      expect(report.hasSuggestedEdits, isTrue);
+    });
+
+    test('returns true when suggested all-day value exists', () {
+      final report = buildReport(suggestedIsDateOnly: true);
+
+      expect(report.hasSuggestedEdits, isTrue);
+    });
+
+    test('returns true when suggested timezone exists', () {
+      final report = buildReport(suggestedTimeZone: 'Europe/Amsterdam');
 
       expect(report.hasSuggestedEdits, isTrue);
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add support for suggesting event `isDateOnly` (all-day) and `timeZone` changes in the Suggest an edit flow
- wire `suggestedIsDateOnly` and `suggestedTimeZone` through event report model parsing + submission payloads
- apply suggested all-day/timezone updates when moderators approve an existing-event suggestion
- update suggest-edit and moderator review UIs to capture/show timezone and all-day schedule suggestions
- extend tests for `EventReport.hasSuggestedEdits` to cover all-day/timezone-only suggestions

## Validation
- `flutter analyze lib/models/event_report.dart lib/services/event_report_service.dart lib/screens/events/event_detail_screen.dart lib/screens/moderator/event_report_queue_screen.dart lib/widgets/event_suggestion_approval_dialog.dart`
- `flutter test test/models/event_report_test.dart test/services/event_report_service_test.dart`
- Manual emulator walkthrough: open event suggest edit dialog, toggle all-day, change timezone, set dates, submit successfully
- Emulator data verification log confirms newest `eventReports` docs include `suggestedIsDateOnly=true` and `suggestedTimeZone=America/Toronto`

## Walkthrough artifacts
[event_suggest_edit_all_day_timezone_submit_success.mp4](https://cursor.com/agents/bc-d28ac5b2-3865-4932-8d6a-06a4bb1623c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_suggest_edit_all_day_timezone_submit_success.mp4)
[suggest edit all-day and timezone form](https://cursor.com/agents/bc-d28ac5b2-3865-4932-8d6a-06a4bb1623c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuggest_edit_all_day_timezone_form.webp)
[suggest edit submission success snackbar](https://cursor.com/agents/bc-d28ac5b2-3865-4932-8d6a-06a4bb1623c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuggest_edit_all_day_timezone_success_snackbar.webp)
[event_reports_all_day_timezone_verification.log](https://cursor.com/agents/bc-d28ac5b2-3865-4932-8d6a-06a4bb1623c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_reports_all_day_timezone_verification.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d28ac5b2-3865-4932-8d6a-06a4bb1623c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d28ac5b2-3865-4932-8d6a-06a4bb1623c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

