### PR TITLE
Add duplicate spot cluster resolver

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -599,13 +599,15 @@ service cloud.firestore {
          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true);
       // Only Cloud Functions (with admin privileges) can create/delete
       allow create, delete: if false;
-      // Moderators and admins can update the collapsedPairs field for UI preferences
+      // Moderators and admins can update review and resolution metadata
       allow update: if request.auth != null &&
         exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
         (get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true ||
          get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isModerator == true) &&
         // Ensure collapsedPairs is a list if present
-        (!('collapsedPairs' in request.resource.data) || request.resource.data.collapsedPairs is list);
+        (!('collapsedPairs' in request.resource.data) || request.resource.data.collapsedPairs is list) &&
+        // Pair resolution details are stored as a map keyed by pair index
+        (!('pairResolutions' in request.resource.data) || request.resource.data.pairResolutions is map);
     }
 
     // UserActivityMetrics collection - only admins can read, only Cloud Functions can write

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -23,6 +23,7 @@ import '../screens/admin/duplicate_images_screen.dart';
 import '../screens/admin/missing_resized_images_screen.dart';
 import '../screens/admin/duplicate_spots_screen.dart';
 import '../screens/admin/duplicate_spots_results_screen.dart';
+import '../screens/admin/duplicate_spots_pair_review_screen.dart';
 import '../screens/admin/device_detection_screen.dart';
 import '../screens/debug/support_debug_screen.dart';
 import '../screens/admin/api_clients_screen.dart';
@@ -493,6 +494,23 @@ class AppRouter {
                     final runId = state.pathParameters['runId']!;
                     return DuplicateSpotsResultsScreen(runId: runId);
                   },
+                  routes: [
+                    GoRoute(
+                      path: 'pair/:pairIndex',
+                      builder: (context, state) {
+                        final runId = state.pathParameters['runId']!;
+                        final pairIndex =
+                            int.tryParse(
+                              state.pathParameters['pairIndex'] ?? '',
+                            ) ??
+                            0;
+                        return DuplicateSpotsPairReviewScreen(
+                          runId: runId,
+                          pairIndex: pairIndex,
+                        );
+                      },
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/screens/admin/duplicate_spots_pair_review_screen.dart
+++ b/lib/screens/admin/duplicate_spots_pair_review_screen.dart
@@ -1,0 +1,1091 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../constants/spot_attributes.dart';
+import '../../models/spot.dart';
+import '../../services/auth_service.dart';
+import '../../services/mobile_detection_service.dart';
+import '../../services/spot_service.dart';
+import '../../services/url_service.dart';
+import '../../utils/duplicate_spot_resolution_utils.dart';
+import '../../utils/marker_icon_utils.dart';
+import '../../widgets/moderator_action_fields.dart';
+import '../../widgets/page_scaffold.dart';
+import '../../widgets/resized_spot_image.dart';
+
+class DuplicateSpotsPairReviewScreen extends StatefulWidget {
+  const DuplicateSpotsPairReviewScreen({
+    super.key,
+    required this.runId,
+    required this.pairIndex,
+  });
+
+  final String runId;
+  final int pairIndex;
+
+  @override
+  State<DuplicateSpotsPairReviewScreen> createState() =>
+      _DuplicateSpotsPairReviewScreenState();
+}
+
+class _DuplicateSpotsPairReviewScreenState
+    extends State<DuplicateSpotsPairReviewScreen> {
+  static const int _duplicateRangeMeters = 50;
+
+  late Future<_DuplicateClusterReviewData> _reviewFuture;
+  final TextEditingController _notesController = TextEditingController();
+  String? _selectedReportId;
+  String? _initializedForClusterKey;
+  String? _baseSpotId;
+  String? _titleSpotId;
+  String? _descriptionSpotId;
+  String? _locationSpotId;
+  String? _attributesSpotId;
+  final Set<String> _photoSpotIds = {};
+  final Set<String> _youtubeSpotIds = {};
+  bool _isResolving = false;
+  String? _resolvedNativeSpotId;
+
+  @override
+  void initState() {
+    super.initState();
+    _reviewFuture = _loadReviewData();
+  }
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<_DuplicateClusterReviewData> _loadReviewData() async {
+    final spotService = context.read<SpotService>();
+    final runDoc = await FirebaseFirestore.instance
+        .collection('duplicateDetectionResults')
+        .doc(widget.runId)
+        .get();
+    if (!runDoc.exists) {
+      throw StateError('Duplicate detection run not found');
+    }
+
+    final data = runDoc.data() ?? <String, dynamic>{};
+    final rawPairs = data['pairs'] as List<dynamic>? ?? <dynamic>[];
+    final pairRefs = rawPairs
+        .whereType<Map<String, dynamic>>()
+        .map(DuplicateSpotPairRef.fromMap)
+        .whereType<DuplicateSpotPairRef>()
+        .toList();
+    if (widget.pairIndex < 0 || widget.pairIndex >= pairRefs.length) {
+      throw StateError('Duplicate pair not found');
+    }
+
+    final connectedIds = buildConnectedDuplicateSpotIds(
+      pairs: pairRefs,
+      startIndex: widget.pairIndex,
+      maxDistanceMeters: _duplicateRangeMeters,
+    );
+    final spots = await spotService.findDuplicateClusterFromSeeds(
+      connectedIds,
+      maxDistanceMeters: _duplicateRangeMeters,
+    );
+    if (spots.length < 2) {
+      throw StateError('Could not load at least two spots for this cluster');
+    }
+
+    final clusterIds = spots.map((spot) => spot.id).whereType<String>().toSet();
+    final pairIndices = findPairIndicesWithinCluster(
+      pairs: pairRefs,
+      clusterSpotIds: clusterIds,
+      maxDistanceMeters: _duplicateRangeMeters,
+    );
+    if (!pairIndices.contains(widget.pairIndex)) {
+      pairIndices.add(widget.pairIndex);
+      pairIndices.sort();
+    }
+
+    return _DuplicateClusterReviewData(
+      runId: widget.runId,
+      pairIndex: widget.pairIndex,
+      sourceName: data['sourceName'] as String? ?? 'Unknown source',
+      spots: spots,
+      pairRefs: pairRefs,
+      resolvedPairIndices: pairIndices,
+      existingResolution:
+          (data['pairResolutions']
+                  as Map<String, dynamic>?)?['${widget.pairIndex}']
+              as Map<String, dynamic>?,
+    );
+  }
+
+  void _ensureSelectionDefaults(_DuplicateClusterReviewData data) {
+    final clusterKey = data.spots.map((spot) => spot.id).join('|');
+    if (_initializedForClusterKey == clusterKey) return;
+
+    final clickedPair = data.pairRefs[data.pairIndex];
+    final clickedSpots = data.spots.where((spot) {
+      return spot.id == clickedPair.spot1Id || spot.id == clickedPair.spot2Id;
+    }).toList();
+    final baseSpot =
+        clickedSpots.where((spot) => spot.spotSource == null).firstOrNull ??
+        data.spots.where((spot) => spot.spotSource == null).firstOrNull ??
+        clickedSpots.firstOrNull ??
+        data.spots.first;
+    final baseId = baseSpot.id!;
+
+    _initializedForClusterKey = clusterKey;
+    _baseSpotId = baseId;
+    _titleSpotId = baseId;
+    _descriptionSpotId = baseId;
+    _locationSpotId = baseId;
+    _attributesSpotId = baseId;
+    _photoSpotIds
+      ..clear()
+      ..addAll(
+        data.spots
+            .where((spot) => spot.imageUrls?.isNotEmpty ?? false)
+            .map((spot) => spot.id)
+            .whereType<String>(),
+      );
+    _youtubeSpotIds
+      ..clear()
+      ..addAll(
+        data.spots
+            .where((spot) => spot.youtubeVideoIds?.isNotEmpty ?? false)
+            .map((spot) => spot.id)
+            .whereType<String>(),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authService = context.watch<AuthService>();
+    final hasModeratorAccess = authService.isModerator || authService.isAdmin;
+    if (!hasModeratorAccess) {
+      return _buildScaffold(
+        body: const Center(child: Text('Moderator access required')),
+      );
+    }
+
+    return _buildScaffold(
+      body: FutureBuilder<_DuplicateClusterReviewData>(
+        future: _reviewFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final data = snapshot.data!;
+          _ensureSelectionDefaults(data);
+          final preview = _buildPreview(data.spots);
+
+          return ListView(
+            padding: EdgeInsets.zero,
+            children: [
+              _buildIntro(data),
+              const SizedBox(height: 12),
+              _buildClusterMap(data.spots),
+              const SizedBox(height: 12),
+              _buildSpotDetailsGrid(data.spots),
+              const SizedBox(height: 12),
+              _buildSelectionPanel(data.spots),
+              const SizedBox(height: 12),
+              _buildPreviewPanel(preview),
+              const SizedBox(height: 12),
+              _buildConfirmPanel(data, preview),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildScaffold({required Widget body}) {
+    return PageScaffold(
+      title: 'Resolve Duplicate Cluster',
+      scrollable: false,
+      onBack: () {
+        if (Navigator.canPop(context)) {
+          Navigator.pop(context);
+        } else {
+          context.go('/moderator/duplicate-spots/${widget.runId}');
+        }
+      },
+      body: body,
+    );
+  }
+
+  Spot _buildPreview(List<Spot> spots) {
+    return buildDuplicateNativeSpotPreview(
+      spots: spots,
+      baseSpotId: _baseSpotId!,
+      titleSpotId: _titleSpotId!,
+      descriptionSpotId: _descriptionSpotId!,
+      locationSpotId: _locationSpotId!,
+      attributesSpotId: _attributesSpotId!,
+      photoSpotIds: _photoSpotIds,
+      youtubeSpotIds: _youtubeSpotIds,
+    );
+  }
+
+  Widget _buildIntro(_DuplicateClusterReviewData data) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final resolution = data.existingResolution;
+    final nativeSpotId = resolution?['nativeSpotId'] as String?;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.primaryContainer.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.merge_type, color: colorScheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Cluster from ${data.sourceName} pair #${data.pairIndex + 1}',
+                  style: TextStyle(
+                    color: colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${data.spots.length} spots are connected within $_duplicateRangeMeters meters. Resolving this cluster will mark ${data.resolvedPairIndices.length} detection pair${data.resolvedPairIndices.length == 1 ? '' : 's'} as resolved.',
+                  style: TextStyle(color: colorScheme.onPrimaryContainer),
+                ),
+                if (nativeSpotId != null) ...[
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    onPressed: () => context.push('/spot/$nativeSpotId'),
+                    icon: const Icon(Icons.open_in_new),
+                    label: const Text('Open existing native resolution'),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildClusterMap(List<Spot> spots) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Cluster map', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            _DuplicateClusterMap(
+              spots: spots,
+              selectedLocationSpotId: _locationSpotId,
+              height: 320,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSpotDetailsGrid(List<Spot> spots) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Spot details',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final cardWidth = constraints.maxWidth >= 900
+                    ? (constraints.maxWidth - 24) / 3
+                    : constraints.maxWidth >= 620
+                    ? (constraints.maxWidth - 12) / 2
+                    : constraints.maxWidth;
+                return Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: spots
+                      .map(
+                        (spot) => SizedBox(
+                          width: cardWidth,
+                          child: _buildSpotCard(spot),
+                        ),
+                      )
+                      .toList(),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSpotCard(Spot spot) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildThumbnail(spot),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        spot.name.isEmpty ? 'Unnamed spot' : spot.name,
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        _sourceLabel(spot),
+                        style: TextStyle(color: colorScheme.onSurfaceVariant),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            if (spot.description.trim().isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                spot.description,
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            const SizedBox(height: 8),
+            _detailLine(Icons.place, _locationLabel(spot)),
+            _detailLine(
+              Icons.gps_fixed,
+              '${spot.latitude.toStringAsFixed(6)}, ${spot.longitude.toStringAsFixed(6)}',
+            ),
+            _detailLine(
+              Icons.photo_library,
+              '${spot.imageUrls?.length ?? 0} photos · ${spot.youtubeVideoIds?.length ?? 0} videos',
+            ),
+            _buildAttributeSummary(spot),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                TextButton.icon(
+                  onPressed: () => _openSpotDetails(spot),
+                  icon: const Icon(Icons.open_in_new),
+                  label: const Text('Details'),
+                ),
+                TextButton.icon(
+                  onPressed: () => context.push(
+                    '/explore?locateSpotId=${Uri.encodeComponent(spot.id!)}',
+                  ),
+                  icon: const Icon(Icons.map),
+                  label: const Text('Locate'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildThumbnail(Spot spot) {
+    final imageUrl = spot.imageUrls?.firstOrNull;
+    if (imageUrl == null) {
+      return Container(
+        width: 72,
+        height: 72,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: const Icon(Icons.image_not_supported_outlined),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: ResizedSpotImage(
+        imageUrl: imageUrl,
+        width: 72,
+        height: 72,
+        fit: BoxFit.cover,
+      ),
+    );
+  }
+
+  Widget _detailLine(IconData icon, String text) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(color: colorScheme.onSurfaceVariant),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAttributeSummary(Spot spot) {
+    final chips = <Widget>[];
+    if (spot.spotAccess != null) {
+      chips.add(
+        _smallChip(SpotAttributes.getLabel('access', spot.spotAccess!)),
+      );
+    }
+    chips.addAll(
+      (spot.spotFeatures ?? <String>[]).map(
+        (key) => _smallChip(SpotAttributes.getLabel('features', key)),
+      ),
+    );
+    chips.addAll(
+      (spot.goodFor ?? <String>[]).map(
+        (key) => _smallChip(SpotAttributes.getLabel('goodFor', key)),
+      ),
+    );
+    spot.spotFacilities?.forEach((key, value) {
+      if (value == 'true') {
+        chips.add(_smallChip(SpotAttributes.getLabel('facilities', key)));
+      }
+    });
+
+    if (chips.isEmpty) {
+      return _detailLine(Icons.tune, 'No attributes');
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Wrap(spacing: 6, runSpacing: 6, children: chips.take(8).toList()),
+    );
+  }
+
+  Widget _smallChip(String label) {
+    return Chip(
+      visualDensity: VisualDensity.compact,
+      label: Text(label),
+      labelStyle: const TextStyle(fontSize: 11),
+    );
+  }
+
+  Widget _buildSelectionPanel(List<Spot> spots) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Create native spot from cluster',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            _spotDropdown(
+              label: 'Basis for the native spot',
+              value: _baseSpotId,
+              spots: spots,
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() {
+                  _baseSpotId = value;
+                  _titleSpotId = value;
+                  _descriptionSpotId = value;
+                  _locationSpotId = value;
+                  _attributesSpotId = value;
+                });
+              },
+            ),
+            const SizedBox(height: 12),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final twoColumns = constraints.maxWidth >= 760;
+                final width = twoColumns
+                    ? (constraints.maxWidth - 12) / 2
+                    : constraints.maxWidth;
+                return Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    SizedBox(
+                      width: width,
+                      child: _spotDropdown(
+                        label: 'Title from',
+                        value: _titleSpotId,
+                        spots: spots,
+                        onChanged: (value) =>
+                            setState(() => _titleSpotId = value),
+                      ),
+                    ),
+                    SizedBox(
+                      width: width,
+                      child: _spotDropdown(
+                        label: 'Description from',
+                        value: _descriptionSpotId,
+                        spots: spots,
+                        onChanged: (value) =>
+                            setState(() => _descriptionSpotId = value),
+                      ),
+                    ),
+                    SizedBox(
+                      width: width,
+                      child: _spotDropdown(
+                        label: 'Location from',
+                        value: _locationSpotId,
+                        spots: spots,
+                        onChanged: (value) =>
+                            setState(() => _locationSpotId = value),
+                      ),
+                    ),
+                    SizedBox(
+                      width: width,
+                      child: _spotDropdown(
+                        label: 'Attributes from',
+                        value: _attributesSpotId,
+                        spots: spots,
+                        onChanged: (value) =>
+                            setState(() => _attributesSpotId = value),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Photos to include',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            _checkboxWrap(
+              spots: spots.where((spot) => spot.imageUrls?.isNotEmpty ?? false),
+              selectedIds: _photoSpotIds,
+              emptyText: 'No spots in this cluster have photos.',
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Videos to include',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            _checkboxWrap(
+              spots: spots.where(
+                (spot) => spot.youtubeVideoIds?.isNotEmpty ?? false,
+              ),
+              selectedIds: _youtubeSpotIds,
+              emptyText: 'No spots in this cluster have videos.',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _spotDropdown({
+    required String label,
+    required String? value,
+    required List<Spot> spots,
+    required ValueChanged<String?> onChanged,
+  }) {
+    return DropdownButtonFormField<String>(
+      initialValue: value,
+      isExpanded: true,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+      ),
+      items: spots.map((spot) {
+        return DropdownMenuItem(
+          value: spot.id,
+          child: Text(
+            '${spot.name.isEmpty ? 'Unnamed spot' : spot.name} · ${_sourceLabel(spot)}',
+            overflow: TextOverflow.ellipsis,
+          ),
+        );
+      }).toList(),
+      onChanged: onChanged,
+    );
+  }
+
+  Widget _checkboxWrap({
+    required Iterable<Spot> spots,
+    required Set<String> selectedIds,
+    required String emptyText,
+  }) {
+    final items = spots.toList();
+    if (items.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 6),
+        child: Text(emptyText),
+      );
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: items.map((spot) {
+        final spotId = spot.id!;
+        final count =
+            spot.imageUrls?.length ?? spot.youtubeVideoIds?.length ?? 0;
+        return FilterChip(
+          label: Text('${spot.name} ($count)'),
+          selected: selectedIds.contains(spotId),
+          onSelected: (selected) {
+            setState(() {
+              if (selected) {
+                selectedIds.add(spotId);
+              } else {
+                selectedIds.remove(spotId);
+              }
+            });
+          },
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildPreviewPanel(Spot preview) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Result preview',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Text(preview.name, style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 6),
+            Text(
+              preview.description.isEmpty
+                  ? 'No description'
+                  : preview.description,
+            ),
+            const SizedBox(height: 8),
+            _detailLine(Icons.place, _locationLabel(preview)),
+            _detailLine(
+              Icons.gps_fixed,
+              '${preview.latitude.toStringAsFixed(6)}, ${preview.longitude.toStringAsFixed(6)}',
+            ),
+            _detailLine(
+              Icons.photo_library,
+              '${preview.imageUrls?.length ?? 0} photos · ${preview.youtubeVideoIds?.length ?? 0} videos',
+            ),
+            _buildAttributeSummary(preview),
+            if (preview.imageUrls?.isNotEmpty ?? false) ...[
+              const SizedBox(height: 12),
+              SizedBox(
+                height: 84,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: preview.imageUrls!.length,
+                  separatorBuilder: (_, _) => const SizedBox(width: 8),
+                  itemBuilder: (context, index) {
+                    return ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: ResizedSpotImage(
+                        imageUrl: preview.imageUrls![index],
+                        width: 84,
+                        height: 84,
+                        fit: BoxFit.cover,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildConfirmPanel(_DuplicateClusterReviewData data, Spot preview) {
+    final authService = context.watch<AuthService>();
+    final canResolve = !_isResolving && _resolvedNativeSpotId == null;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Confirm resolution',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            ModeratorActionFields(
+              spotId: _baseSpotId,
+              notesController: _notesController,
+              onReportSelected: (reportId) {
+                _selectedReportId = reportId;
+              },
+              showReportSelector: true,
+            ),
+            const SizedBox(height: 16),
+            if (_resolvedNativeSpotId != null)
+              FilledButton.icon(
+                onPressed: () => context.push('/spot/$_resolvedNativeSpotId'),
+                icon: const Icon(Icons.open_in_new),
+                label: const Text('Open created native spot'),
+              )
+            else
+              FilledButton.icon(
+                onPressed: canResolve
+                    ? () => _confirmResolution(data, preview, authService)
+                    : null,
+                icon: _isResolving
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.check_circle),
+                label: Text(
+                  _isResolving
+                      ? 'Resolving cluster...'
+                      : 'Create native spot and resolve cluster',
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmResolution(
+    _DuplicateClusterReviewData data,
+    Spot preview,
+    AuthService authService,
+  ) async {
+    final currentUser = authService.currentUser;
+    if (currentUser == null) {
+      _showSnack('You must be signed in to resolve duplicate clusters.');
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Resolve duplicate cluster?'),
+        content: Text(
+          'This will create one native spot named "${preview.name}" and mark ${data.spots.length} cluster spots as duplicates of it. ${data.resolvedPairIndices.length} duplicate detection pair${data.resolvedPairIndices.length == 1 ? '' : 's'} will be marked resolved.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Resolve'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _isResolving = true);
+    final spotService = context.read<SpotService>();
+    final userName =
+        authService.userProfile?.displayName ??
+        currentUser.displayName ??
+        currentUser.email ??
+        currentUser.uid;
+    final nativeSpotId = await spotService.resolveDuplicateClusterToNative(
+      clusterSpots: data.spots,
+      previewSpot: preview,
+      userId: currentUser.uid,
+      userName: userName,
+      runId: data.runId,
+      resolvedPairIndices: data.resolvedPairIndices,
+      reportId: _selectedReportId,
+      notes: _notesController.text.trim().isEmpty
+          ? null
+          : _notesController.text.trim(),
+    );
+
+    if (!mounted) return;
+    setState(() {
+      _isResolving = false;
+      _resolvedNativeSpotId = nativeSpotId;
+    });
+    if (nativeSpotId == null) {
+      _showSnack(spotService.error ?? 'Failed to resolve duplicate cluster.');
+      return;
+    }
+    _showSnack('Duplicate cluster resolved.');
+  }
+
+  Future<void> _openSpotDetails(Spot spot) async {
+    final spotId = spot.id!;
+    if (MobileDetectionService.isRunningInBrowser) {
+      final uri = Uri.parse(
+        UrlService.generateSpotUrl(
+          spotId,
+          countryCode: spot.countryCode,
+          city: spot.city,
+        ),
+      );
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      }
+    } else if (mounted) {
+      context.push(
+        UrlService.generateNavigationUrl(
+          spotId,
+          countryCode: spot.countryCode,
+          city: spot.city,
+        ),
+      );
+    }
+  }
+
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  String _sourceLabel(Spot spot) {
+    return spot.spotSourceName ?? spot.spotSource ?? 'Native parkour.spot';
+  }
+
+  String _locationLabel(Spot spot) {
+    final parts = [
+      spot.address,
+      spot.city,
+      spot.countryCode,
+    ].whereType<String>().where((value) => value.trim().isNotEmpty).toList();
+    return parts.isEmpty ? 'No address' : parts.join(', ');
+  }
+}
+
+class _DuplicateClusterReviewData {
+  const _DuplicateClusterReviewData({
+    required this.runId,
+    required this.pairIndex,
+    required this.sourceName,
+    required this.spots,
+    required this.pairRefs,
+    required this.resolvedPairIndices,
+    this.existingResolution,
+  });
+
+  final String runId;
+  final int pairIndex;
+  final String sourceName;
+  final List<Spot> spots;
+  final List<DuplicateSpotPairRef> pairRefs;
+  final List<int> resolvedPairIndices;
+  final Map<String, dynamic>? existingResolution;
+}
+
+class _DuplicateClusterMap extends StatefulWidget {
+  const _DuplicateClusterMap({
+    required this.spots,
+    required this.selectedLocationSpotId,
+    required this.height,
+  });
+
+  final List<Spot> spots;
+  final String? selectedLocationSpotId;
+  final double height;
+
+  @override
+  State<_DuplicateClusterMap> createState() => _DuplicateClusterMapState();
+}
+
+class _DuplicateClusterMapState extends State<_DuplicateClusterMap> {
+  bool _isSatelliteView = false;
+  BitmapDescriptor? _normalPinIcon;
+  BitmapDescriptor? _selectedPinIcon;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPinIcons();
+  }
+
+  Future<void> _loadPinIcons() async {
+    final double h = MarkerIconUtils.mapPinSingleSpotLogicalHeight;
+    final normal = await MarkerIconUtils.loadMapPinPng(
+      MarkerIconUtils.mapPinNormalAsset,
+      fallbackFill: MarkerIconUtils.mapPinNormalFallbackFill,
+      logicalHeight: h,
+    );
+    final selected = await MarkerIconUtils.loadMapPinPng(
+      MarkerIconUtils.mapPinNormalSelectedAsset,
+      fallbackFill: MarkerIconUtils.mapPinNormalFallbackFill,
+      logicalHeight: h,
+    );
+    if (!mounted) return;
+    setState(() {
+      _normalPinIcon = normal;
+      _selectedPinIcon = selected;
+    });
+  }
+
+  LatLng get _cameraTarget {
+    final latSum = widget.spots.fold<double>(
+      0,
+      (total, spot) => total + spot.latitude,
+    );
+    final lngSum = widget.spots.fold<double>(
+      0,
+      (total, spot) => total + spot.longitude,
+    );
+    return LatLng(latSum / widget.spots.length, lngSum / widget.spots.length);
+  }
+
+  double get _cameraZoom {
+    if (widget.spots.length <= 1) return 16;
+    final latitudes = widget.spots.map((spot) => spot.latitude);
+    final longitudes = widget.spots.map((spot) => spot.longitude);
+    final latSpan =
+        (latitudes.reduce((a, b) => a > b ? a : b) -
+                latitudes.reduce((a, b) => a < b ? a : b))
+            .abs();
+    final lngSpan =
+        (longitudes.reduce((a, b) => a > b ? a : b) -
+                longitudes.reduce((a, b) => a < b ? a : b))
+            .abs();
+    final span = (latSpan > lngSpan ? latSpan : lngSpan) * 111000;
+    if (span > 10000) return 10;
+    if (span > 5000) return 11;
+    if (span > 2000) return 12;
+    if (span > 500) return 14;
+    return 16;
+  }
+
+  Set<Marker> _markers() {
+    final markers = <Marker>{};
+    for (var i = 0; i < widget.spots.length; i++) {
+      final spot = widget.spots[i];
+      final selected = spot.id == widget.selectedLocationSpotId;
+      markers.add(
+        Marker(
+          markerId: MarkerId(spot.id ?? 'spot-$i'),
+          position: LatLng(spot.latitude, spot.longitude),
+          infoWindow: InfoWindow(
+            title: spot.name,
+            snippet:
+                spot.spotSourceName ?? spot.spotSource ?? 'Native parkour.spot',
+          ),
+          icon: selected
+              ? (_selectedPinIcon ?? BitmapDescriptor.defaultMarker)
+              : (_normalPinIcon ?? BitmapDescriptor.defaultMarker),
+          anchor: const Offset(0.5, 1.0),
+          zIndexInt: selected ? 10 + i : i,
+        ),
+      );
+    }
+    return markers;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: SizedBox(
+        height: widget.height,
+        child: Stack(
+          children: [
+            GoogleMap(
+              key: ValueKey(
+                'duplicate_cluster_${widget.spots.map((spot) => spot.id).join('_')}_${widget.selectedLocationSpotId ?? ''}',
+              ),
+              initialCameraPosition: CameraPosition(
+                target: _cameraTarget,
+                zoom: _cameraZoom,
+              ),
+              mapType: _isSatelliteView ? MapType.hybrid : MapType.normal,
+              markers: _markers(),
+              zoomControlsEnabled: false,
+              myLocationButtonEnabled: false,
+              mapToolbarEnabled: false,
+              webCameraControlEnabled: false,
+              liteModeEnabled: kIsWeb,
+              compassEnabled: false,
+              tiltGesturesEnabled: false,
+            ),
+            Positioned(
+              bottom: 8,
+              right: 8,
+              child: FloatingActionButton(
+                heroTag: 'duplicateClusterMapType_${widget.spots.length}',
+                mini: true,
+                tooltip: _isSatelliteView
+                    ? 'Switch to Map'
+                    : 'Switch to Hybrid',
+                onPressed: () {
+                  setState(() => _isSatelliteView = !_isSatelliteView);
+                },
+                child: Icon(_isSatelliteView ? Icons.map : Icons.terrain),
+              ),
+            ),
+            if (widget.spots.length > 1)
+              Positioned(
+                left: 8,
+                bottom: 8,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surface.withValues(alpha: 0.92),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: theme.colorScheme.outline.withValues(alpha: 0.35),
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 6,
+                    ),
+                    child: Text(
+                      '${widget.spots.length} cluster pins · highlighted pin supplies preview location',
+                      style: theme.textTheme.labelSmall,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/admin/duplicate_spots_results_screen.dart
+++ b/lib/screens/admin/duplicate_spots_results_screen.dart
@@ -100,6 +100,8 @@ class _DuplicateSpotsResultsScreenState
           final pairsFound = stats['pairsFound'] as int? ?? 0;
           final spotsChecked = stats['spotsChecked'] as int? ?? 0;
           final sourceName = data['sourceName'] as String? ?? 'Unknown';
+          final pairResolutions =
+              data['pairResolutions'] as Map<String, dynamic>? ?? {};
 
           // Load collapsed pairs from Firestore if available and runId changed
           if (_lastLoadedRunId != widget.runId) {
@@ -136,6 +138,7 @@ class _DuplicateSpotsResultsScreenState
             sourceName: sourceName,
             pairsFound: pairsFound,
             spotsChecked: spotsChecked,
+            pairResolutions: pairResolutions,
           );
         },
       ),
@@ -147,6 +150,7 @@ class _DuplicateSpotsResultsScreenState
     required String sourceName,
     required int pairsFound,
     required int spotsChecked,
+    required Map<String, dynamic> pairResolutions,
   }) {
     // Filter pairs based on hideCheckedPairs setting, maintaining original order.
     final List<Map<String, dynamic>> displayPairs = [];
@@ -211,6 +215,9 @@ class _DuplicateSpotsResultsScreenState
         final spot2 = pair['spot2'] as Map<String, dynamic>;
         final distanceMeters = pair['distanceMeters'] as int? ?? 0;
         final isCollapsed = _collapsedPairs.contains(index);
+        final resolution =
+            pairResolutions[index.toString()] as Map<String, dynamic>?;
+        final isResolved = resolution?['status'] == 'resolved_to_native';
         final colorScheme = Theme.of(context).colorScheme;
 
         return Card(
@@ -268,13 +275,27 @@ class _DuplicateSpotsResultsScreenState
                             ),
                             const SizedBox(width: 4),
                             Text(
-                              '${distanceMeters}m apart',
+                              isResolved
+                                  ? 'Resolved · ${distanceMeters}m apart'
+                                  : '${distanceMeters}m apart',
                               style: TextStyle(
                                 color: colorScheme.onSecondaryContainer,
                               ),
                             ),
                           ],
                         ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    FilledButton.tonalIcon(
+                      onPressed: () {
+                        context.push(
+                          '/moderator/duplicate-spots/${widget.runId}/pair/$index',
+                        );
+                      },
+                      icon: const Icon(Icons.merge_type, size: 18),
+                      label: Text(
+                        isResolved ? 'View resolution' : 'Review cluster',
                       ),
                     ),
                   ],
@@ -350,7 +371,7 @@ class _DuplicateSpotsResultsScreenState
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Review each pair of spots to determine if they are duplicates. Click on a spot card to view its details, or use the location icon to locate it on the map. Check the checkbox when you\'ve reviewed a pair to mark it as checked. Use the "Hide checked" toggle to focus on pairs that still need review.',
+                  'Review each pair of spots to determine if they are duplicates. Use "Review cluster" to compare the full nearby cluster, choose what data to keep, and create one native spot. Check the checkbox when you\'ve reviewed a pair to mark it as checked. Use the "Hide checked" toggle to focus on pairs that still need review.',
                   style: TextStyle(
                     color: colorScheme.onPrimaryContainer,
                     fontSize: 12,

--- a/lib/services/spot_service.dart
+++ b/lib/services/spot_service.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:math';
 import '../models/spot.dart';
 import '../models/rating.dart';
+import '../utils/duplicate_spot_resolution_utils.dart';
 import '../utils/image_preparation.dart';
 import '../utils/image_url_utils.dart';
 import 'audit_log_service.dart';
@@ -1720,6 +1721,255 @@ class SpotService extends ChangeNotifier {
     } catch (e) {
       debugPrint('Error getting duplicates of spot: $e');
       return [];
+    }
+  }
+
+  Future<List<Spot>> getNearbyDuplicateCandidates(
+    Spot spot, {
+    int maxDistanceMeters = 50,
+    int limit = 50,
+  }) async {
+    final spotId = spot.id;
+    if (spotId == null) return [];
+
+    try {
+      final bounds = boundsForRadiusMeters(
+        latitude: spot.latitude,
+        longitude: spot.longitude,
+        radiusMeters: maxDistanceMeters,
+      );
+
+      Query query = _firestore.collection('spots');
+      if ((spot.countryCode?.isNotEmpty ?? false) &&
+          (spot.city?.isNotEmpty ?? false)) {
+        query = query
+            .where('countryCode', isEqualTo: spot.countryCode)
+            .where('city', isEqualTo: spot.city)
+            .where('duplicateOf', isEqualTo: null)
+            .where('hidden', isEqualTo: false);
+      }
+
+      final snapshot = await query
+          .where('latitude', isGreaterThanOrEqualTo: bounds['minLat'])
+          .where('latitude', isLessThanOrEqualTo: bounds['maxLat'])
+          .limit(limit)
+          .get();
+
+      final candidates = <Spot>[];
+      for (final doc in snapshot.docs) {
+        if (doc.id == spotId) continue;
+        final candidate = Spot.fromFirestore(doc);
+        if (candidate.hidden || candidate.duplicateOf != null) continue;
+        if (candidate.longitude < bounds['minLng']! ||
+            candidate.longitude > bounds['maxLng']!) {
+          continue;
+        }
+        final distance = distanceMeters(
+          spot.latitude,
+          spot.longitude,
+          candidate.latitude,
+          candidate.longitude,
+        );
+        if (distance <= maxDistanceMeters) {
+          candidates.add(candidate);
+        }
+      }
+
+      candidates.sort((a, b) {
+        final aDistance = distanceMeters(
+          spot.latitude,
+          spot.longitude,
+          a.latitude,
+          a.longitude,
+        );
+        final bDistance = distanceMeters(
+          spot.latitude,
+          spot.longitude,
+          b.latitude,
+          b.longitude,
+        );
+        return aDistance.compareTo(bDistance);
+      });
+      return candidates;
+    } catch (e) {
+      debugPrint('Error loading nearby duplicate candidates: $e');
+      return [];
+    }
+  }
+
+  Future<List<Spot>> findDuplicateClusterFromSeeds(
+    Iterable<String> seedSpotIds, {
+    int maxDistanceMeters = 50,
+  }) async {
+    final spotsById = <String, Spot>{};
+    final queue = <Spot>[];
+
+    Future<void> addSpot(Spot? spot) async {
+      final id = spot?.id;
+      if (spot == null || id == null || spotsById.containsKey(id)) return;
+      spotsById[id] = spot;
+      queue.add(spot);
+    }
+
+    for (final spotId in seedSpotIds.toSet()) {
+      await addSpot(await getSpotById(spotId));
+    }
+
+    while (queue.isNotEmpty) {
+      final current = queue.removeAt(0);
+      final currentId = current.id;
+      if (currentId == null) continue;
+
+      for (final linkedDuplicate in await getDuplicatesOfSpot(currentId)) {
+        await addSpot(linkedDuplicate);
+      }
+
+      for (final nearby in await getNearbyDuplicateCandidates(
+        current,
+        maxDistanceMeters: maxDistanceMeters,
+      )) {
+        await addSpot(nearby);
+      }
+    }
+
+    final spots = spotsById.values.toList();
+    spots.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    return spots;
+  }
+
+  Future<String?> resolveDuplicateClusterToNative({
+    required List<Spot> clusterSpots,
+    required Spot previewSpot,
+    required String userId,
+    required String userName,
+    String? runId,
+    List<int> resolvedPairIndices = const [],
+    String? reportId,
+    String? notes,
+  }) async {
+    final memberIds = clusterSpots
+        .map((spot) => spot.id)
+        .whereType<String>()
+        .toSet();
+    if (memberIds.length < 2) {
+      _error = 'At least two spots are required to resolve a duplicate cluster';
+      notifyListeners();
+      return null;
+    }
+
+    try {
+      _isLoading = true;
+      _error = null;
+      notifyListeners();
+
+      final duplicateIdsToUpdate = <String>{...memberIds};
+      for (final memberId in memberIds) {
+        final linkedDuplicates = await getDuplicatesOfSpot(memberId);
+        duplicateIdsToUpdate.addAll(
+          linkedDuplicates.map((spot) => spot.id).whereType<String>(),
+        );
+      }
+
+      final nativeRef = _firestore.collection('spots').doc();
+      final now = DateTime.now();
+      final nativeSpot = Spot(
+        name: previewSpot.name,
+        description: previewSpot.description,
+        latitude: previewSpot.latitude,
+        longitude: previewSpot.longitude,
+        address: previewSpot.address,
+        city: previewSpot.city,
+        countryCode: previewSpot.countryCode,
+        imageUrls: previewSpot.imageUrls,
+        youtubeVideoIds: previewSpot.youtubeVideoIds,
+        createdBy: userId,
+        createdByName: userName,
+        createdAt: now,
+        updatedAt: now,
+        averageRating: 0,
+        ratingCount: 0,
+        wilsonLowerBound: 0,
+        ranking: previewSpot.ranking ?? Random().nextDouble(),
+        spotAccess: previewSpot.spotAccess,
+        spotFeatures: previewSpot.spotFeatures,
+        spotFacilities: previewSpot.spotFacilities,
+        goodFor: previewSpot.goodFor,
+        duplicateOf: null,
+        hidden: false,
+        createdFromCreateNative: true,
+      );
+
+      final batch = _firestore.batch();
+      batch.set(nativeRef, nativeSpot.toFirestore());
+      for (final duplicateId in duplicateIdsToUpdate) {
+        batch.update(_firestore.collection('spots').doc(duplicateId), {
+          'duplicateOf': nativeRef.id,
+          'updatedAt': FieldValue.serverTimestamp(),
+        });
+      }
+
+      if (runId != null) {
+        final resolution = {
+          'status': 'resolved_to_native',
+          'nativeSpotId': nativeRef.id,
+          'clusterSpotIds': memberIds.toList()..sort(),
+          'resolvedAt': FieldValue.serverTimestamp(),
+          'resolvedBy': userId,
+          'resolvedByName': userName,
+          if (notes?.isNotEmpty ?? false) 'notes': notes,
+          if (reportId?.isNotEmpty ?? false) 'reportId': reportId,
+        };
+        final runUpdates = <String, dynamic>{
+          'collapsedPairs': FieldValue.arrayUnion(resolvedPairIndices),
+        };
+        for (final pairIndex in resolvedPairIndices) {
+          runUpdates['pairResolutions.$pairIndex'] = resolution;
+        }
+        batch.update(
+          _firestore.collection('duplicateDetectionResults').doc(runId),
+          runUpdates,
+        );
+      }
+
+      await batch.commit();
+
+      for (final duplicateId in duplicateIdsToUpdate) {
+        await _auditLogService.logSpotMarkedAsDuplicate(
+          spotId: duplicateId,
+          originalSpotId: nativeRef.id,
+          userId: userId,
+          userName: userName,
+          reportId: reportId,
+          notes: notes,
+        );
+      }
+      await _auditLogService.logSpotEdit(
+        spotId: nativeRef.id,
+        userId: userId,
+        userName: userName,
+        reportId: reportId,
+        notes: notes,
+        changes: {
+          'createdFromDuplicateCluster': {
+            'from': null,
+            'to': memberIds.toList()..sort(),
+          },
+        },
+        metadata: {
+          'sourceSpotIds': memberIds.toList()..sort(),
+          'resolvedPairIndices': resolvedPairIndices,
+        },
+      );
+
+      _isLoading = false;
+      notifyListeners();
+      return nativeRef.id;
+    } catch (e) {
+      _error = 'Failed to resolve duplicate cluster: $e';
+      debugPrint('Error resolving duplicate cluster: $e');
+      _isLoading = false;
+      notifyListeners();
+      return null;
     }
   }
 

--- a/lib/utils/duplicate_spot_resolution_utils.dart
+++ b/lib/utils/duplicate_spot_resolution_utils.dart
@@ -1,0 +1,191 @@
+import 'dart:math' as math;
+
+import '../models/spot.dart';
+
+class DuplicateSpotPairRef {
+  const DuplicateSpotPairRef({
+    required this.spot1Id,
+    required this.spot2Id,
+    required this.distanceMeters,
+  });
+
+  final String spot1Id;
+  final String spot2Id;
+  final int distanceMeters;
+
+  static DuplicateSpotPairRef? fromMap(Map<String, dynamic> pair) {
+    final spot1 = pair['spot1'] as Map<String, dynamic>?;
+    final spot2 = pair['spot2'] as Map<String, dynamic>?;
+    final spot1Id = spot1?['id'] as String?;
+    final spot2Id = spot2?['id'] as String?;
+    if (spot1Id == null || spot2Id == null) return null;
+    return DuplicateSpotPairRef(
+      spot1Id: spot1Id,
+      spot2Id: spot2Id,
+      distanceMeters: (pair['distanceMeters'] as num?)?.round() ?? 0,
+    );
+  }
+}
+
+Set<String> buildConnectedDuplicateSpotIds({
+  required List<DuplicateSpotPairRef> pairs,
+  required int startIndex,
+  int maxDistanceMeters = 50,
+}) {
+  if (startIndex < 0 || startIndex >= pairs.length) return <String>{};
+
+  final startPair = pairs[startIndex];
+  final cluster = <String>{startPair.spot1Id, startPair.spot2Id};
+  var changed = true;
+
+  while (changed) {
+    changed = false;
+    for (final pair in pairs) {
+      if (pair.distanceMeters > maxDistanceMeters) continue;
+      final touchesCluster =
+          cluster.contains(pair.spot1Id) || cluster.contains(pair.spot2Id);
+      if (!touchesCluster) continue;
+      changed = cluster.add(pair.spot1Id) || changed;
+      changed = cluster.add(pair.spot2Id) || changed;
+    }
+  }
+
+  return cluster;
+}
+
+List<int> findPairIndicesWithinCluster({
+  required List<DuplicateSpotPairRef> pairs,
+  required Set<String> clusterSpotIds,
+  int maxDistanceMeters = 50,
+}) {
+  final indices = <int>[];
+  for (var i = 0; i < pairs.length; i++) {
+    final pair = pairs[i];
+    if (pair.distanceMeters <= maxDistanceMeters &&
+        clusterSpotIds.contains(pair.spot1Id) &&
+        clusterSpotIds.contains(pair.spot2Id)) {
+      indices.add(i);
+    }
+  }
+  return indices;
+}
+
+double distanceMeters(double lat1, double lon1, double lat2, double lon2) {
+  const earthRadiusMeters = 6371000.0;
+  final dLat = _degreesToRadians(lat2 - lat1);
+  final dLon = _degreesToRadians(lon2 - lon1);
+  final a =
+      math.sin(dLat / 2) * math.sin(dLat / 2) +
+      math.cos(_degreesToRadians(lat1)) *
+          math.cos(_degreesToRadians(lat2)) *
+          math.sin(dLon / 2) *
+          math.sin(dLon / 2);
+  final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+  return earthRadiusMeters * c;
+}
+
+Map<String, double> boundsForRadiusMeters({
+  required double latitude,
+  required double longitude,
+  required int radiusMeters,
+}) {
+  final latOffset = radiusMeters / 111000.0;
+  final cosLat = math.cos(latitude * math.pi / 180.0).abs();
+  final lngOffset = cosLat < 0.000001 ? 180.0 : latOffset / cosLat;
+
+  return {
+    'minLat': latitude - latOffset,
+    'maxLat': latitude + latOffset,
+    'minLng': longitude - lngOffset,
+    'maxLng': longitude + lngOffset,
+  };
+}
+
+Spot buildDuplicateNativeSpotPreview({
+  required List<Spot> spots,
+  required String baseSpotId,
+  required String titleSpotId,
+  required String descriptionSpotId,
+  required String locationSpotId,
+  required String attributesSpotId,
+  required Set<String> photoSpotIds,
+  required Set<String> youtubeSpotIds,
+}) {
+  if (spots.isEmpty) {
+    throw ArgumentError.value(spots, 'spots', 'Must include at least one spot');
+  }
+
+  final baseSpot = _spotByIdOrFallback(spots, baseSpotId);
+  final titleSpot = _spotByIdOrFallback(spots, titleSpotId, baseSpot);
+  final descriptionSpot = _spotByIdOrFallback(
+    spots,
+    descriptionSpotId,
+    baseSpot,
+  );
+  final locationSpot = _spotByIdOrFallback(spots, locationSpotId, baseSpot);
+  final attributesSpot = _spotByIdOrFallback(spots, attributesSpotId, baseSpot);
+
+  final imageUrls = _dedupe(
+    spots
+        .where((spot) => photoSpotIds.contains(spot.id))
+        .expand((spot) => spot.imageUrls ?? const <String>[]),
+  );
+  final youtubeIds = _dedupe(
+    spots
+        .where((spot) => youtubeSpotIds.contains(spot.id))
+        .expand((spot) => spot.youtubeVideoIds ?? const <String>[]),
+  );
+
+  return Spot(
+    name: titleSpot.name.isNotEmpty ? titleSpot.name : baseSpot.name,
+    description: descriptionSpot.description.isNotEmpty
+        ? descriptionSpot.description
+        : baseSpot.description,
+    latitude: locationSpot.latitude,
+    longitude: locationSpot.longitude,
+    address: locationSpot.address,
+    city: locationSpot.city,
+    countryCode: locationSpot.countryCode,
+    imageUrls: imageUrls.isEmpty ? null : imageUrls,
+    youtubeVideoIds: youtubeIds.isEmpty ? null : youtubeIds,
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+    averageRating: 0,
+    ratingCount: 0,
+    wilsonLowerBound: 0,
+    ranking: baseSpot.ranking,
+    spotAccess: attributesSpot.spotAccess,
+    spotFeatures: _copyList(attributesSpot.spotFeatures),
+    spotFacilities: attributesSpot.spotFacilities == null
+        ? null
+        : Map<String, String>.from(attributesSpot.spotFacilities!),
+    goodFor: _copyList(attributesSpot.goodFor),
+    duplicateOf: null,
+    hidden: false,
+    createdFromCreateNative: true,
+  );
+}
+
+Spot _spotByIdOrFallback(List<Spot> spots, String id, [Spot? fallback]) {
+  for (final spot in spots) {
+    if (spot.id == id) return spot;
+  }
+  return fallback ?? spots.first;
+}
+
+List<String>? _copyList(List<String>? values) {
+  return values == null ? null : List<String>.from(values);
+}
+
+List<String> _dedupe(Iterable<String> values) {
+  final seen = <String>{};
+  final result = <String>[];
+  for (final value in values) {
+    if (value.trim().isEmpty || seen.contains(value)) continue;
+    seen.add(value);
+    result.add(value);
+  }
+  return result;
+}
+
+double _degreesToRadians(double degrees) => degrees * math.pi / 180.0;

--- a/test/utils/duplicate_spot_resolution_utils_test.dart
+++ b/test/utils/duplicate_spot_resolution_utils_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/models/spot.dart';
+import 'package:parkour_spot/utils/duplicate_spot_resolution_utils.dart';
+
+void main() {
+  group('duplicate spot resolution utils', () {
+    test('buildConnectedDuplicateSpotIds follows recursive nearby pairs', () {
+      final pairs = [
+        const DuplicateSpotPairRef(
+          spot1Id: 'a',
+          spot2Id: 'b',
+          distanceMeters: 12,
+        ),
+        const DuplicateSpotPairRef(
+          spot1Id: 'b',
+          spot2Id: 'c',
+          distanceMeters: 48,
+        ),
+        const DuplicateSpotPairRef(
+          spot1Id: 'c',
+          spot2Id: 'd',
+          distanceMeters: 51,
+        ),
+      ];
+
+      final cluster = buildConnectedDuplicateSpotIds(
+        pairs: pairs,
+        startIndex: 0,
+      );
+
+      expect(cluster, {'a', 'b', 'c'});
+    });
+
+    test('findPairIndicesWithinCluster returns resolved in-cluster pairs', () {
+      final pairs = [
+        const DuplicateSpotPairRef(
+          spot1Id: 'a',
+          spot2Id: 'b',
+          distanceMeters: 12,
+        ),
+        const DuplicateSpotPairRef(
+          spot1Id: 'b',
+          spot2Id: 'c',
+          distanceMeters: 48,
+        ),
+        const DuplicateSpotPairRef(
+          spot1Id: 'c',
+          spot2Id: 'd',
+          distanceMeters: 40,
+        ),
+      ];
+
+      final indices = findPairIndicesWithinCluster(
+        pairs: pairs,
+        clusterSpotIds: {'a', 'b', 'c'},
+      );
+
+      expect(indices, [0, 1]);
+    });
+
+    test('buildDuplicateNativeSpotPreview merges selected sources', () {
+      final spotA = Spot(
+        id: 'a',
+        name: 'Title A',
+        description: 'Description A',
+        latitude: 52,
+        longitude: 4,
+        imageUrls: const ['photo-a', 'shared-photo'],
+        youtubeVideoIds: const ['video-a'],
+        spotFeatures: const ['walls_low'],
+      );
+      final spotB = Spot(
+        id: 'b',
+        name: 'Title B',
+        description: 'Description B',
+        latitude: 53,
+        longitude: 5,
+        address: 'Address B',
+        city: 'Rotterdam',
+        countryCode: 'NL',
+        imageUrls: const ['shared-photo', 'photo-b'],
+        youtubeVideoIds: const ['video-b'],
+        spotAccess: 'public',
+        spotFeatures: const ['bars_low'],
+        goodFor: const ['vaults'],
+      );
+
+      final preview = buildDuplicateNativeSpotPreview(
+        spots: [spotA, spotB],
+        baseSpotId: 'a',
+        titleSpotId: 'b',
+        descriptionSpotId: 'a',
+        locationSpotId: 'b',
+        attributesSpotId: 'b',
+        photoSpotIds: {'a', 'b'},
+        youtubeSpotIds: {'b'},
+      );
+
+      expect(preview.name, 'Title B');
+      expect(preview.description, 'Description A');
+      expect(preview.latitude, 53);
+      expect(preview.longitude, 5);
+      expect(preview.address, 'Address B');
+      expect(preview.imageUrls, ['photo-a', 'shared-photo', 'photo-b']);
+      expect(preview.youtubeVideoIds, ['video-b']);
+      expect(preview.spotAccess, 'public');
+      expect(preview.spotFeatures, ['bars_low']);
+      expect(preview.goodFor, ['vaults']);
+      expect(preview.spotSource, isNull);
+      expect(preview.duplicateOf, isNull);
+      expect(preview.createdFromCreateNative, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds a moderator duplicate cluster review route from duplicate spot results.
- Shows cluster spot details, a multi-pin map with satellite toggle, merge-source selectors, and a native spot preview.
- Adds batch resolution support that creates a native spot, marks cluster members as duplicates, and records resolved detection pairs.
- Adds focused tests for recursive cluster and preview merge logic.

### Walkthrough
[duplicate_cluster_resolution_flow.mp4](https://cursor.com/agents/bc-b23f756b-ac3b-4a92-99ed-6b882298dc69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fduplicate_cluster_resolution_flow.mp4)
[Duplicate cluster preview](https://cursor.com/agents/bc-b23f756b-ac3b-4a92-99ed-6b882298dc69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fduplicate_cluster_resolution_preview.webp)
[Duplicate cluster resolved](https://cursor.com/agents/bc-b23f756b-ac3b-4a92-99ed-6b882298dc69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fduplicate_cluster_resolution_success.webp)

### Testing
- `flutter analyze` (repository still reports pre-existing info-level diagnostics; no errors in changed files)
- `flutter test test/utils/duplicate_spot_resolution_utils_test.dart`
- `flutter test`
- Manual emulator walkthrough using seeded moderator duplicate cluster

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b23f756b-ac3b-4a92-99ed-6b882298dc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b23f756b-ac3b-4a92-99ed-6b882298dc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

