### PR TITLE
Show badge counts for new moderator report queues

### DIFF
--- a/lib/screens/moderator/moderator_tools_screen.dart
+++ b/lib/screens/moderator/moderator_tools_screen.dart
@@ -3,6 +3,8 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 import '../../services/auth_service.dart';
+import '../../services/event_report_service.dart';
+import '../../services/spot_report_service.dart';
 import '../../widgets/page_scaffold.dart';
 
 class ModeratorToolsScreen extends StatelessWidget {
@@ -119,28 +121,36 @@ class ModeratorToolsScreen extends StatelessWidget {
       body: ListView(
         padding: EdgeInsets.zero,
         children: [
-          Card(
-            child: ListTile(
-              leading: const Icon(Icons.report_problem),
-              title: const Text('Spot Report Queue'),
-              subtitle: const Text(
-                'Work through new spot reports, keeping moderators aligned on progress',
-              ),
-              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-              onTap: () => context.push('/moderator/reports'),
-            ),
+          StreamBuilder<int>(
+            initialData: context.read<SpotReportService>().newReportCount,
+            stream: context.read<SpotReportService>().watchNewReportCount(),
+            builder: (context, snapshot) {
+              final newCount = snapshot.data ?? 0;
+              return _buildQueueTile(
+                icon: Icons.report_problem,
+                title: 'Spot Report Queue',
+                subtitle:
+                    'Work through new spot reports, keeping moderators aligned on progress',
+                badgeCount: newCount > 0 ? newCount : null,
+                onTap: () => context.push('/moderator/reports'),
+              );
+            },
           ),
           const SizedBox(height: 8),
-          Card(
-            child: ListTile(
-              leading: const Icon(Icons.event_note_outlined),
-              title: const Text('Event Report Queue'),
-              subtitle: const Text(
-                'Review user-submitted event proposals and publish approved events',
-              ),
-              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-              onTap: () => context.push('/moderator/event-reports'),
-            ),
+          StreamBuilder<int>(
+            initialData: context.read<EventReportService>().newReportCount,
+            stream: context.read<EventReportService>().watchNewReportCount(),
+            builder: (context, snapshot) {
+              final newCount = snapshot.data ?? 0;
+              return _buildQueueTile(
+                icon: Icons.event_note_outlined,
+                title: 'Event Report Queue',
+                subtitle:
+                    'Review user-submitted event proposals and publish approved events',
+                badgeCount: newCount > 0 ? newCount : null,
+                onTap: () => context.push('/moderator/event-reports'),
+              );
+            },
           ),
           const SizedBox(height: 8),
           Card(
@@ -155,6 +165,31 @@ class ModeratorToolsScreen extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildQueueTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback onTap,
+    int? badgeCount,
+  }) {
+    Widget leading = Icon(icon);
+    if (badgeCount != null && badgeCount > 0) {
+      leading = Badge(
+        label: Text('$badgeCount'),
+        child: leading,
+      );
+    }
+    return Card(
+      child: ListTile(
+        leading: leading,
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+        onTap: onTap,
       ),
     );
   }

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -7,6 +7,8 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:web/web.dart' as web;
 import 'package:lottie/lottie.dart';
 import '../../services/auth_service.dart';
+import '../../services/event_report_service.dart';
+import '../../services/spot_report_service.dart';
 import '../../services/user_notification_service.dart';
 import '../../services/mobile_detection_service.dart';
 import '../../widgets/custom_button.dart';
@@ -392,15 +394,45 @@ class _ProfileScreenState extends State<ProfileScreen>
                             ),
                             if (authService.isModerator ||
                                 authService.isAdmin) ...[
-                              _buildActionTile(
-                                context,
-                                Icons.shield,
-                                l10n.profileModeratorToolsTitle,
-                                l10n.profileModeratorToolsSubtitle,
-                                () {
-                                  // Use go (not push) so Explore/SearchScreen dispose and
-                                  // release Firestore listeners before moderator flows.
-                                  context.go('/moderator');
+                              StreamBuilder<int>(
+                                initialData: Provider.of<SpotReportService>(
+                                  context,
+                                  listen: false,
+                                ).newReportCount,
+                                stream: Provider.of<SpotReportService>(
+                                  context,
+                                  listen: false,
+                                ).watchNewReportCount(),
+                                builder: (context, spotSnapshot) {
+                                  final spotNew = spotSnapshot.data ?? 0;
+                                  return StreamBuilder<int>(
+                                    initialData:
+                                        Provider.of<EventReportService>(
+                                      context,
+                                      listen: false,
+                                    ).newReportCount,
+                                    stream: Provider.of<EventReportService>(
+                                      context,
+                                      listen: false,
+                                    ).watchNewReportCount(),
+                                    builder: (context, eventSnapshot) {
+                                      final totalNew = spotNew +
+                                          (eventSnapshot.data ?? 0);
+                                      return _buildActionTile(
+                                        context,
+                                        Icons.shield,
+                                        l10n.profileModeratorToolsTitle,
+                                        l10n.profileModeratorToolsSubtitle,
+                                        () {
+                                          // Use go (not push) so Explore/SearchScreen dispose and
+                                          // release Firestore listeners before moderator flows.
+                                          context.go('/moderator');
+                                        },
+                                        badgeCount:
+                                            totalNew > 0 ? totalNew : null,
+                                      );
+                                    },
+                                  );
                                 },
                               ),
                             ],

--- a/lib/services/event_report_service.dart
+++ b/lib/services/event_report_service.dart
@@ -527,17 +527,32 @@ class EventReportService {
   }
 
   Stream<List<EventReport>>? _eventReportsStream;
+  Stream<int>? _newReportCountStream;
+  List<EventReport>? _latestEventReports;
+
+  /// Count of reports with status [statuses.first] ("New"); used as [StreamBuilder.initialData].
+  int get newReportCount =>
+      _latestEventReports?.where((r) => r.status == statuses.first).length ?? 0;
 
   Stream<List<EventReport>> watchEventReports() {
     return _eventReportsStream ??= _firestore
         .collection('eventReports')
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map(
-          (snapshot) => snapshot.docs
+        .map((snapshot) {
+          final reports = snapshot.docs
               .map((doc) => EventReport.fromSnapshot(doc))
-              .toList(growable: false),
-        );
+              .toList(growable: false);
+          _latestEventReports = reports;
+          return reports;
+        });
+  }
+
+  /// Streams the number of event reports with status [statuses.first] ("New").
+  Stream<int> watchNewReportCount() {
+    return _newReportCountStream ??= watchEventReports().map(
+      (reports) => reports.where((r) => r.status == statuses.first).length,
+    );
   }
 
   /// Move staging photos from [eventSuggestions/] to [events/] with resize.

--- a/lib/services/spot_report_service.dart
+++ b/lib/services/spot_report_service.dart
@@ -14,6 +14,12 @@ class SpotReportService {
 
   /// Shared listener for all UI subscribers (avoids duplicate Firestore targets).
   Stream<List<SpotReport>>? _spotReportsStream;
+  Stream<int>? _newReportCountStream;
+  List<SpotReport>? _latestSpotReports;
+
+  /// Count of reports with status [statuses.first] ("New"); used as [StreamBuilder.initialData].
+  int get newReportCount =>
+      _latestSpotReports?.where((r) => r.status == statuses.first).length ?? 0;
 
   /// Default categories shown to the user when reporting a spot.
   static const List<String> defaultCategories = <String>[
@@ -343,11 +349,20 @@ class SpotReportService {
         .collection('spotReports')
         .orderBy('createdAt', descending: false)
         .snapshots()
-        .map(
-          (snapshot) => snapshot.docs
+        .map((snapshot) {
+          final reports = snapshot.docs
               .map((doc) => SpotReport.fromSnapshot(doc))
-              .toList(growable: false),
-        );
+              .toList(growable: false);
+          _latestSpotReports = reports;
+          return reports;
+        });
+  }
+
+  /// Streams the number of spot reports with status [statuses.first] ("New").
+  Stream<int> watchNewReportCount() {
+    return _newReportCountStream ??= watchSpotReports().map(
+      (reports) => reports.where((r) => r.status == statuses.first).length,
+    );
   }
 
   /// Gets all spot reports for a specific spot.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moderators now see badge counts for pending report queues, matching the existing notifications pattern on the Account tab.

- **Account tab → Moderator Tools**: shows a combined count of Spot Reports and Event Reports with status `New`
- **Moderator Tools screen**: shows individual counts on Spot Report Queue and Event Report Queue rows

## Implementation

- Added `newReportCount` and `watchNewReportCount()` to `SpotReportService` and `EventReportService`, derived from the existing Firestore report streams
- Wired `StreamBuilder` badges in `profile_screen.dart` and `moderator_tools_screen.dart` using the same `Badge` widget pattern as notifications

## Test plan

- [ ] Sign in as `moderator@parkour.spot` with seed data that includes new spot/event reports
- [ ] Verify Account tab shows a badge on Moderator Tools when any new reports exist
- [ ] Open Moderator Tools and confirm each queue row shows its own new-report count
- [ ] Mark reports as Reviewing/Done and confirm badges update in real time
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9da6f3c1-a1d4-4d2f-b38a-751b848fad99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9da6f3c1-a1d4-4d2f-b38a-751b848fad99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

