### PR TITLE
Fix moderators unable to mark external events as duplicates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -127,6 +127,25 @@ service cloud.firestore {
           eventCommonShape(request.resource.data);
       }
 
+      // Staff may set or clear duplicateOf on any event (including external imports)
+      // without granting full edit access to imported calendar data.
+      function eventDuplicateOfOk(data) {
+        return !('duplicateOf' in data) || data.duplicateOf == null ||
+          (data.duplicateOf is string &&
+            data.duplicateOf.size() > 0 &&
+            data.duplicateOf.size() <= 200);
+      }
+
+      function eventDuplicateStatusUpdateShape() {
+        return request.auth != null &&
+          request.resource.data.createdBy == resource.data.createdBy &&
+          request.resource.data.createdAt == resource.data.createdAt &&
+          request.resource.data.diff(resource.data).affectedKeys()
+            .hasOnly(['duplicateOf', 'updatedAt']) &&
+          eventUpdatedAtOk(request.resource.data) &&
+          eventDuplicateOfOk(request.resource.data);
+      }
+
       // Native events have no external calendar source id.
       function eventIsNative() {
         return !('eventSourceId' in resource.data) ||
@@ -137,9 +156,13 @@ service cloud.firestore {
 
       allow read: if true;
       allow create: if requestingUserIsStaff() && eventCreateShape();
-      allow update: if eventUpdateShape() && (
-        requestingUserIsAdmin() ||
-        (requestingUserIsModerator() && eventIsNative())
+      allow update: if (
+        eventUpdateShape() && (
+          requestingUserIsAdmin() ||
+          (requestingUserIsModerator() && eventIsNative())
+        )
+      ) || (
+        eventDuplicateStatusUpdateShape() && requestingUserIsStaff()
       );
       allow delete: if requestingUserIsAdmin();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Moderators could see the "Mark as duplicate" menu item and complete the selection dialog, but the Firestore write failed with permission denied when marking **external/imported** events as duplicates of a native event.

## Root cause

`firestore.rules` only allowed moderators to update **native** events (`eventIsNative()`). Marking a duplicate updates the duplicate event document — which is often an imported calendar event — so moderators were blocked while admins were not.

This also affected **Create native event**, which creates a native copy and then marks the original external event as a duplicate.

## Fix

Add a narrow `eventDuplicateStatusUpdateShape()` rule that allows staff (moderators and admins) to update **only** `duplicateOf` and `updatedAt` on any event. Full edits to external events remain admin-only.

## Verification

- Firestore rules compile and load in the emulator
- Rules unit test confirmed:
  - Moderator can set `duplicateOf` on an external event
  - Moderator cannot change other fields (e.g. title) on external events
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69346e76-7fcb-45bb-a5a8-e2022eb252fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69346e76-7fcb-45bb-a5a8-e2022eb252fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

