### PR TITLE
Fix selected spot visibility on small screens

### DIFF
--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -32,6 +32,7 @@ import '../../widgets/source_details_dialog.dart';
 import '../../config/app_config.dart';
 import '../../utils/marker_icon_utils.dart';
 import '../../utils/map_bounds_utils.dart';
+import '../../utils/map_camera_utils.dart';
 import '../../utils/location_permission_utils.dart';
 import '../../constants/spot_attributes.dart';
 import '../../l10n/app_localizations.dart';
@@ -2758,6 +2759,8 @@ class SearchScreenState extends State<SearchScreen>
   }
 
   Future<void> _locateSpot(Spot spot) async {
+    final viewport = MediaQuery.sizeOf(context);
+
     // Collapse bottom sheet if open
     if (_isBottomSheetOpen) {
       await _bottomSheetAnimationController.reverse();
@@ -2768,19 +2771,17 @@ class SearchScreenState extends State<SearchScreen>
       }
     }
 
-    // Center map on spot with fluid zoom-in (no zoom-out)
+    // Focus the spot with fluid zoom-in (no zoom-out). On small screens, the
+    // final pixel scroll keeps the marker visible above the detail card.
     if (_mapController != null) {
-      const double desiredZoom = 15.0;
-      final double targetZoom = _lastKnownZoom < desiredZoom
-          ? desiredZoom
-          : _lastKnownZoom;
-      // Step 1: pan to target at current zoom (smoother motion)
-      await _mapController!.animateCamera(
-        CameraUpdate.newLatLng(LatLng(spot.latitude, spot.longitude)),
+      final updates = selectedSpotCameraUpdates(
+        target: LatLng(spot.latitude, spot.longitude),
+        currentZoom: _lastKnownZoom,
+        viewportWidth: viewport.width,
+        viewportHeight: viewport.height,
       );
-      // Step 2: if we need to zoom in, do that as a separate animation
-      if (_lastKnownZoom < targetZoom) {
-        await _mapController!.animateCamera(CameraUpdate.zoomTo(targetZoom));
+      for (final update in updates) {
+        await _mapController!.animateCamera(update);
       }
     }
 

--- a/lib/utils/map_camera_utils.dart
+++ b/lib/utils/map_camera_utils.dart
@@ -1,0 +1,28 @@
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+const double _mobileMapBreakpoint = 600;
+const double _selectedSpotZoom = 15;
+
+/// Camera updates used when locating a spot from Explore.
+///
+/// On a narrow viewport, the final pixel scroll places the selected spot in
+/// the middle of the top half of the screen so the overlay card does not hide
+/// its marker.
+List<CameraUpdate> selectedSpotCameraUpdates({
+  required LatLng target,
+  required double currentZoom,
+  required double viewportWidth,
+  required double viewportHeight,
+}) {
+  final updates = <CameraUpdate>[CameraUpdate.newLatLng(target)];
+
+  if (currentZoom < _selectedSpotZoom) {
+    updates.add(CameraUpdate.zoomTo(_selectedSpotZoom));
+  }
+
+  if (viewportWidth < _mobileMapBreakpoint) {
+    updates.add(CameraUpdate.scrollBy(0, viewportHeight / 4));
+  }
+
+  return updates;
+}

--- a/test/utils/map_camera_utils_test.dart
+++ b/test/utils/map_camera_utils_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:parkour_spot/utils/map_camera_utils.dart';
+
+void main() {
+  group('selectedSpotCameraUpdates', () {
+    const target = LatLng(48.6271, 2.4311);
+
+    test(
+      'places a selected entity in the middle of the top half on mobile',
+      () {
+        final updates = selectedSpotCameraUpdates(
+          target: target,
+          currentZoom: 12,
+          viewportWidth: 390,
+          viewportHeight: 667,
+        );
+
+        expect(updates.map(_type), ['newLatLng', 'zoomTo', 'scrollBy']);
+
+        final scroll = updates.last.toJson() as List<Object>;
+        expect(scroll[1], 0);
+        expect(scroll[2], closeTo(667 / 4, 0.001));
+      },
+    );
+
+    test('keeps the selected entity centered on wider screens', () {
+      final updates = selectedSpotCameraUpdates(
+        target: target,
+        currentZoom: 15,
+        viewportWidth: 900,
+        viewportHeight: 700,
+      );
+
+      expect(updates.map(_type), ['newLatLng']);
+    });
+
+    test('applies the mobile offset after any zoom animation', () {
+      final updates = selectedSpotCameraUpdates(
+        target: target,
+        currentZoom: 10,
+        viewportWidth: 599,
+        viewportHeight: 800,
+      );
+
+      expect(_type(updates.last), 'scrollBy');
+    });
+  });
+}
+
+String _type(CameraUpdate update) =>
+    (update.toJson() as List<Object>).first as String;


### PR DESCRIPTION
## Summary

- Keep the selected spot marker visible above the detail card on small screens
- Preserve the existing centered behavior on wider screens
- Add regression tests for the camera movement sequence

## Problem

When navigating to a spot on a small screen, the map centered the selected
location in the viewport. The spot detail card then covered the marker, making
the selected location impossible to see.

## Solution

On viewports narrower than 600 px, the map now applies a vertical camera offset
after panning and zooming to the spot.

The offset is based on one quarter of the viewport height, which places the
selected marker approximately in the middle of the top half of the screen.
Wider screens keep the existing centered behavior.

## Before

<img width="390" height="667" alt="image" src="https://github.com/user-attachments/assets/324cd7f8-365f-4145-a0de-9e9ad96e8d91" />


## After

<img width="390" height="667" alt="image" src="https://github.com/user-attachments/assets/1591e9eb-1b93-4929-92ef-ac7e22919e25" />


## Validation

- Added unit coverage for the mobile camera offset
- Added coverage ensuring desktop centering remains unchanged
- Added coverage ensuring the offset is applied after zooming
- Ran the complete Flutter test suite: 199 tests passed
- Ran `flutter analyze`: no errors introduced
- Manually verified at a 390x667 viewport
- Manually verified that desktop behavior remains unchanged

Closes wardweistra/Parkour.Spot#92
