### PR TITLE
Name explicit browser expectations in install prompt

### DIFF
--- a/l10n/app_de.arb
+++ b/l10n/app_de.arb
@@ -76,7 +76,7 @@
   "profileInstallBannerTitle": "Parkour·Spot-App installieren",
   "profileInstallBannerSubtitle": "Die volle App-Erfahrung nutzen",
   "profileInstallDialogTitle": "Parkour·Spot installieren",
-  "profileInstallIntro": "So installierst du Parkour·Spot auf deinem {device}:",
+  "profileInstallIntro": "Um Parkour·Spot auf deinem {device} zu installieren, öffne diese Seite in {browser} und folge diesen Schritten:",
   "profileInstallDeviceIphone": "iPhone",
   "profileInstallDeviceAndroid": "Android-Gerät",
   "profileInstallIosStep1": "Tippe unten auf den Teilen-Button",

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -509,13 +509,17 @@
   "@profileInstallDialogTitle": {
     "description": "PWA install instructions dialog title"
   },
-  "profileInstallIntro": "To install Parkour·Spot on your {device}:",
+  "profileInstallIntro": "To install Parkour·Spot on your {device}, open this page in {browser} and follow these steps:",
   "@profileInstallIntro": {
     "description": "PWA install dialog: intro before steps",
     "placeholders": {
       "device": {
         "type": "String",
         "example": "iPhone"
+      },
+      "browser": {
+        "type": "String",
+        "example": "Safari"
       }
     }
   },

--- a/l10n/app_es.arb
+++ b/l10n/app_es.arb
@@ -76,7 +76,7 @@
   "profileInstallBannerTitle": "Instala la app Parkour·Spot",
   "profileInstallBannerSubtitle": "Obtén la experiencia completa",
   "profileInstallDialogTitle": "Instalar Parkour·Spot",
-  "profileInstallIntro": "Para instalar Parkour·Spot en tu {device}:",
+  "profileInstallIntro": "Para instalar Parkour·Spot en tu {device}, abre esta página en {browser} y sigue estos pasos:",
   "profileInstallDeviceIphone": "iPhone",
   "profileInstallDeviceAndroid": "dispositivo Android",
   "profileInstallIosStep1": "Toca el botón Compartir en la parte inferior de la pantalla",

--- a/l10n/app_fr.arb
+++ b/l10n/app_fr.arb
@@ -76,7 +76,7 @@
   "profileInstallBannerTitle": "Installer l’appli Parkour·Spot",
   "profileInstallBannerSubtitle": "Profitez de l’expérience complète",
   "profileInstallDialogTitle": "Installer Parkour·Spot",
-  "profileInstallIntro": "Pour installer Parkour·Spot sur votre {device} :",
+  "profileInstallIntro": "Pour installer Parkour·Spot sur votre {device}, ouvrez cette page dans {browser}, puis suivez ces étapes :",
   "profileInstallDeviceIphone": "iPhone",
   "profileInstallDeviceAndroid": "appareil Android",
   "profileInstallIosStep1": "Appuyez sur le bouton Partager en bas de l’écran",

--- a/l10n/app_nl.arb
+++ b/l10n/app_nl.arb
@@ -117,7 +117,7 @@
   "profileInstallBannerTitle": "Installeer de Parkour·Spot-app",
   "profileInstallBannerSubtitle": "De volledige app-ervaring",
   "profileInstallDialogTitle": "Parkour·Spot installeren",
-  "profileInstallIntro": "Om Parkour·Spot op je {device} te installeren:",
+  "profileInstallIntro": "Open deze pagina in {browser} en volg deze stappen om Parkour·Spot op je {device} te installeren:",
   "profileInstallDeviceIphone": "iPhone",
   "profileInstallDeviceAndroid": "Android-apparaat",
   "profileInstallIosStep1": "Tik onderaan op de Deel-knop",

--- a/l10n/app_pt.arb
+++ b/l10n/app_pt.arb
@@ -76,7 +76,7 @@
   "profileInstallBannerTitle": "Instalar a app Parkour·Spot",
   "profileInstallBannerSubtitle": "Experiência completa da aplicação",
   "profileInstallDialogTitle": "Instalar Parkour·Spot",
-  "profileInstallIntro": "Para instalar o Parkour·Spot no seu {device}:",
+  "profileInstallIntro": "Para instalar o Parkour·Spot no seu {device}, abra esta página no {browser} e siga estes passos:",
   "profileInstallDeviceIphone": "iPhone",
   "profileInstallDeviceAndroid": "dispositivo Android",
   "profileInstallIosStep1": "Toque no botão Partilhar na parte inferior do ecrã",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -811,8 +811,8 @@ abstract class AppLocalizations {
   /// PWA install dialog: intro before steps
   ///
   /// In en, this message translates to:
-  /// **'To install Parkour·Spot on your {device}:'**
-  String profileInstallIntro(String device);
+  /// **'To install Parkour·Spot on your {device}, open this page in {browser} and follow these steps:'**
+  String profileInstallIntro(String device, String browser);
 
   /// Device name for iOS install instructions
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -430,8 +430,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileInstallDialogTitle => 'Parkour·Spot installieren';
 
   @override
-  String profileInstallIntro(String device) {
-    return 'So installierst du Parkour·Spot auf deinem $device:';
+  String profileInstallIntro(String device, String browser) {
+    return 'Um Parkour·Spot auf deinem $device zu installieren, öffne diese Seite in $browser und folge diesen Schritten:';
   }
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -424,8 +424,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileInstallDialogTitle => 'Install Parkour·Spot';
 
   @override
-  String profileInstallIntro(String device) {
-    return 'To install Parkour·Spot on your $device:';
+  String profileInstallIntro(String device, String browser) {
+    return 'To install Parkour·Spot on your $device, open this page in $browser and follow these steps:';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -427,8 +427,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileInstallDialogTitle => 'Instalar Parkour·Spot';
 
   @override
-  String profileInstallIntro(String device) {
-    return 'Para instalar Parkour·Spot en tu $device:';
+  String profileInstallIntro(String device, String browser) {
+    return 'Para instalar Parkour·Spot en tu $device, abre esta página en $browser y sigue estos pasos:';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -426,8 +426,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileInstallDialogTitle => 'Installer Parkour·Spot';
 
   @override
-  String profileInstallIntro(String device) {
-    return 'Pour installer Parkour·Spot sur votre $device :';
+  String profileInstallIntro(String device, String browser) {
+    return 'Pour installer Parkour·Spot sur votre $device, ouvrez cette page dans $browser, puis suivez ces étapes :';
   }
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -426,8 +426,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileInstallDialogTitle => 'Parkour·Spot installeren';
 
   @override
-  String profileInstallIntro(String device) {
-    return 'Om Parkour·Spot op je $device te installeren:';
+  String profileInstallIntro(String device, String browser) {
+    return 'Open deze pagina in $browser en volg deze stappen om Parkour·Spot op je $device te installeren:';
   }
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -428,8 +428,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileInstallDialogTitle => 'Instalar Parkour·Spot';
 
   @override
-  String profileInstallIntro(String device) {
-    return 'Para instalar o Parkour·Spot no seu $device:';
+  String profileInstallIntro(String device, String browser) {
+    return 'Para instalar o Parkour·Spot no seu $device, abra esta página no $browser e siga estes passos:';
   }
 
   @override

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -1000,6 +1000,7 @@ class _ProfileScreenState extends State<ProfileScreen>
     final deviceLabel = isIos
         ? l10n.profileInstallDeviceIphone
         : l10n.profileInstallDeviceAndroid;
+    final browserLabel = isIos ? 'Safari' : 'Chrome';
     final step1 = isIos
         ? l10n.profileInstallIosStep1
         : l10n.profileInstallAndroidStep1;
@@ -1028,7 +1029,7 @@ class _ProfileScreenState extends State<ProfileScreen>
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.profileInstallIntro(deviceLabel),
+              l10n.profileInstallIntro(deviceLabel, browserLabel),
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 16),

--- a/lib/widgets/pwa_install_prompt.dart
+++ b/lib/widgets/pwa_install_prompt.dart
@@ -54,6 +54,7 @@ class _PwaInstallPromptState extends State<PwaInstallPrompt> {
     final isIos = MobileDetectionService.isIOS;
     final deviceLabel =
         isIos ? l10n.profileInstallDeviceIphone : l10n.profileInstallDeviceAndroid;
+    final browserLabel = isIos ? 'Safari' : 'Chrome';
     final step1 = isIos ? l10n.profileInstallIosStep1 : l10n.profileInstallAndroidStep1;
     final step2 = isIos ? l10n.profileInstallIosStep2 : l10n.profileInstallAndroidStep2;
     final step3 = isIos ? l10n.profileInstallIosStep3 : l10n.profileInstallAndroidStep3;
@@ -74,7 +75,7 @@ class _PwaInstallPromptState extends State<PwaInstallPrompt> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.profileInstallIntro(deviceLabel),
+              l10n.profileInstallIntro(deviceLabel, browserLabel),
               style: Theme.of(dialogContext).textTheme.titleMedium,
             ),
             const SizedBox(height: 16),

--- a/test/l10n/pwa_install_browser_expectations_test.dart
+++ b/test/l10n/pwa_install_browser_expectations_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/l10n/app_localizations.dart';
+import 'package:parkour_spot/l10n/app_localizations_de.dart';
+import 'package:parkour_spot/l10n/app_localizations_en.dart';
+import 'package:parkour_spot/l10n/app_localizations_es.dart';
+import 'package:parkour_spot/l10n/app_localizations_fr.dart';
+import 'package:parkour_spot/l10n/app_localizations_nl.dart';
+import 'package:parkour_spot/l10n/app_localizations_pt.dart';
+
+void main() {
+  final localizations = <AppLocalizations>[
+    AppLocalizationsDe(),
+    AppLocalizationsEn(),
+    AppLocalizationsEs(),
+    AppLocalizationsFr(),
+    AppLocalizationsNl(),
+    AppLocalizationsPt(),
+  ];
+
+  for (final l10n in localizations) {
+    test('${l10n.localeName} names Safari for iOS installation', () {
+      final intro = l10n.profileInstallIntro(
+        l10n.profileInstallDeviceIphone,
+        'Safari',
+      );
+
+      expect(intro, contains('Safari'));
+    });
+
+    test('${l10n.localeName} names Chrome for Android installation', () {
+      final intro = l10n.profileInstallIntro(
+        l10n.profileInstallDeviceAndroid,
+        'Chrome',
+      );
+
+      expect(intro, contains('Chrome'));
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- explicitly name Safari in the iOS install instructions
- explicitly name Chrome in the Android install instructions
- update the localized copy for every supported language
- add regression coverage for both browser expectations across all locales

## Why

The install prompt previously described platform-specific steps without naming the browser they apply to. Users opening Parkour·Spot in another browser could therefore expect those exact steps to be available there.

## User impact

iOS users are told to open the page in Safari, while Android users are told to open it in Chrome before following the installation steps.

https://github.com/user-attachments/assets/a76d6033-3944-46f2-8ce0-210d41953326


## Testing

- `flutter test` — 211 tests passed

Closes #193
