### PR TITLE
Add excludeFolders filter for parkour spot sources

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -112,6 +112,11 @@ const {
 } = require("./lib/import-helpers");
 const {shouldRunSync} = require("./lib/sync-helpers");
 const {
+  normalizeFolderList,
+  applyFolderFilter,
+  sortFoldersByIncludeOrder,
+} = require("./lib/folder-filter");
+const {
   EVENT_SYNC_SOURCE_TYPE_WIX_PUBLISHED_CALENDAR,
   hasExternalEventAddressChanged,
   hasExternalEventContentChanges,
@@ -2646,73 +2651,37 @@ async function processSyncSource(source, sourceId, apiKey, updateImagesForExisti
     }
   }
 
-  // Normalize includeFolders from source configuration
-  let includeFolders = [];
-  if (Array.isArray(source.includeFolders)) {
-    includeFolders = source.includeFolders;
-  } else if (typeof source.includeFolders === "string") {
-    includeFolders = source.includeFolders.split(",");
-  }
-  includeFolders = includeFolders
-      .map((s) => (typeof s === "string" ? s.trim() : ""))
-      .filter((s) => s.length > 0);
+  // Normalize and apply include/exclude folder filter (mutually exclusive)
+  const beforeFolderFilterCount = placemarks.length;
+  const folderFilterResult = applyFolderFilter(
+      placemarks,
+      source.includeFolders,
+      source.excludeFolders,
+  );
+  placemarks = folderFilterResult.placemarks;
+  const includeFolders = folderFilterResult.includeFolders;
+  const excludeFolders = folderFilterResult.excludeFolders;
 
-  if (includeFolders.length > 0) {
+  if (folderFilterResult.mode !== "none") {
     console.log(
-        `[FOLDER FILTER] Applying folder filter for source: ${source.name}`,
+        `[FOLDER FILTER] Applying ${folderFilterResult.mode} folder filter ` +
+        `for source: ${source.name}`,
     );
     console.log(
-        `[FOLDER FILTER] Total placemarks before filter: ${placemarks.length}`,
+        `[FOLDER FILTER] Total placemarks before filter: ${beforeFolderFilterCount}`,
     );
-    console.log(
-        `[FOLDER FILTER] Include folders: [${includeFolders.join(", ")}]`,
-    );
-
-    // Log all folder names found in placemarks before processing
-    const foldersInPlacemarks = new Set();
-    placemarks.forEach((placemark) => {
-      if (placemark.folderName) {
-        foldersInPlacemarks.add(placemark.folderName);
-      }
-    });
-    console.log(
-        `[FOLDER FILTER] Folders found in placemarks: [${Array.from(foldersInPlacemarks).join(", ")}]`,
-    );
-
-    const includeSetLower = new Set(includeFolders.map((f) => f.toLowerCase()));
-    const beforeCount = placemarks.length;
-    placemarks = placemarks.filter((p) => {
-      const path = Array.isArray(p.folderPath) ? p.folderPath : [];
-      return path.some((seg) => includeSetLower.has(String(seg).toLowerCase()));
-    });
-
-    // Sort placemarks by the order specified in includeFolders
-    placemarks.sort((a, b) => {
-      const aFolderName = a.folderName ? a.folderName.toLowerCase() : "";
-      const bFolderName = b.folderName ? b.folderName.toLowerCase() : "";
-
-      const aIndex = includeFolders.findIndex(
-          (folder) => folder.toLowerCase() === aFolderName,
+    if (folderFilterResult.mode === "include") {
+      console.log(
+          `[FOLDER FILTER] Include folders: [${includeFolders.join(", ")}]`,
       );
-      const bIndex = includeFolders.findIndex(
-          (folder) => folder.toLowerCase() === bFolderName,
+    } else {
+      console.log(
+          `[FOLDER FILTER] Exclude folders: [${excludeFolders.join(", ")}]`,
       );
-
-      // If both folders are in includeFolders, sort by their order
-      if (aIndex !== -1 && bIndex !== -1) {
-        return aIndex - bIndex;
-      }
-
-      // If only one folder is in includeFolders, prioritize it
-      if (aIndex !== -1) return -1;
-      if (bIndex !== -1) return 1;
-
-      // If neither folder is in includeFolders, maintain original order
-      return 0;
-    });
-
+    }
     console.log(
-        `Applied folder filter and ordering for source ${source.name}: ${placemarks.length}/${beforeCount} placemarks kept`,
+        `[FOLDER FILTER] Placemarks after filter: ` +
+        `${placemarks.length}/${beforeFolderFilterCount}`,
     );
   }
 
@@ -3273,27 +3242,8 @@ async function processSyncSource(source, sourceId, apiKey, updateImagesForExisti
           `[FOLDER COLLECTION] Final allFolders before sorting: [${Array.from(allFolders).join(", ")}]`,
       );
 
-      // Sort folders by the order specified in includeFolders, then alphabetically for any not in includeFolders
-      const sortedFolders = Array.from(allFolders).sort((a, b) => {
-        const aIndex = includeFolders.findIndex(
-            (folder) => folder.toLowerCase() === a.toLowerCase(),
-        );
-        const bIndex = includeFolders.findIndex(
-            (folder) => folder.toLowerCase() === b.toLowerCase(),
-        );
-
-        // If both folders are in includeFolders, sort by their order
-        if (aIndex !== -1 && bIndex !== -1) {
-          return aIndex - bIndex;
-        }
-
-        // If only one folder is in includeFolders, prioritize it
-        if (aIndex !== -1) return -1;
-        if (bIndex !== -1) return 1;
-
-        // If neither folder is in includeFolders, sort alphabetically
-        return a.localeCompare(b);
-      });
+      // Sort folders by includeFolders order (when set), then alphabetically
+      const sortedFolders = sortFoldersByIncludeOrder(allFolders, includeFolders);
 
       console.log(
           `[FOLDER COLLECTION] Final sorted allFolders: [${sortedFolders.join(", ")}]`,
@@ -3781,6 +3731,7 @@ exports.createSyncSource = onCall(
           instagramHandle,
           isActive = true,
           includeFolders,
+          excludeFolders,
           recordFolderName,
           defaultSpotAttributes,
           folderSpotAttributes,
@@ -3791,6 +3742,15 @@ exports.createSyncSource = onCall(
 
         if (!name || !kmzUrl) {
           throw new Error("name and kmzUrl are required");
+        }
+
+        const normalizedInclude = normalizeFolderList(includeFolders);
+        const normalizedExclude = normalizeFolderList(excludeFolders);
+        if (normalizedInclude.length > 0 && normalizedExclude.length > 0) {
+          throw new Error(
+              "includeFolders and excludeFolders are mutually exclusive; " +
+              "provide only one",
+          );
         }
 
         const sourceData = {
@@ -3804,19 +3764,11 @@ exports.createSyncSource = onCall(
           updatedAt: FieldValue.serverTimestamp(),
         };
 
-        // Add optional folder config only if they have values
-        if (Array.isArray(includeFolders) && includeFolders.length > 0) {
-          sourceData.includeFolders = includeFolders
-              .map((s) => s.trim())
-              .filter((s) => s.length > 0);
-        } else if (
-          typeof includeFolders === "string" &&
-        includeFolders.trim().length > 0
-        ) {
-          sourceData.includeFolders = includeFolders
-              .split(",")
-              .map((s) => s.trim())
-              .filter((s) => s.length > 0);
+        // Add optional folder config only if they have values (mutually exclusive)
+        if (normalizedInclude.length > 0) {
+          sourceData.includeFolders = normalizedInclude;
+        } else if (normalizedExclude.length > 0) {
+          sourceData.excludeFolders = normalizedExclude;
         }
 
         if (typeof recordFolderName === "boolean") {
@@ -3874,6 +3826,7 @@ exports.updateSyncSource = onCall(
           instagramHandle,
           isActive,
           includeFolders,
+          excludeFolders,
           recordFolderName,
           defaultSpotAttributes,
           folderSpotAttributes,
@@ -3898,19 +3851,42 @@ exports.updateSyncSource = onCall(
           updateData.instagramHandle = instagramHandle;
         }
         if (isActive !== undefined) updateData.isActive = isActive;
-        if (includeFolders !== undefined) {
-          if (Array.isArray(includeFolders)) {
-            updateData.includeFolders = includeFolders
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0);
-          } else if (typeof includeFolders === "string") {
-            const list = includeFolders
-                .split(",")
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0);
-            updateData.includeFolders = list;
-          } else if (includeFolders === null) {
+
+        // Folder filters are mutually exclusive: setting one clears the other.
+        if (includeFolders !== undefined || excludeFolders !== undefined) {
+          const normalizedInclude = includeFolders !== undefined ?
+            normalizeFolderList(includeFolders) :
+            null;
+          const normalizedExclude = excludeFolders !== undefined ?
+            normalizeFolderList(excludeFolders) :
+            null;
+
+          if (
+            normalizedInclude &&
+            normalizedInclude.length > 0 &&
+            normalizedExclude &&
+            normalizedExclude.length > 0
+          ) {
+            throw new Error(
+                "includeFolders and excludeFolders are mutually exclusive; " +
+                "provide only one",
+            );
+          }
+
+          if (normalizedInclude && normalizedInclude.length > 0) {
+            updateData.includeFolders = normalizedInclude;
+            updateData.excludeFolders = FieldValue.delete();
+          } else if (normalizedExclude && normalizedExclude.length > 0) {
+            updateData.excludeFolders = normalizedExclude;
             updateData.includeFolders = FieldValue.delete();
+          } else {
+            // Cleared filter(s): remove whichever side(s) the client sent
+            if (includeFolders !== undefined) {
+              updateData.includeFolders = FieldValue.delete();
+            }
+            if (excludeFolders !== undefined) {
+              updateData.excludeFolders = FieldValue.delete();
+            }
           }
         }
         if (recordFolderName !== undefined) {

--- a/functions/lib/folder-filter.js
+++ b/functions/lib/folder-filter.js
@@ -1,0 +1,152 @@
+/**
+ * Folder include/exclude filtering for sync sources.
+ * Include and exclude modes are mutually exclusive: when both lists are
+ * non-empty, include wins and exclude is ignored.
+ */
+
+/**
+ * Normalize a folder list from array or comma-separated string.
+ * @param {*} value Raw folder list value
+ * @return {string[]} Normalized folder names
+ */
+function normalizeFolderList(value) {
+  let list = [];
+  if (Array.isArray(value)) {
+    list = value;
+  } else if (typeof value === "string") {
+    list = value.split(",");
+  }
+  return list
+      .map((s) => (typeof s === "string" ? s.trim() : ""))
+      .filter((s) => s.length > 0);
+}
+
+/**
+ * Whether a placemark's folderPath intersects the given folder set.
+ * Matching is case-insensitive.
+ * @param {Object} placemark Placemark with optional folderPath
+ * @param {Set<string>} folderSetLower Lowercase folder names
+ * @return {boolean} True if any path segment matches
+ */
+function placemarkMatchesFolderSet(placemark, folderSetLower) {
+  const path = Array.isArray(placemark.folderPath) ?
+    placemark.folderPath :
+    [];
+  return path.some((seg) => folderSetLower.has(String(seg).toLowerCase()));
+}
+
+/**
+ * Sort placemarks by leaf folderName order in orderFolders.
+ * @param {Array<Object>} placemarks Placemarks to sort
+ * @param {string[]} orderFolders Preferred folder order
+ * @return {Array<Object>} Sorted placemarks copy
+ */
+function sortPlacemarksByFolderOrder(placemarks, orderFolders) {
+  return placemarks.slice().sort((a, b) => {
+    const aFolderName = a.folderName ? a.folderName.toLowerCase() : "";
+    const bFolderName = b.folderName ? b.folderName.toLowerCase() : "";
+
+    const aIndex = orderFolders.findIndex(
+        (folder) => folder.toLowerCase() === aFolderName,
+    );
+    const bIndex = orderFolders.findIndex(
+        (folder) => folder.toLowerCase() === bFolderName,
+    );
+
+    if (aIndex !== -1 && bIndex !== -1) {
+      return aIndex - bIndex;
+    }
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
+    return 0;
+  });
+}
+
+/**
+ * Apply include or exclude folder filtering to placemarks.
+ * @param {Array<Object>} placemarks Placemarks to filter
+ * @param {*} includeFoldersRaw Include folder list
+ * @param {*} excludeFoldersRaw Exclude folder list
+ * @return {Object} Filtered placemarks and mode metadata
+ */
+function applyFolderFilter(placemarks, includeFoldersRaw, excludeFoldersRaw) {
+  const includeFolders = normalizeFolderList(includeFoldersRaw);
+  const excludeFolders = normalizeFolderList(excludeFoldersRaw);
+
+  if (includeFolders.length > 0 && excludeFolders.length > 0) {
+    console.warn(
+        "[FOLDER FILTER] Both includeFolders and excludeFolders are set; " +
+        "using includeFolders and ignoring excludeFolders",
+    );
+  }
+
+  if (includeFolders.length > 0) {
+    const includeSetLower = new Set(
+        includeFolders.map((f) => f.toLowerCase()),
+    );
+    const filtered = placemarks.filter((p) =>
+      placemarkMatchesFolderSet(p, includeSetLower),
+    );
+    return {
+      placemarks: sortPlacemarksByFolderOrder(filtered, includeFolders),
+      includeFolders,
+      excludeFolders,
+      mode: "include",
+    };
+  }
+
+  if (excludeFolders.length > 0) {
+    const excludeSetLower = new Set(
+        excludeFolders.map((f) => f.toLowerCase()),
+    );
+    const filtered = placemarks.filter(
+        (p) => !placemarkMatchesFolderSet(p, excludeSetLower),
+    );
+    return {
+      placemarks: filtered,
+      includeFolders,
+      excludeFolders,
+      mode: "exclude",
+    };
+  }
+
+  return {
+    placemarks,
+    includeFolders,
+    excludeFolders,
+    mode: "none",
+  };
+}
+
+/**
+ * Sort folder names by includeFolders order, then alphabetically.
+ * @param {Iterable<string>} folders Folder names
+ * @param {string[]} includeFolders Preferred order
+ * @return {string[]} Sorted folder names
+ */
+function sortFoldersByIncludeOrder(folders, includeFolders) {
+  const order = Array.isArray(includeFolders) ? includeFolders : [];
+  return Array.from(folders).sort((a, b) => {
+    const aIndex = order.findIndex(
+        (folder) => folder.toLowerCase() === a.toLowerCase(),
+    );
+    const bIndex = order.findIndex(
+        (folder) => folder.toLowerCase() === b.toLowerCase(),
+    );
+
+    if (aIndex !== -1 && bIndex !== -1) {
+      return aIndex - bIndex;
+    }
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
+    return a.localeCompare(b);
+  });
+}
+
+module.exports = {
+  normalizeFolderList,
+  placemarkMatchesFolderSet,
+  sortPlacemarksByFolderOrder,
+  applyFolderFilter,
+  sortFoldersByIncludeOrder,
+};

--- a/functions/test/folder-filter.test.js
+++ b/functions/test/folder-filter.test.js
@@ -1,0 +1,82 @@
+const {
+  normalizeFolderList,
+  applyFolderFilter,
+  sortFoldersByIncludeOrder,
+} = require("../lib/folder-filter");
+
+describe("normalizeFolderList", () => {
+  it("normalizes arrays and trims empties", () => {
+    expect(normalizeFolderList([" A ", "", "B"])).toEqual(["A", "B"]);
+  });
+
+  it("splits comma-separated strings", () => {
+    expect(normalizeFolderList("A, B , ,C")).toEqual(["A", "B", "C"]);
+  });
+
+  it("returns empty for null/undefined/non-string", () => {
+    expect(normalizeFolderList(null)).toEqual([]);
+    expect(normalizeFolderList(undefined)).toEqual([]);
+    expect(normalizeFolderList(42)).toEqual([]);
+  });
+});
+
+describe("applyFolderFilter", () => {
+  const placemarks = [
+    {name: "a", folderName: "Parks", folderPath: ["Parks"]},
+    {name: "b", folderName: "Gyms", folderPath: ["Gyms"]},
+    {name: "c", folderName: "Rooftops", folderPath: ["Cities", "Rooftops"]},
+    {name: "d", folderName: "Misc", folderPath: []},
+  ];
+
+  it("keeps all placemarks when no filter is set", () => {
+    const result = applyFolderFilter(placemarks, null, null);
+    expect(result.mode).toBe("none");
+    expect(result.placemarks).toHaveLength(4);
+  });
+
+  it("includes only matching folderPath segments (case-insensitive)", () => {
+    const result = applyFolderFilter(placemarks, ["parks", "Cities"], null);
+    expect(result.mode).toBe("include");
+    expect(result.placemarks.map((p) => p.name)).toEqual(["a", "c"]);
+  });
+
+  it("sorts included placemarks by includeFolders order", () => {
+    const result = applyFolderFilter(
+        placemarks,
+        ["Rooftops", "Parks"],
+        null,
+    );
+    expect(result.placemarks.map((p) => p.name)).toEqual(["c", "a"]);
+  });
+
+  it("excludes matching folderPath segments and keeps the rest", () => {
+    const result = applyFolderFilter(placemarks, null, ["Gyms", "cities"]);
+    expect(result.mode).toBe("exclude");
+    expect(result.placemarks.map((p) => p.name)).toEqual(["a", "d"]);
+  });
+
+  it("prefers include when both include and exclude are set", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const result = applyFolderFilter(placemarks, ["Parks"], ["Parks"]);
+    expect(result.mode).toBe("include");
+    expect(result.placemarks.map((p) => p.name)).toEqual(["a"]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("sortFoldersByIncludeOrder", () => {
+  it("orders by include list then alphabetically", () => {
+    expect(
+        sortFoldersByIncludeOrder(["Zeta", "Alpha", "Beta"], ["Beta", "Zeta"]),
+    ).toEqual(["Beta", "Zeta", "Alpha"]);
+  });
+
+  it("sorts alphabetically when include list is empty", () => {
+    expect(sortFoldersByIncludeOrder(["c", "a", "b"], [])).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});

--- a/lib/screens/admin/sync_sources_screen.dart
+++ b/lib/screens/admin/sync_sources_screen.dart
@@ -528,6 +528,21 @@ class _SyncSourcesScreenState extends State<SyncSourcesScreen> {
                           ],
                         ),
                       ],
+                      if (s.excludeFolders != null && s.excludeFolders!.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Wrap(
+                          spacing: 4,
+                          runSpacing: 2,
+                          children: [
+                            const Text('Exclude folders:', style: TextStyle( fontSize: 12)),
+                            ...s.excludeFolders!.map((folder) => Chip(
+                              label: Text(folder, style: _kSyncChipLabelText),
+                              labelStyle: _kSyncChipLabelText,
+                              backgroundColor: Colors.orange.shade100,
+                            )),
+                          ],
+                        ),
+                      ],
                       if (s.allFolders != null && s.allFolders!.isNotEmpty) ...[
                         const SizedBox(height: 4),
                         Wrap(
@@ -1721,12 +1736,15 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
   late final TextEditingController publicUrlCtrl;
   late final TextEditingController instagramHandleCtrl;
   late final TextEditingController includeFoldersCtrl;
+  late final TextEditingController excludeFoldersCtrl;
   late final TextEditingController folderRuleNameCtrl;
   late final TextEditingController lightSyncScheduleCtrl;
   late final TextEditingController fullSyncScheduleCtrl;
   late bool isActive;
   late bool recordFolderName;
   late bool autoSyncEnabled;
+  /// 'include' or 'exclude' — mutually exclusive folder filter mode
+  late String folderFilterMode;
   late _EditableSpotAttributes _sourceDefaultAttributes;
   final Map<String, _EditableSpotAttributes> _folderDefaultAttributes = {};
 
@@ -1743,6 +1761,14 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
           ? ''
           : widget.source!.includeFolders!.join('\n'),
     );
+    excludeFoldersCtrl = TextEditingController(
+      text: (widget.source?.excludeFolders == null || widget.source?.excludeFolders?.isEmpty == true)
+          ? ''
+          : widget.source!.excludeFolders!.join('\n'),
+    );
+    final hasExclude = widget.source?.excludeFolders != null &&
+        widget.source!.excludeFolders!.isNotEmpty;
+    folderFilterMode = hasExclude ? 'exclude' : 'include';
     folderRuleNameCtrl = TextEditingController();
     lightSyncScheduleCtrl = TextEditingController(text: widget.source?.lightSyncSchedule ?? '');
     fullSyncScheduleCtrl = TextEditingController(text: widget.source?.fullSyncSchedule ?? '');
@@ -1770,10 +1796,19 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
     publicUrlCtrl.dispose();
     instagramHandleCtrl.dispose();
     includeFoldersCtrl.dispose();
+    excludeFoldersCtrl.dispose();
     folderRuleNameCtrl.dispose();
     lightSyncScheduleCtrl.dispose();
     fullSyncScheduleCtrl.dispose();
     super.dispose();
+  }
+
+  List<String> _parseFolderLines(String text) {
+    return text
+        .split('\n')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList();
   }
 
   String? _findExistingFolderRuleKey(String folderName) {
@@ -1858,15 +1893,55 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
                 ),
               ),
               const SizedBox(height: 8),
-              TextFormField(
-                controller: includeFoldersCtrl,
-                decoration: const InputDecoration(
-                  labelText: 'Include Folders (optional)',
-                  helperText: 'One folder name per line. Folder names with commas are fully supported.',
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Folder filter (optional)',
+                  style: Theme.of(context).textTheme.titleSmall,
                 ),
-                maxLines: 5,
-                minLines: 3,
               ),
+              const SizedBox(height: 8),
+              SegmentedButton<String>(
+                segments: const [
+                  ButtonSegment(
+                    value: 'include',
+                    label: Text('Include'),
+                  ),
+                  ButtonSegment(
+                    value: 'exclude',
+                    label: Text('Exclude'),
+                  ),
+                ],
+                selected: {folderFilterMode},
+                onSelectionChanged: (Set<String> selected) {
+                  setState(() {
+                    folderFilterMode = selected.first;
+                  });
+                },
+              ),
+              const SizedBox(height: 8),
+              if (folderFilterMode == 'include')
+                TextFormField(
+                  controller: includeFoldersCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Include Folders (optional)',
+                    helperText:
+                        'One folder name per line. Only these folders are imported; leave empty to import all.',
+                  ),
+                  maxLines: 5,
+                  minLines: 3,
+                )
+              else
+                TextFormField(
+                  controller: excludeFoldersCtrl,
+                  decoration: const InputDecoration(
+                    labelText: 'Exclude Folders (optional)',
+                    helperText:
+                        'One folder name per line. These folders are skipped; all others are imported.',
+                  ),
+                  maxLines: 5,
+                  minLines: 3,
+                ),
               const SizedBox(height: 8),
               const Divider(),
               Align(
@@ -2142,6 +2217,12 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
             final folderDefaultAttributesPayload =
                 _serializeFolderDefaultAttributes();
             bool ok;
+            final includeList = folderFilterMode == 'include'
+                ? _parseFolderLines(includeFoldersCtrl.text)
+                : <String>[];
+            final excludeList = folderFilterMode == 'exclude'
+                ? _parseFolderLines(excludeFoldersCtrl.text)
+                : <String>[];
             if (widget.source == null) {
               ok = await service.createSource(
                 name: nameCtrl.text.trim(),
@@ -2150,13 +2231,8 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
                 publicUrl: publicUrlCtrl.text.trim().isEmpty ? null : publicUrlCtrl.text.trim(),
                 instagramHandle: instagramHandleCtrl.text.trim().isEmpty ? null : instagramHandleCtrl.text.trim(),
                 isActive: isActive,
-                includeFolders: includeFoldersCtrl.text.trim().isEmpty
-                    ? null
-                    : includeFoldersCtrl.text
-                        .split('\n')
-                        .map((s) => s.trim())
-                        .where((s) => s.isNotEmpty)
-                        .toList(),
+                includeFolders: includeList.isEmpty ? null : includeList,
+                excludeFolders: excludeList.isEmpty ? null : excludeList,
                 recordFolderName: recordFolderName,
                 defaultSpotAttributes: sourceDefaultAttributesPayload,
                 folderSpotAttributes: folderDefaultAttributesPayload,
@@ -2173,13 +2249,9 @@ class _SyncSourceEditDialogState extends State<SyncSourceEditDialog> {
                 publicUrl: publicUrlCtrl.text.trim(),
                 instagramHandle: instagramHandleCtrl.text.trim(),
                 isActive: isActive,
-                includeFolders: includeFoldersCtrl.text.trim().isEmpty
-                    ? <String>[]
-                    : includeFoldersCtrl.text
-                        .split('\n')
-                        .map((s) => s.trim())
-                        .where((s) => s.isNotEmpty)
-                        .toList(),
+                // Always send both so the unused mode is cleared server-side
+                includeFolders: includeList,
+                excludeFolders: excludeList,
                 recordFolderName: recordFolderName,
                 defaultSpotAttributes: sourceDefaultAttributesPayload,
                 folderSpotAttributes: folderDefaultAttributesPayload,

--- a/lib/services/sync_source_service.dart
+++ b/lib/services/sync_source_service.dart
@@ -73,7 +73,8 @@ class SyncSource {
   final String? publicUrl;
   final String? instagramHandle; // Instagram handle for the source owner
   final bool isActive;
-  final List<String>? includeFolders; // Optional list of folders to include
+  final List<String>? includeFolders; // Optional whitelist of folders to include
+  final List<String>? excludeFolders; // Optional blacklist of folders to exclude (mutually exclusive with includeFolders)
   final bool? recordFolderName; // Whether to store folder name on spots
   final List<String>? allFolders; // List of all folders found during sync (when recordFolderName is true)
   final Map<String, dynamic>? defaultSpotAttributes; // Defaults for all new spots in this source
@@ -100,6 +101,7 @@ class SyncSource {
     this.instagramHandle,
     required this.isActive,
     this.includeFolders,
+    this.excludeFolders,
     this.recordFolderName,
     this.allFolders,
     this.defaultSpotAttributes,
@@ -128,6 +130,7 @@ class SyncSource {
       instagramHandle: data['instagramHandle'],
       isActive: data['isActive'] ?? true,
       includeFolders: _stringListFromDynamic(data['includeFolders']),
+      excludeFolders: _stringListFromDynamic(data['excludeFolders']),
       recordFolderName: data['recordFolderName'] is bool ? data['recordFolderName'] as bool : null,
       allFolders: _stringListFromDynamic(data['allFolders']),
       defaultSpotAttributes: _parseDefaultSpotAttributes(data['defaultSpotAttributes']),
@@ -323,6 +326,7 @@ class SyncSourceService extends ChangeNotifier {
     String? instagramHandle,
     bool isActive = true,
     List<String>? includeFolders,
+    List<String>? excludeFolders,
     bool? recordFolderName,
     Map<String, dynamic>? defaultSpotAttributes,
     Map<String, dynamic>? folderSpotAttributes,
@@ -340,6 +344,7 @@ class SyncSourceService extends ChangeNotifier {
         'instagramHandle': instagramHandle,
         'isActive': isActive,
         if (includeFolders != null) 'includeFolders': includeFolders,
+        if (excludeFolders != null) 'excludeFolders': excludeFolders,
         if (recordFolderName != null) 'recordFolderName': recordFolderName,
         if (defaultSpotAttributes != null) 'defaultSpotAttributes': defaultSpotAttributes,
         if (folderSpotAttributes != null) 'folderSpotAttributes': folderSpotAttributes,
@@ -369,6 +374,7 @@ class SyncSourceService extends ChangeNotifier {
     String? instagramHandle,
     bool? isActive,
     List<String>? includeFolders,
+    List<String>? excludeFolders,
     bool? recordFolderName,
     Map<String, dynamic>? defaultSpotAttributes,
     Map<String, dynamic>? folderSpotAttributes,
@@ -387,6 +393,7 @@ class SyncSourceService extends ChangeNotifier {
       if (instagramHandle != null) payload['instagramHandle'] = instagramHandle;
       if (isActive != null) payload['isActive'] = isActive;
       if (includeFolders != null) payload['includeFolders'] = includeFolders;
+      if (excludeFolders != null) payload['excludeFolders'] = excludeFolders;
       if (recordFolderName != null) payload['recordFolderName'] = recordFolderName;
       if (updateSpotAttributeDefaults) {
         payload['defaultSpotAttributes'] = defaultSpotAttributes;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Admins configuring a sync source can now choose **Include** or **Exclude** folder filtering (mutually exclusive).

- **Include** (existing): only listed folders are imported
- **Exclude** (new): listed folders are skipped; all other folders are imported

This is useful for sources with many folders where only one or two should be skipped.

## Changes
- Admin edit dialog: segmented Include/Exclude mode with a single folder list field
- Source list shows orange “Exclude folders” chips when set
- Cloud Functions sync applies exclude filtering (case-insensitive `folderPath` match, same as include)
- Create/update rejects both lists being non-empty; setting one clears the other
- Extracted `functions/lib/folder-filter.js` with unit tests

## Testing
- `cd functions && npm test` (230 tests passed, including new folder-filter suite)
- `cd functions && npm run lint`
- `dart analyze` on changed Dart files (info-level only, pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49e3bee3-4e7f-4e0e-bfdb-0808d2f15c0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49e3bee3-4e7f-4e0e-bfdb-0808d2f15c0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

