### PR TITLE
Add user contribution stats to nightly Users export

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -134,6 +134,10 @@ const {executeEventsInBoundsQuery} = require("./lib/events-in-bounds");
 const {
   lookupTimeZoneFromCoordinates,
 } = require("./lib/timezone-lookup");
+const {
+  buildUserContributionStats,
+  getUserContributionStats,
+} = require("./lib/user-contribution-stats");
 
 // Import shared HTML template
 const {generateHtmlPage} = require("./html-template");
@@ -9408,6 +9412,12 @@ async function calculateUserActivityMetrics(useYesterdayDate = false) {
           "Has Any Saved Spot Lists",
           "Has Any Check Ins",
           "Has Any Training Plans",
+          "Spots Added",
+          "Spots Improved",
+          "Spots Deduplicated",
+          "Events Created",
+          "Events Improved",
+          "Events Deduplicated",
         ],
       ];
       await rateLimitedSheetsCall(
@@ -9478,6 +9488,10 @@ async function calculateUserActivityMetrics(useYesterdayDate = false) {
       const usersWithCheckIns = await getUserIdsWithAnyInTopLevelCollection("spotCheckIns");
       const usersWithTrainingPlans = await getUserIdsWithAnyInTopLevelCollection("spotTrainingPlans");
 
+      // Aggregate per-user spot/event contribution counts for Looker Studio.
+      console.log("Building per-user contribution stats from spots and events...");
+      const contributionStatsByUser = await buildUserContributionStats(db);
+
       let processingUsers = true;
       while (processingUsers) {
         userBatchNumber++;
@@ -9523,6 +9537,10 @@ async function calculateUserActivityMetrics(useYesterdayDate = false) {
           const hasAnySavedSpotLists = usersWithSavedSpotLists.has(doc.id);
           const hasAnyCheckIns = usersWithCheckIns.has(doc.id);
           const hasAnyTrainingPlans = usersWithTrainingPlans.has(doc.id);
+          const contributionStats = getUserContributionStats(
+              contributionStatsByUser,
+              doc.id,
+          );
 
           userBatchData.push([
             doc.id, // User ID
@@ -9543,6 +9561,12 @@ async function calculateUserActivityMetrics(useYesterdayDate = false) {
             hasAnySavedSpotLists, // Has Any Saved Spot Lists
             hasAnyCheckIns, // Has Any Check Ins
             hasAnyTrainingPlans, // Has Any Training Plans
+            contributionStats.spotsAdded, // Spots Added
+            contributionStats.spotsImproved, // Spots Improved
+            contributionStats.spotsDeduplicated, // Spots Deduplicated
+            contributionStats.eventsCreated, // Events Created
+            contributionStats.eventsImproved, // Events Improved
+            contributionStats.eventsDeduplicated, // Events Deduplicated
           ]);
         });
 

--- a/functions/lib/user-contribution-stats.js
+++ b/functions/lib/user-contribution-stats.js
@@ -1,0 +1,235 @@
+/* eslint-disable max-len */
+/**
+ * Per-user contribution counters for the nightly Users Google Sheets export.
+ *
+ * Spots/events created via moderator "Create native" deduplication are counted
+ * separately and excluded from the regular "added/created" totals (matching
+ * profile and admin user stats elsewhere in the app).
+ *
+ * Improvers are users listed in `contributors` who are not the document creator.
+ */
+
+/**
+ * Zero-filled contribution stats for one user.
+ * @return {{
+ *   spotsAdded: number,
+ *   spotsImproved: number,
+ *   spotsDeduplicated: number,
+ *   eventsCreated: number,
+ *   eventsImproved: number,
+ *   eventsDeduplicated: number,
+ * }}
+ */
+function emptyUserContributionStats() {
+  return {
+    spotsAdded: 0,
+    spotsImproved: 0,
+    spotsDeduplicated: 0,
+    eventsCreated: 0,
+    eventsImproved: 0,
+    eventsDeduplicated: 0,
+  };
+}
+
+/**
+ * @param {Map<string, object>} statsByUser
+ * @param {string} userId
+ * @return {object}
+ */
+function getOrCreateUserContributionStats(statsByUser, userId) {
+  let stats = statsByUser.get(userId);
+  if (!stats) {
+    stats = emptyUserContributionStats();
+    statsByUser.set(userId, stats);
+  }
+  return stats;
+}
+
+/**
+ * @param {Map<string, object>} statsByUser
+ * @param {string} userId
+ * @return {object}
+ */
+function getUserContributionStats(statsByUser, userId) {
+  return statsByUser.get(userId) || emptyUserContributionStats();
+}
+
+/**
+ * Credit unique improvers from a contributors array, excluding the creator.
+ * @param {Map<string, object>} statsByUser
+ * @param {unknown} contributors
+ * @param {string} createdBy
+ * @param {"spotsImproved"|"eventsImproved"} field
+ */
+function accumulateImprovers(statsByUser, contributors, createdBy, field) {
+  if (!Array.isArray(contributors)) {
+    return;
+  }
+
+  const seen = new Set();
+  for (const contributor of contributors) {
+    if (!contributor || typeof contributor !== "object") {
+      continue;
+    }
+    const userId = typeof contributor.userId === "string" ?
+      contributor.userId.trim() :
+      "";
+    if (!userId || userId === createdBy || seen.has(userId)) {
+      continue;
+    }
+    seen.add(userId);
+    getOrCreateUserContributionStats(statsByUser, userId)[field] += 1;
+  }
+}
+
+/**
+ * Accumulate contribution stats from one spot document.
+ * @param {Map<string, object>} statsByUser
+ * @param {object|null|undefined} spotData
+ */
+function accumulateSpotContribution(statsByUser, spotData) {
+  if (!spotData || typeof spotData !== "object") {
+    return;
+  }
+
+  const createdBy = typeof spotData.createdBy === "string" ?
+    spotData.createdBy.trim() :
+    "";
+  const fromCreateNative = spotData.createdFromCreateNative === true;
+
+  if (createdBy) {
+    const stats = getOrCreateUserContributionStats(statsByUser, createdBy);
+    if (fromCreateNative) {
+      stats.spotsDeduplicated += 1;
+    } else {
+      stats.spotsAdded += 1;
+    }
+  }
+
+  accumulateImprovers(
+      statsByUser,
+      spotData.contributors,
+      createdBy,
+      "spotsImproved",
+  );
+}
+
+/**
+ * Accumulate contribution stats from one event document.
+ * @param {Map<string, object>} statsByUser
+ * @param {object|null|undefined} eventData
+ */
+function accumulateEventContribution(statsByUser, eventData) {
+  if (!eventData || typeof eventData !== "object") {
+    return;
+  }
+
+  const createdBy = typeof eventData.createdBy === "string" ?
+    eventData.createdBy.trim() :
+    "";
+  const fromCreateNative = eventData.createdFromCreateNative === true;
+
+  if (createdBy) {
+    const stats = getOrCreateUserContributionStats(statsByUser, createdBy);
+    if (fromCreateNative) {
+      stats.eventsDeduplicated += 1;
+    } else {
+      stats.eventsCreated += 1;
+    }
+  }
+
+  accumulateImprovers(
+      statsByUser,
+      eventData.contributors,
+      createdBy,
+      "eventsImproved",
+  );
+}
+
+/**
+ * Page through a collection and accumulate contribution stats.
+ * @param {object} options
+ * @param {object} options.db Firestore instance
+ * @param {string} options.collectionName
+ * @param {Map<string, object>} options.statsByUser
+ * @param {Function} options.accumulate Accumulator for one document's data
+ * @param {number=} options.pageSize
+ * @return {Promise<number>} documents scanned
+ */
+async function accumulateContributionsFromCollection({
+  db,
+  collectionName,
+  statsByUser,
+  accumulate,
+  pageSize = 500,
+}) {
+  let lastDoc = null;
+  let scanned = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    let query = db.collection(collectionName)
+        .select("createdBy", "createdFromCreateNative", "contributors")
+        .limit(pageSize);
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+
+    const snapshot = await query.get();
+    if (snapshot.empty) {
+      hasMore = false;
+      continue;
+    }
+
+    snapshot.forEach((doc) => {
+      accumulate(statsByUser, doc.data());
+    });
+
+    scanned += snapshot.size;
+    lastDoc = snapshot.docs[snapshot.docs.length - 1];
+    if (snapshot.size < pageSize) {
+      hasMore = false;
+    }
+  }
+
+  return scanned;
+}
+
+/**
+ * Build per-user contribution stats from spots and events collections.
+ * @param {object} db Firestore instance
+ * @return {Promise<Map<string, object>>}
+ */
+async function buildUserContributionStats(db) {
+  const statsByUser = new Map();
+
+  const spotsScanned = await accumulateContributionsFromCollection({
+    db,
+    collectionName: "spots",
+    statsByUser,
+    accumulate: accumulateSpotContribution,
+  });
+  const eventsScanned = await accumulateContributionsFromCollection({
+    db,
+    collectionName: "events",
+    statsByUser,
+    accumulate: accumulateEventContribution,
+  });
+
+  console.log(
+      `Contribution stats: scanned ${spotsScanned} spots and ` +
+      `${eventsScanned} events for ${statsByUser.size} contributing users`,
+  );
+
+  return statsByUser;
+}
+
+module.exports = {
+  emptyUserContributionStats,
+  getOrCreateUserContributionStats,
+  getUserContributionStats,
+  accumulateSpotContribution,
+  accumulateEventContribution,
+  accumulateContributionsFromCollection,
+  buildUserContributionStats,
+};

--- a/functions/test/user-contribution-stats.test.js
+++ b/functions/test/user-contribution-stats.test.js
@@ -1,0 +1,240 @@
+const {
+  emptyUserContributionStats,
+  getUserContributionStats,
+  accumulateSpotContribution,
+  accumulateEventContribution,
+  accumulateContributionsFromCollection,
+  buildUserContributionStats,
+} = require("../lib/user-contribution-stats");
+
+describe("accumulateSpotContribution", () => {
+  it("counts regular spot creation as spotsAdded", () => {
+    const statsByUser = new Map();
+    accumulateSpotContribution(statsByUser, {
+      createdBy: "user-1",
+      createdFromCreateNative: false,
+    });
+
+    expect(getUserContributionStats(statsByUser, "user-1")).toEqual({
+      ...emptyUserContributionStats(),
+      spotsAdded: 1,
+    });
+  });
+
+  it("counts create-native spots as spotsDeduplicated, not spotsAdded", () => {
+    const statsByUser = new Map();
+    accumulateSpotContribution(statsByUser, {
+      createdBy: "mod-1",
+      createdFromCreateNative: true,
+    });
+
+    expect(getUserContributionStats(statsByUser, "mod-1")).toEqual({
+      ...emptyUserContributionStats(),
+      spotsDeduplicated: 1,
+    });
+  });
+
+  it("counts unique improvers excluding the creator", () => {
+    const statsByUser = new Map();
+    accumulateSpotContribution(statsByUser, {
+      createdBy: "user-1",
+      contributors: [
+        {userId: "user-1", userName: "Creator"},
+        {userId: "user-2", userName: "Improver"},
+        {userId: "user-2", userName: "Improver Dup"},
+        {userId: "user-3", userName: "Other"},
+        {userId: "", userName: "Invalid"},
+        null,
+      ],
+    });
+
+    expect(getUserContributionStats(statsByUser, "user-1").spotsImproved).toBe(0);
+    expect(getUserContributionStats(statsByUser, "user-2").spotsImproved).toBe(1);
+    expect(getUserContributionStats(statsByUser, "user-3").spotsImproved).toBe(1);
+  });
+
+  it("ignores invalid documents", () => {
+    const statsByUser = new Map();
+    accumulateSpotContribution(statsByUser, null);
+    accumulateSpotContribution(statsByUser, undefined);
+    accumulateSpotContribution(statsByUser, {});
+    expect(statsByUser.size).toBe(0);
+  });
+});
+
+describe("accumulateEventContribution", () => {
+  it("counts regular event creation as eventsCreated", () => {
+    const statsByUser = new Map();
+    accumulateEventContribution(statsByUser, {
+      createdBy: "user-1",
+    });
+
+    expect(getUserContributionStats(statsByUser, "user-1")).toEqual({
+      ...emptyUserContributionStats(),
+      eventsCreated: 1,
+    });
+  });
+
+  it("counts create-native events as eventsDeduplicated, not eventsCreated", () => {
+    const statsByUser = new Map();
+    accumulateEventContribution(statsByUser, {
+      createdBy: "mod-1",
+      createdFromCreateNative: true,
+    });
+
+    expect(getUserContributionStats(statsByUser, "mod-1")).toEqual({
+      ...emptyUserContributionStats(),
+      eventsDeduplicated: 1,
+    });
+  });
+
+  it("counts unique event improvers excluding the creator", () => {
+    const statsByUser = new Map();
+    accumulateEventContribution(statsByUser, {
+      createdBy: "user-1",
+      contributors: [
+        {userId: "user-1", userName: "Creator"},
+        {userId: "user-2", userName: "Improver"},
+      ],
+    });
+
+    expect(getUserContributionStats(statsByUser, "user-1").eventsImproved).toBe(0);
+    expect(getUserContributionStats(statsByUser, "user-2").eventsImproved).toBe(1);
+  });
+});
+
+describe("accumulateContributionsFromCollection", () => {
+  it("pages through documents and accumulates stats", async () => {
+    const page1 = {
+      empty: false,
+      size: 2,
+      docs: [{id: "a"}, {id: "b"}],
+      forEach(callback) {
+        callback({
+          data: () => ({createdBy: "user-1", createdFromCreateNative: false}),
+        });
+        callback({
+          data: () => ({createdBy: "mod-1", createdFromCreateNative: true}),
+        });
+      },
+    };
+    const page2 = {
+      empty: true,
+      size: 0,
+      docs: [],
+      forEach() {},
+    };
+
+    let calls = 0;
+    const query = {
+      select() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      startAfter() {
+        return this;
+      },
+      async get() {
+        calls += 1;
+        return calls === 1 ? page1 : page2;
+      },
+    };
+
+    const db = {
+      collection(name) {
+        expect(name).toBe("spots");
+        return query;
+      },
+    };
+
+    const statsByUser = new Map();
+    const scanned = await accumulateContributionsFromCollection({
+      db,
+      collectionName: "spots",
+      statsByUser,
+      accumulate: accumulateSpotContribution,
+      pageSize: 2,
+    });
+
+    expect(scanned).toBe(2);
+    expect(getUserContributionStats(statsByUser, "user-1").spotsAdded).toBe(1);
+    expect(getUserContributionStats(statsByUser, "mod-1").spotsDeduplicated).toBe(1);
+  });
+});
+
+describe("buildUserContributionStats", () => {
+  it("aggregates spots and events", async () => {
+    const spotQuery = {
+      select() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      startAfter() {
+        return this;
+      },
+      async get() {
+        return {
+          empty: false,
+          size: 1,
+          docs: [{id: "spot-1"}],
+          forEach(callback) {
+            callback({
+              data: () => ({
+                createdBy: "user-1",
+                contributors: [{userId: "user-2", userName: "Improver"}],
+              }),
+            });
+          },
+        };
+      },
+    };
+    const eventQuery = {
+      select() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      startAfter() {
+        return this;
+      },
+      async get() {
+        return {
+          empty: false,
+          size: 1,
+          docs: [{id: "event-1"}],
+          forEach(callback) {
+            callback({
+              data: () => ({
+                createdBy: "user-1",
+                createdFromCreateNative: false,
+                contributors: [{userId: "user-3", userName: "Event Improver"}],
+              }),
+            });
+          },
+        };
+      },
+    };
+
+    const db = {
+      collection(name) {
+        if (name === "spots") return spotQuery;
+        if (name === "events") return eventQuery;
+        throw new Error(`Unexpected collection: ${name}`);
+      },
+    };
+
+    const statsByUser = await buildUserContributionStats(db);
+    expect(getUserContributionStats(statsByUser, "user-1")).toEqual({
+      ...emptyUserContributionStats(),
+      spotsAdded: 1,
+      eventsCreated: 1,
+    });
+    expect(getUserContributionStats(statsByUser, "user-2").spotsImproved).toBe(1);
+    expect(getUserContributionStats(statsByUser, "user-3").eventsImproved).toBe(1);
+  });
+});

--- a/lib/screens/admin/user_activity_metrics_screen.dart
+++ b/lib/screens/admin/user_activity_metrics_screen.dart
@@ -178,6 +178,10 @@ class _UserActivityMetricsScreenState extends State<UserActivityMetricsScreen> {
                   Text(
                     '• Also refreshes Spots, Users, and Events tabs for Looker Studio dashboards',
                   ),
+                  Text(
+                    '• Users export includes contribution counts: spots/events added or '
+                    'improved, plus moderator create-native deduplications',
+                  ),
                   SizedBox(height: 8),
                   Text(
                     'Note: This function runs automatically every night at 1 minute after midnight UTC. '


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds per-user contribution counters to the nightly **Users** Google Sheets export so Looker Studio can chart community activity and moderator deduplication work.

New Users columns:
- **Spots Added** – spots where the user is `createdBy`, excluding create-native
- **Spots Improved** – unique spots where the user appears in `contributors` (excluding the creator)
- **Spots Deduplicated** – spots created via moderator Create native (`createdFromCreateNative`)
- **Events Created** – events where the user is `createdBy`, excluding create-native
- **Events Improved** – unique events where the user appears in `contributors` (excluding the creator)
- **Events Deduplicated** – events created via moderator Create native

Create-native counts match existing profile/admin stats: they are attributed to the moderator as deduplications and not as regular adds/creates.

## Implementation
- New helper `functions/lib/user-contribution-stats.js` aggregates counts by paging spots/events with a field projection
- Wired into `calculateUserActivityMetrics` Users sheet export
- Unit tests cover add/improve/deduplicate counting and pagination
- Admin metrics screen notes the new Users columns

## Test plan
- [x] `cd functions && npm test -- --testPathPattern=user-contribution-stats`
- [x] `cd functions && npm run lint`
- [ ] After deploy, run Admin → User Activity Metrics → Calculate and confirm the Users sheet has the six new numeric columns
- [ ] In Looker Studio, refresh the Users data source and build contribution / moderator dedup overviews
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8e7abe4-43cf-4217-9d7c-028afd20475b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8e7abe4-43cf-4217-9d7c-028afd20475b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

