### PR TITLE
Fix admin All notifications failed to load

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -404,5 +404,28 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "notifications",
+      "fieldPath": "createdAt",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    }
+  ]
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -10561,6 +10561,11 @@ exports.listInAppNotificationsForAdmin = onCall(
         const docPath =
           cursor && typeof cursor.docPath === "string" ? cursor.docPath : null;
 
+        // Collection-group orderBy(createdAt) needs a fieldOverride on
+        // notifications.createdAt with queryScope COLLECTION_GROUP. That
+        // override must also keep COLLECTION indexes; otherwise it replaces
+        // automatic single-field indexes and breaks users/{uid}/notifications
+        // inbox queries.
         let query = db.collectionGroup("notifications")
             .orderBy("createdAt", "desc")
             .limit(pageSize + 1);
@@ -10595,9 +10600,9 @@ exports.listInAppNotificationsForAdmin = onCall(
         console.error("listInAppNotificationsForAdmin error:", error);
         const hint =
           error && String(error.message || "").includes("FAILED_PRECONDITION") ?
-            " If this is the first deploy, create a Firestore index for " +
-            "collection group `notifications` on `createdAt` DESC " +
-            "(see firestore.indexes.json fieldOverrides)." :
+            " Deploy firestore.indexes.json fieldOverrides for collection " +
+            "group `notifications` on `createdAt` (COLLECTION_GROUP DESC, " +
+            "and keep COLLECTION indexes so per-user inboxes still work)." :
             "";
         throw new Error(`Failed to list notifications: ${error.message}${hint}`);
       }

--- a/lib/services/admin_notifications_service.dart
+++ b/lib/services/admin_notifications_service.dart
@@ -84,7 +84,7 @@ class AdminNotificationsService extends ChangeNotifier {
       _applyCallablePage(data, replaceExisting: true);
     } catch (e, stackTrace) {
       _error = 'Failed to load notifications';
-      _lastDiagnostics = await _collectAdminFirestoreDiagnostics();
+      _lastDiagnostics = await _collectAdminFirestoreDiagnostics(e);
       debugPrint('AdminNotificationsService.fetchInitial error: $e');
       debugPrint(_lastDiagnostics ?? '(no diagnostics)');
       debugPrint('$stackTrace');
@@ -113,7 +113,7 @@ class AdminNotificationsService extends ChangeNotifier {
       _applyCallablePage(data, replaceExisting: false);
     } catch (e, stackTrace) {
       _error = 'Failed to load more notifications';
-      _lastDiagnostics = await _collectAdminFirestoreDiagnostics();
+      _lastDiagnostics = await _collectAdminFirestoreDiagnostics(e);
       debugPrint('AdminNotificationsService.loadMore error: $e');
       debugPrint(_lastDiagnostics ?? '(no diagnostics)');
       debugPrint('$stackTrace');
@@ -202,35 +202,73 @@ class AdminNotificationsService extends ChangeNotifier {
     }
   }
 
-  Future<String> _collectAdminFirestoreDiagnostics() async {
-    final b = StringBuffer();
+  Future<String> _collectAdminFirestoreDiagnostics(Object error) async {
+    String uid = '(signed out)';
+    Object? adminClaim;
+    Object? firestoreIsAdmin;
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
-      b.writeln('FirebaseAuth.currentUser: null (signed out)');
-      return b.toString();
+      return formatAdminNotificationsLoadDiagnostics(
+        error: error,
+        uid: uid,
+        adminClaim: adminClaim,
+        firestoreIsAdmin: firestoreIsAdmin,
+      );
     }
-    b.writeln('FirebaseAuth.currentUser.uid: ${user.uid}');
+    uid = user.uid;
     try {
       final tr = await user.getIdTokenResult(true);
-      b.writeln('claim admin: ${tr.claims?['admin']}');
+      adminClaim = tr.claims?['admin'];
     } catch (e) {
-      b.writeln('getIdTokenResult(true): $e');
+      adminClaim = 'getIdTokenResult(true): $e';
     }
     try {
       final doc = await _firestore
           .collection('users')
           .doc(user.uid)
           .get(const GetOptions(source: Source.server));
-      b.writeln('Firestore users/{uid}.isAdmin: ${doc.data()?['isAdmin']}');
+      firestoreIsAdmin = doc.data()?['isAdmin'];
     } catch (e) {
-      b.writeln('Firestore users/{uid} get: $e');
+      firestoreIsAdmin = 'Firestore users/{uid} get: $e';
     }
-    b.writeln(
-      'Listing uses HTTPS callable listInAppNotificationsForAdmin (Admin SDK). '
-      'If this fails, check Functions logs / deployment. '
-      'Client collectionGroup("notifications") often fails when any extra '
-      'notifications subcollection exists outside users/{{uid}}.',
+    return formatAdminNotificationsLoadDiagnostics(
+      error: error,
+      uid: uid,
+      adminClaim: adminClaim,
+      firestoreIsAdmin: firestoreIsAdmin,
     );
-    return b.toString();
   }
+}
+
+/// On-screen dump when listing all in-app notifications fails.
+@visibleForTesting
+String formatAdminNotificationsLoadDiagnostics({
+  required Object error,
+  required String uid,
+  required Object? adminClaim,
+  required Object? firestoreIsAdmin,
+}) {
+  final b = StringBuffer();
+  b.writeln('callable error: $error');
+  if (error is FirebaseFunctionsException) {
+    b.writeln('FirebaseFunctionsException.code: ${error.code}');
+    b.writeln('FirebaseFunctionsException.message: ${error.message}');
+    if (error.details != null) {
+      b.writeln('FirebaseFunctionsException.details: ${error.details}');
+    }
+  }
+  b.writeln('FirebaseAuth.currentUser.uid: $uid');
+  b.writeln('claim admin: $adminClaim');
+  b.writeln('Firestore users/{uid}.isAdmin: $firestoreIsAdmin');
+  b.writeln(
+    'Listing uses HTTPS callable listInAppNotificationsForAdmin (Admin SDK). '
+    'If this fails, check Functions logs / deployment and the collection '
+    'group index on notifications.createdAt '
+    '(firestore.indexes.json fieldOverrides). '
+    'A null admin claim is OK when Firestore isAdmin is true; the callable '
+    'accepts either token.admin or users/{uid}.isAdmin. '
+    'Client collectionGroup("notifications") often fails when any extra '
+    'notifications subcollection exists outside users/{{uid}}.',
+  );
+  return b.toString();
 }

--- a/test/firestore_indexes_test.dart
+++ b/test/firestore_indexes_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'notifications.createdAt has collection-group and collection field overrides',
+    () {
+      final file = File('firestore.indexes.json');
+      expect(file.existsSync(), isTrue, reason: 'run flutter test from repo root');
+
+      final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      final overrides = json['fieldOverrides'];
+      expect(overrides, isA<List>());
+
+      final createdAt = (overrides as List).cast<dynamic>().whereType<Map>().firstWhere(
+        (override) =>
+            override['collectionGroup'] == 'notifications' &&
+            override['fieldPath'] == 'createdAt',
+        orElse: () => <String, dynamic>{},
+      );
+      expect(
+        createdAt,
+        isNotEmpty,
+        reason:
+            'Admin All notifications uses collectionGroup("notifications").orderBy(createdAt). '
+            'A fieldOverride with COLLECTION_GROUP DESC is required. Keep COLLECTION indexes '
+            'in the same override so per-user inboxes keep working.',
+      );
+
+      final indexes = (createdAt['indexes'] as List).cast<dynamic>().whereType<Map>();
+      expect(
+        indexes.any(
+          (index) =>
+              index['order'] == 'DESCENDING' &&
+              index['queryScope'] == 'COLLECTION_GROUP',
+        ),
+        isTrue,
+      );
+      expect(
+        indexes.any(
+          (index) =>
+              index['order'] == 'DESCENDING' && index['queryScope'] == 'COLLECTION',
+        ),
+        isTrue,
+        reason:
+            'Field overrides replace automatic single-field indexes. '
+            'COLLECTION DESC must remain for users/{uid}/notifications inbox queries.',
+      );
+    },
+  );
+}

--- a/test/services/admin_notifications_diagnostics_test.dart
+++ b/test/services/admin_notifications_diagnostics_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/services/admin_notifications_service.dart';
+
+void main() {
+  test('load diagnostics include callable error and admin sources', () {
+    final text = formatAdminNotificationsLoadDiagnostics(
+      error: StateError('FAILED_PRECONDITION: requires an index'),
+      uid: 'user-1',
+      adminClaim: null,
+      firestoreIsAdmin: true,
+    );
+
+    expect(text, contains('callable error: Bad state: FAILED_PRECONDITION: requires an index'));
+    expect(text, contains('FirebaseAuth.currentUser.uid: user-1'));
+    expect(text, contains('claim admin: null'));
+    expect(text, contains('Firestore users/{uid}.isAdmin: true'));
+    expect(text, contains('A null admin claim is OK when Firestore isAdmin is true'));
+    expect(text, contains('fieldOverrides'));
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The admin **All notifications** screen fails with "Failed to load notifications". Diagnostics show `claim admin: null` and `Firestore users/{uid}.isAdmin: true`. That claim gap is a red herring: `listInAppNotificationsForAdmin` already accepts Firestore `isAdmin`.

The callable lists `collectionGroup("notifications").orderBy("createdAt", "desc")`. That needs a Firestore **field override** for collection-group scope. The override was added, then removed in `0c07979` ("Removing obsolete index that gave trouble") because it only declared `COLLECTION_GROUP` and therefore replaced automatic **collection** indexes used by each user's inbox.

## Fix

- Restore `firestore.indexes.json` fieldOverrides for `notifications.createdAt` with:
  - `COLLECTION` ASC/DESC/ARRAY_CONTAINS (keep per-user inbox queries working)
  - `COLLECTION_GROUP` DESC (admin list)
- Show the actual callable error in on-screen diagnostics, and note that a null admin claim is OK when `isAdmin` is true.
- Add regression tests so the override is not dropped again.

## Deploy note

Production needs `firebase deploy --only firestore:indexes` (in addition to shipping this commit). Until that index exists in the project, the callable will still fail with `FAILED_PRECONDITION`.

## Testing

- `flutter test test/firestore_indexes_test.dart test/services/admin_notifications_diagnostics_test.dart` — passed
- `cd functions && npm run lint` — passed
- Firebase emulators: signed in as `admin@parkour.spot` with **no** `admin` custom claim and Firestore `isAdmin: true` (same shape as the production screenshot). Seeded two inbox docs, then `listInAppNotificationsForAdmin` returned HTTP 200 with both notifications, newest first. Per-user `users/{uid}/notifications` `orderBy(createdAt desc)` still works.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c40adde4-5bd5-4c79-82f6-df7345e2c79a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c40adde4-5bd5-4c79-82f6-df7345e2c79a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

