### PR TITLE
Add YouTube thumbnails and reorder on moderator spot edit

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -109,6 +109,10 @@ const {
   extractImageUrls,
 } = require("./lib/text-processing");
 const {
+  youtubeThumbnailUrl,
+  isPlausibleYoutubeVideoId,
+} = require("./lib/youtube-thumbnails");
+const {
   pickSpotIdsForTitleSearch,
   buildSpotIdMatchCounts,
   spotHasSearchTerm,
@@ -2153,6 +2157,26 @@ async function downloadAndUploadImage(
       imageBuffer = null;
     }
   }
+}
+
+/**
+ * Downloads a YouTube thumbnail and uploads it to Storage.
+ * Tries maxresdefault, then sddefault, then hqdefault.
+ * @param {string} videoId
+ * @param {string} spotName
+ * @param {number} imageIndex
+ * @return {Promise<{url: string, hash: string}|null>}
+ */
+async function downloadAndUploadYoutubeThumbnail(videoId, spotName, imageIndex) {
+  const qualities = ["maxresdefault", "sddefault", "hqdefault"];
+  for (const quality of qualities) {
+    const thumbUrl = youtubeThumbnailUrl(videoId, quality);
+    const result = await downloadAndUploadImage(thumbUrl, spotName, imageIndex);
+    if (result) {
+      return result;
+    }
+  }
+  return null;
 }
 
 /**
@@ -7791,6 +7815,57 @@ exports.uploadReplacementImage = onCall(
         return {
           success: false,
           error: error.message,
+        };
+      }
+    },
+);
+
+/**
+ * Downloads YouTube thumbnails for newly added video IDs and stores them as
+ * spot photos (same Storage path as import). Moderator or admin only.
+ */
+exports.fetchYoutubeThumbnails = onCall(
+    {region: "europe-west1", memory: "512MiB", timeoutSeconds: 120},
+    async (request) => {
+      try {
+        await ensureModerator(request);
+        const {videoIds, spotName} = request.data || {};
+        if (!Array.isArray(videoIds) || videoIds.length === 0) {
+          return {success: true, thumbnails: []};
+        }
+
+        const name = typeof spotName === "string" && spotName.trim() ?
+          spotName.trim() :
+          "spot";
+        const uniqueIds = [];
+        const seen = new Set();
+        for (const raw of videoIds) {
+          const id = typeof raw === "string" ? raw.trim() : "";
+          if (!isPlausibleYoutubeVideoId(id) || seen.has(id)) continue;
+          seen.add(id);
+          uniqueIds.push(id);
+          if (uniqueIds.length >= 20) break;
+        }
+
+        const thumbnails = [];
+        for (let i = 0; i < uniqueIds.length; i++) {
+          const videoId = uniqueIds[i];
+          const result = await downloadAndUploadYoutubeThumbnail(
+              videoId,
+              name,
+              i,
+          );
+          if (result && result.url) {
+            thumbnails.push({videoId, url: result.url});
+          }
+        }
+        return {success: true, thumbnails};
+      } catch (error) {
+        console.error("Error fetching YouTube thumbnails:", error);
+        return {
+          success: false,
+          error: error.message,
+          thumbnails: [],
         };
       }
     },

--- a/functions/lib/youtube-thumbnails.js
+++ b/functions/lib/youtube-thumbnails.js
@@ -1,0 +1,61 @@
+/**
+ * YouTube thumbnail URL helpers shared by import and moderator edit.
+ */
+
+/**
+ * Builds a YouTube thumbnail URL for a video ID.
+ * @param {string} videoId
+ * @param {string=} quality maxresdefault, sddefault, or hqdefault
+ * @return {string}
+ */
+function youtubeThumbnailUrl(videoId, quality = "maxresdefault") {
+  return `https://img.youtube.com/vi/${videoId}/${quality}.jpg`;
+}
+
+/**
+ * True when the string looks like a YouTube video ID (not a URL).
+ * @param {string} id
+ * @return {boolean}
+ */
+function isPlausibleYoutubeVideoId(id) {
+  return typeof id === "string" && /^[a-zA-Z0-9_-]{6,20}$/.test(id);
+}
+
+/**
+ * Newly added video IDs that do not already have a YouTube CDN
+ * thumbnail in photos.
+ * @param {string[]} previousIds
+ * @param {string[]} nextIds
+ * @param {string[]=} existingImageUrls
+ * @return {string[]}
+ */
+function youtubeIdsNeedingThumbnails(
+    previousIds,
+    nextIds,
+    existingImageUrls = [],
+) {
+  const previous = new Set((previousIds || []).filter(Boolean));
+  const urls = existingImageUrls || [];
+  const seen = new Set();
+  const result = [];
+  for (const rawId of nextIds || []) {
+    const id = typeof rawId === "string" ? rawId.trim() : "";
+    if (!id || previous.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    const alreadyHasThumbnail = urls.some((url) =>
+      typeof url === "string" &&
+      (url.includes(`img.youtube.com/vi/${id}/`) ||
+        url.includes(`i.ytimg.com/vi/${id}/`)),
+    );
+    if (!alreadyHasThumbnail) {
+      result.push(id);
+    }
+  }
+  return result;
+}
+
+module.exports = {
+  youtubeThumbnailUrl,
+  isPlausibleYoutubeVideoId,
+  youtubeIdsNeedingThumbnails,
+};

--- a/functions/test/youtube-thumbnails.test.js
+++ b/functions/test/youtube-thumbnails.test.js
@@ -1,0 +1,57 @@
+const {
+  youtubeThumbnailUrl,
+  isPlausibleYoutubeVideoId,
+  youtubeIdsNeedingThumbnails,
+} = require("../lib/youtube-thumbnails");
+
+describe("youtubeThumbnailUrl", () => {
+  it("uses maxresdefault by default", () => {
+    expect(youtubeThumbnailUrl("abc123xyz")).toBe(
+        "https://img.youtube.com/vi/abc123xyz/maxresdefault.jpg",
+    );
+  });
+
+  it("accepts an alternate quality", () => {
+    expect(youtubeThumbnailUrl("abc123xyz", "hqdefault")).toBe(
+        "https://img.youtube.com/vi/abc123xyz/hqdefault.jpg",
+    );
+  });
+});
+
+describe("isPlausibleYoutubeVideoId", () => {
+  it("accepts typical 11-character IDs", () => {
+    expect(isPlausibleYoutubeVideoId("dQw4w9WgXcQ")).toBe(true);
+  });
+
+  it("rejects URLs and empty values", () => {
+    expect(isPlausibleYoutubeVideoId("")).toBe(false);
+    expect(isPlausibleYoutubeVideoId("https://youtu.be/abc")).toBe(false);
+    expect(isPlausibleYoutubeVideoId("ab")).toBe(false);
+  });
+});
+
+describe("youtubeIdsNeedingThumbnails", () => {
+  it("returns only newly added IDs", () => {
+    expect(youtubeIdsNeedingThumbnails(
+        ["aaa"],
+        ["aaa", "bbb"],
+        [],
+    )).toEqual(["bbb"]);
+  });
+
+  it("skips IDs that already have a CDN thumbnail in photos", () => {
+    expect(youtubeIdsNeedingThumbnails(
+        [],
+        ["bbb"],
+        ["https://img.youtube.com/vi/bbb/maxresdefault.jpg"],
+    )).toEqual([]);
+  });
+
+  it("preserves first-seen order and drops duplicates", () => {
+    expect(youtubeIdsNeedingThumbnails(
+        [],
+        ["bbb", "ccc", "bbb"],
+        [],
+    )).toEqual(["bbb", "ccc"]);
+  });
+});

--- a/l10n/app_de.arb
+++ b/l10n/app_de.arb
@@ -1211,5 +1211,14 @@
   "eventSuggestionApprovalSuccess": "Genehmigt und auf Event {eventId} angewendet.",
   "eventSuggestionChangedFieldsTitle": "Vorgeschlagene Änderungen",
   "eventSuggestionLocationRemoved": "Standort entfernen",
-  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Keine verknüpften Spots} =1{1 verknüpfter Spot} other{{count} verknüpfte Spots}}"
+  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Keine verknüpften Spots} =1{1 verknüpfter Spot} other{{count} verknüpfte Spots}}",
+  "editSpotYoutubeSectionTitle": "YouTube-Links",
+  "editSpotYoutubeAddTooltip": "YouTube-Link hinzufügen",
+  "editSpotYoutubeHint": "YouTube-Video-IDs oder URLs eingeben (z. B. dQw4w9WgXcQ oder https://www.youtube.com/watch?v=dQw4w9WgXcQ). Zum Sortieren ziehen.",
+  "editSpotYoutubeEmpty": "Keine YouTube-Links hinzugefügt. Klicke auf +, um einen hinzuzufügen.",
+  "editSpotYoutubeLinkLabel": "YouTube-Link {index}",
+  "editSpotYoutubeLinkHint": "YouTube-Video-ID oder URL eingeben",
+  "editSpotYoutubeRemoveTooltip": "YouTube-Link entfernen",
+  "editSpotYoutubeReorderTooltip": "YouTube-Link neu anordnen",
+  "editSpotYoutubeThumbnailSemanticLabel": "YouTube-Vorschaubild"
 }

--- a/l10n/app_en.arb
+++ b/l10n/app_en.arb
@@ -4451,5 +4451,46 @@
         "type": "int"
       }
     }
+  },
+  "editSpotYoutubeSectionTitle": "YouTube links",
+  "@editSpotYoutubeSectionTitle": {
+    "description": "Moderator edit spot: YouTube links card title"
+  },
+  "editSpotYoutubeAddTooltip": "Add YouTube link",
+  "@editSpotYoutubeAddTooltip": {
+    "description": "Moderator edit spot: add a YouTube video row"
+  },
+  "editSpotYoutubeHint": "Enter YouTube video IDs or URLs (e.g., dQw4w9WgXcQ or https://www.youtube.com/watch?v=dQw4w9WgXcQ). Drag to reorder.",
+  "@editSpotYoutubeHint": {
+    "description": "Moderator edit spot: hint under YouTube links title"
+  },
+  "editSpotYoutubeEmpty": "No YouTube links added. Click the + button to add one.",
+  "@editSpotYoutubeEmpty": {
+    "description": "Moderator edit spot: empty YouTube links list"
+  },
+  "editSpotYoutubeLinkLabel": "YouTube link {index}",
+  "@editSpotYoutubeLinkLabel": {
+    "description": "Moderator edit spot: labeled YouTube URL field",
+    "placeholders": {
+      "index": {
+        "type": "int"
+      }
+    }
+  },
+  "editSpotYoutubeLinkHint": "Enter YouTube video ID or URL",
+  "@editSpotYoutubeLinkHint": {
+    "description": "Moderator edit spot: YouTube field placeholder"
+  },
+  "editSpotYoutubeRemoveTooltip": "Remove YouTube link",
+  "@editSpotYoutubeRemoveTooltip": {
+    "description": "Moderator edit spot: remove a YouTube video row"
+  },
+  "editSpotYoutubeReorderTooltip": "Reorder YouTube link",
+  "@editSpotYoutubeReorderTooltip": {
+    "description": "Moderator edit spot: drag handle for YouTube video order"
+  },
+  "editSpotYoutubeThumbnailSemanticLabel": "YouTube thumbnail",
+  "@editSpotYoutubeThumbnailSemanticLabel": {
+    "description": "Moderator edit spot: semantic label for video thumbnail preview"
   }
 }

--- a/l10n/app_es.arb
+++ b/l10n/app_es.arb
@@ -1210,5 +1210,14 @@
   "eventSuggestionApprovalSuccess": "Aprobada y aplicada al evento {eventId}.",
   "eventSuggestionChangedFieldsTitle": "Cambios sugeridos",
   "eventSuggestionLocationRemoved": "Eliminar ubicación",
-  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Sin spots vinculados} =1{1 spot vinculado} other{{count} spots vinculados}}"
+  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Sin spots vinculados} =1{1 spot vinculado} other{{count} spots vinculados}}",
+  "editSpotYoutubeSectionTitle": "Enlaces de YouTube",
+  "editSpotYoutubeAddTooltip": "Añadir enlace de YouTube",
+  "editSpotYoutubeHint": "Introduce IDs o URLs de YouTube (p. ej., dQw4w9WgXcQ o https://www.youtube.com/watch?v=dQw4w9WgXcQ). Arrastra para reordenar.",
+  "editSpotYoutubeEmpty": "No hay enlaces de YouTube. Pulsa + para añadir uno.",
+  "editSpotYoutubeLinkLabel": "Enlace de YouTube {index}",
+  "editSpotYoutubeLinkHint": "Introduce el ID o la URL de YouTube",
+  "editSpotYoutubeRemoveTooltip": "Quitar enlace de YouTube",
+  "editSpotYoutubeReorderTooltip": "Reordenar enlace de YouTube",
+  "editSpotYoutubeThumbnailSemanticLabel": "Miniatura de YouTube"
 }

--- a/l10n/app_fr.arb
+++ b/l10n/app_fr.arb
@@ -1210,5 +1210,14 @@
   "eventSuggestionApprovalSuccess": "Approuvée et appliquée à l’événement {eventId}.",
   "eventSuggestionChangedFieldsTitle": "Modifications suggérées",
   "eventSuggestionLocationRemoved": "Supprimer l’emplacement",
-  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Aucun spot lié} =1{1 spot lié} other{{count} spots liés}}"
+  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Aucun spot lié} =1{1 spot lié} other{{count} spots liés}}",
+  "editSpotYoutubeSectionTitle": "Liens YouTube",
+  "editSpotYoutubeAddTooltip": "Ajouter un lien YouTube",
+  "editSpotYoutubeHint": "Saisissez des identifiants ou des URLs YouTube (ex. dQw4w9WgXcQ ou https://www.youtube.com/watch?v=dQw4w9WgXcQ). Glissez pour réordonner.",
+  "editSpotYoutubeEmpty": "Aucun lien YouTube. Cliquez sur + pour en ajouter un.",
+  "editSpotYoutubeLinkLabel": "Lien YouTube {index}",
+  "editSpotYoutubeLinkHint": "Saisissez l’identifiant ou l’URL YouTube",
+  "editSpotYoutubeRemoveTooltip": "Supprimer le lien YouTube",
+  "editSpotYoutubeReorderTooltip": "Réordonner le lien YouTube",
+  "editSpotYoutubeThumbnailSemanticLabel": "Vignette YouTube"
 }

--- a/l10n/app_nl.arb
+++ b/l10n/app_nl.arb
@@ -1210,5 +1210,14 @@
   "eventSuggestionApprovalSuccess": "Goedgekeurd en toegepast op evenement {eventId}.",
   "eventSuggestionChangedFieldsTitle": "Voorgestelde wijzigingen",
   "eventSuggestionLocationRemoved": "Locatie verwijderen",
-  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Geen gekoppelde spots} =1{1 gekoppelde spot} other{{count} gekoppelde spots}}"
+  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Geen gekoppelde spots} =1{1 gekoppelde spot} other{{count} gekoppelde spots}}",
+  "editSpotYoutubeSectionTitle": "YouTube-links",
+  "editSpotYoutubeAddTooltip": "YouTube-link toevoegen",
+  "editSpotYoutubeHint": "Voer YouTube-video-ID’s of URL’s in (bijv. dQw4w9WgXcQ of https://www.youtube.com/watch?v=dQw4w9WgXcQ). Sleep om te herschikken.",
+  "editSpotYoutubeEmpty": "Geen YouTube-links toegevoegd. Klik op + om er een toe te voegen.",
+  "editSpotYoutubeLinkLabel": "YouTube-link {index}",
+  "editSpotYoutubeLinkHint": "Voer YouTube-video-ID of URL in",
+  "editSpotYoutubeRemoveTooltip": "YouTube-link verwijderen",
+  "editSpotYoutubeReorderTooltip": "YouTube-link herschikken",
+  "editSpotYoutubeThumbnailSemanticLabel": "YouTube-miniatuur"
 }

--- a/l10n/app_pt.arb
+++ b/l10n/app_pt.arb
@@ -1210,5 +1210,14 @@
   "eventSuggestionApprovalSuccess": "Aprovada e aplicada ao evento {eventId}.",
   "eventSuggestionChangedFieldsTitle": "Alterações sugeridas",
   "eventSuggestionLocationRemoved": "Remover localização",
-  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Sem spots associados} =1{1 spot associado} other{{count} spots associados}}"
+  "eventSuggestionLinkedSpotsCount": "{count, plural, =0{Sem spots associados} =1{1 spot associado} other{{count} spots associados}}",
+  "editSpotYoutubeSectionTitle": "Ligações YouTube",
+  "editSpotYoutubeAddTooltip": "Adicionar ligação YouTube",
+  "editSpotYoutubeHint": "Introduz IDs ou URLs de YouTube (p. ex. dQw4w9WgXcQ ou https://www.youtube.com/watch?v=dQw4w9WgXcQ). Arrasta para reordenar.",
+  "editSpotYoutubeEmpty": "Sem ligações YouTube. Clica em + para adicionar uma.",
+  "editSpotYoutubeLinkLabel": "Ligação YouTube {index}",
+  "editSpotYoutubeLinkHint": "Introduz o ID ou URL do YouTube",
+  "editSpotYoutubeRemoveTooltip": "Remover ligação YouTube",
+  "editSpotYoutubeReorderTooltip": "Reordenar ligação YouTube",
+  "editSpotYoutubeThumbnailSemanticLabel": "Miniatura do YouTube"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7328,6 +7328,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =0{No linked spots} =1{1 linked spot} other{{count} linked spots}}'**
   String eventSuggestionLinkedSpotsCount(int count);
+
+  /// Moderator edit spot: YouTube links card title
+  ///
+  /// In en, this message translates to:
+  /// **'YouTube links'**
+  String get editSpotYoutubeSectionTitle;
+
+  /// Moderator edit spot: add a YouTube video row
+  ///
+  /// In en, this message translates to:
+  /// **'Add YouTube link'**
+  String get editSpotYoutubeAddTooltip;
+
+  /// Moderator edit spot: hint under YouTube links title
+  ///
+  /// In en, this message translates to:
+  /// **'Enter YouTube video IDs or URLs (e.g., dQw4w9WgXcQ or https://www.youtube.com/watch?v=dQw4w9WgXcQ). Drag to reorder.'**
+  String get editSpotYoutubeHint;
+
+  /// Moderator edit spot: empty YouTube links list
+  ///
+  /// In en, this message translates to:
+  /// **'No YouTube links added. Click the + button to add one.'**
+  String get editSpotYoutubeEmpty;
+
+  /// Moderator edit spot: labeled YouTube URL field
+  ///
+  /// In en, this message translates to:
+  /// **'YouTube link {index}'**
+  String editSpotYoutubeLinkLabel(int index);
+
+  /// Moderator edit spot: YouTube field placeholder
+  ///
+  /// In en, this message translates to:
+  /// **'Enter YouTube video ID or URL'**
+  String get editSpotYoutubeLinkHint;
+
+  /// Moderator edit spot: remove a YouTube video row
+  ///
+  /// In en, this message translates to:
+  /// **'Remove YouTube link'**
+  String get editSpotYoutubeRemoveTooltip;
+
+  /// Moderator edit spot: drag handle for YouTube video order
+  ///
+  /// In en, this message translates to:
+  /// **'Reorder YouTube link'**
+  String get editSpotYoutubeReorderTooltip;
+
+  /// Moderator edit spot: semantic label for video thumbnail preview
+  ///
+  /// In en, this message translates to:
+  /// **'YouTube thumbnail'**
+  String get editSpotYoutubeThumbnailSemanticLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4442,4 +4442,35 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get editSpotYoutubeSectionTitle => 'YouTube-Links';
+
+  @override
+  String get editSpotYoutubeAddTooltip => 'YouTube-Link hinzufügen';
+
+  @override
+  String get editSpotYoutubeHint =>
+      'YouTube-Video-IDs oder URLs eingeben (z. B. dQw4w9WgXcQ oder https://www.youtube.com/watch?v=dQw4w9WgXcQ). Zum Sortieren ziehen.';
+
+  @override
+  String get editSpotYoutubeEmpty =>
+      'Keine YouTube-Links hinzugefügt. Klicke auf +, um einen hinzuzufügen.';
+
+  @override
+  String editSpotYoutubeLinkLabel(int index) {
+    return 'YouTube-Link $index';
+  }
+
+  @override
+  String get editSpotYoutubeLinkHint => 'YouTube-Video-ID oder URL eingeben';
+
+  @override
+  String get editSpotYoutubeRemoveTooltip => 'YouTube-Link entfernen';
+
+  @override
+  String get editSpotYoutubeReorderTooltip => 'YouTube-Link neu anordnen';
+
+  @override
+  String get editSpotYoutubeThumbnailSemanticLabel => 'YouTube-Vorschaubild';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4371,4 +4371,35 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get editSpotYoutubeSectionTitle => 'YouTube links';
+
+  @override
+  String get editSpotYoutubeAddTooltip => 'Add YouTube link';
+
+  @override
+  String get editSpotYoutubeHint =>
+      'Enter YouTube video IDs or URLs (e.g., dQw4w9WgXcQ or https://www.youtube.com/watch?v=dQw4w9WgXcQ). Drag to reorder.';
+
+  @override
+  String get editSpotYoutubeEmpty =>
+      'No YouTube links added. Click the + button to add one.';
+
+  @override
+  String editSpotYoutubeLinkLabel(int index) {
+    return 'YouTube link $index';
+  }
+
+  @override
+  String get editSpotYoutubeLinkHint => 'Enter YouTube video ID or URL';
+
+  @override
+  String get editSpotYoutubeRemoveTooltip => 'Remove YouTube link';
+
+  @override
+  String get editSpotYoutubeReorderTooltip => 'Reorder YouTube link';
+
+  @override
+  String get editSpotYoutubeThumbnailSemanticLabel => 'YouTube thumbnail';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4411,4 +4411,35 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get editSpotYoutubeSectionTitle => 'Enlaces de YouTube';
+
+  @override
+  String get editSpotYoutubeAddTooltip => 'Añadir enlace de YouTube';
+
+  @override
+  String get editSpotYoutubeHint =>
+      'Introduce IDs o URLs de YouTube (p. ej., dQw4w9WgXcQ o https://www.youtube.com/watch?v=dQw4w9WgXcQ). Arrastra para reordenar.';
+
+  @override
+  String get editSpotYoutubeEmpty =>
+      'No hay enlaces de YouTube. Pulsa + para añadir uno.';
+
+  @override
+  String editSpotYoutubeLinkLabel(int index) {
+    return 'Enlace de YouTube $index';
+  }
+
+  @override
+  String get editSpotYoutubeLinkHint => 'Introduce el ID o la URL de YouTube';
+
+  @override
+  String get editSpotYoutubeRemoveTooltip => 'Quitar enlace de YouTube';
+
+  @override
+  String get editSpotYoutubeReorderTooltip => 'Reordenar enlace de YouTube';
+
+  @override
+  String get editSpotYoutubeThumbnailSemanticLabel => 'Miniatura de YouTube';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4450,4 +4450,36 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get editSpotYoutubeSectionTitle => 'Liens YouTube';
+
+  @override
+  String get editSpotYoutubeAddTooltip => 'Ajouter un lien YouTube';
+
+  @override
+  String get editSpotYoutubeHint =>
+      'Saisissez des identifiants ou des URLs YouTube (ex. dQw4w9WgXcQ ou https://www.youtube.com/watch?v=dQw4w9WgXcQ). Glissez pour réordonner.';
+
+  @override
+  String get editSpotYoutubeEmpty =>
+      'Aucun lien YouTube. Cliquez sur + pour en ajouter un.';
+
+  @override
+  String editSpotYoutubeLinkLabel(int index) {
+    return 'Lien YouTube $index';
+  }
+
+  @override
+  String get editSpotYoutubeLinkHint =>
+      'Saisissez l’identifiant ou l’URL YouTube';
+
+  @override
+  String get editSpotYoutubeRemoveTooltip => 'Supprimer le lien YouTube';
+
+  @override
+  String get editSpotYoutubeReorderTooltip => 'Réordonner le lien YouTube';
+
+  @override
+  String get editSpotYoutubeThumbnailSemanticLabel => 'Vignette YouTube';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4396,4 +4396,35 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get editSpotYoutubeSectionTitle => 'YouTube-links';
+
+  @override
+  String get editSpotYoutubeAddTooltip => 'YouTube-link toevoegen';
+
+  @override
+  String get editSpotYoutubeHint =>
+      'Voer YouTube-video-ID’s of URL’s in (bijv. dQw4w9WgXcQ of https://www.youtube.com/watch?v=dQw4w9WgXcQ). Sleep om te herschikken.';
+
+  @override
+  String get editSpotYoutubeEmpty =>
+      'Geen YouTube-links toegevoegd. Klik op + om er een toe te voegen.';
+
+  @override
+  String editSpotYoutubeLinkLabel(int index) {
+    return 'YouTube-link $index';
+  }
+
+  @override
+  String get editSpotYoutubeLinkHint => 'Voer YouTube-video-ID of URL in';
+
+  @override
+  String get editSpotYoutubeRemoveTooltip => 'YouTube-link verwijderen';
+
+  @override
+  String get editSpotYoutubeReorderTooltip => 'YouTube-link herschikken';
+
+  @override
+  String get editSpotYoutubeThumbnailSemanticLabel => 'YouTube-miniatuur';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4420,4 +4420,35 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get editSpotYoutubeSectionTitle => 'Ligações YouTube';
+
+  @override
+  String get editSpotYoutubeAddTooltip => 'Adicionar ligação YouTube';
+
+  @override
+  String get editSpotYoutubeHint =>
+      'Introduz IDs ou URLs de YouTube (p. ex. dQw4w9WgXcQ ou https://www.youtube.com/watch?v=dQw4w9WgXcQ). Arrasta para reordenar.';
+
+  @override
+  String get editSpotYoutubeEmpty =>
+      'Sem ligações YouTube. Clica em + para adicionar uma.';
+
+  @override
+  String editSpotYoutubeLinkLabel(int index) {
+    return 'Ligação YouTube $index';
+  }
+
+  @override
+  String get editSpotYoutubeLinkHint => 'Introduz o ID ou URL do YouTube';
+
+  @override
+  String get editSpotYoutubeRemoveTooltip => 'Remover ligação YouTube';
+
+  @override
+  String get editSpotYoutubeReorderTooltip => 'Reordenar ligação YouTube';
+
+  @override
+  String get editSpotYoutubeThumbnailSemanticLabel => 'Miniatura do YouTube';
 }

--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../utils/youtube_utils.dart';
 
 class Spot {
   final String? id;
@@ -109,57 +110,6 @@ class Spot {
 
   factory Spot.fromFirestore(DocumentSnapshot doc) {
     Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
-    String? extractYoutubeId(String input) {
-      final trimmed = input.trim();
-      if (trimmed.isEmpty) return null;
-      // If it's already a likely ID, return as-is (11 chars typical)
-      if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) &&
-          !trimmed.contains('/')) {
-        return trimmed;
-      }
-      try {
-        final uri = Uri.parse(trimmed);
-        // youtu.be/<id>
-        if (uri.host.contains('youtu.be')) {
-          final seg = uri.pathSegments.isNotEmpty
-              ? uri.pathSegments.last
-              : null;
-          if (seg != null && seg.isNotEmpty) return seg;
-        }
-        // youtube.com/watch?v=<id>
-        final vParam = uri.queryParameters['v'];
-        if (vParam != null && vParam.isNotEmpty) return vParam;
-        // youtube.com/embed/<id>
-        final embedIndex = uri.pathSegments.indexOf('embed');
-        if (embedIndex != -1 && embedIndex + 1 < uri.pathSegments.length) {
-          return uri.pathSegments[embedIndex + 1];
-        }
-        // youtube.com/shorts/<id>
-        final shortsIndex = uri.pathSegments.indexOf('shorts');
-        if (shortsIndex != -1 && shortsIndex + 1 < uri.pathSegments.length) {
-          return uri.pathSegments[shortsIndex + 1];
-        }
-      } catch (_) {}
-      return trimmed; // Fallback to raw value
-    }
-
-    List<String>? extractYoutubeIdsList(dynamic value) {
-      if (value == null) return null;
-      if (value is List) {
-        return value
-            .whereType<dynamic>()
-            .map((e) => e.toString())
-            .map((s) => extractYoutubeId(s))
-            .whereType<String>()
-            .toList();
-      }
-      if (value is String) {
-        final id = extractYoutubeId(value);
-        return id == null ? null : <String>[id];
-      }
-      return null;
-    }
-
     return Spot(
       id: doc.id,
       name: data['name'] ?? '',
@@ -172,7 +122,7 @@ class Spot {
       imageUrls: data['imageUrls'] != null
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl']] : null),
-      youtubeVideoIds: extractYoutubeIdsList(data['youtubeVideoIds']),
+      youtubeVideoIds: extractYoutubeVideoIdsFromValue(data['youtubeVideoIds']),
       folderName: data['folderName'],
       createdBy: data['createdBy'],
       createdByName: data['createdByName'],
@@ -230,52 +180,6 @@ class Spot {
   }
 
   factory Spot.fromMap(Map<String, dynamic> data) {
-    String? extractYoutubeId(String input) {
-      final trimmed = input.trim();
-      if (trimmed.isEmpty) return null;
-      if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) &&
-          !trimmed.contains('/')) {
-        return trimmed;
-      }
-      try {
-        final uri = Uri.parse(trimmed);
-        if (uri.host.contains('youtu.be')) {
-          final seg = uri.pathSegments.isNotEmpty
-              ? uri.pathSegments.last
-              : null;
-          if (seg != null && seg.isNotEmpty) return seg;
-        }
-        final vParam = uri.queryParameters['v'];
-        if (vParam != null && vParam.isNotEmpty) return vParam;
-        final embedIndex = uri.pathSegments.indexOf('embed');
-        if (embedIndex != -1 && embedIndex + 1 < uri.pathSegments.length) {
-          return uri.pathSegments[embedIndex + 1];
-        }
-        final shortsIndex = uri.pathSegments.indexOf('shorts');
-        if (shortsIndex != -1 && shortsIndex + 1 < uri.pathSegments.length) {
-          return uri.pathSegments[shortsIndex + 1];
-        }
-      } catch (_) {}
-      return trimmed;
-    }
-
-    List<String>? extractYoutubeIdsList(dynamic value) {
-      if (value == null) return null;
-      if (value is List) {
-        return value
-            .whereType<dynamic>()
-            .map((e) => e.toString())
-            .map((s) => extractYoutubeId(s))
-            .whereType<String>()
-            .toList();
-      }
-      if (value is String) {
-        final id = extractYoutubeId(value);
-        return id == null ? null : <String>[id];
-      }
-      return null;
-    }
-
     DateTime? parseDate(dynamic v) {
       if (v == null) return null;
       if (v is Timestamp) return v.toDate();
@@ -301,7 +205,7 @@ class Spot {
       imageUrls: data['imageUrls'] is List
           ? List<String>.from(data['imageUrls'])
           : (data['imageUrl'] != null ? [data['imageUrl'] as String] : null),
-      youtubeVideoIds: extractYoutubeIdsList(data['youtubeVideoIds']),
+      youtubeVideoIds: extractYoutubeVideoIdsFromValue(data['youtubeVideoIds']),
       folderName: data['folderName'] as String?,
       createdBy: data['createdBy'] as String?,
       createdByName: data['createdByName'] as String?,

--- a/lib/screens/spots/edit_spot_screen.dart
+++ b/lib/screens/spots/edit_spot_screen.dart
@@ -16,6 +16,7 @@ import '../../widgets/moderator_action_fields.dart';
 import '../../widgets/spot_form/location_section.dart';
 import '../../widgets/spot_form/image_section.dart';
 import '../../widgets/spot_form/attributes_section.dart';
+import '../../widgets/spot_form/youtube_section.dart';
 import '../../widgets/explore_entity_picker/explore_entity_picker_config.dart';
 import '../../widgets/explore_entity_picker/explore_entity_picker_screen.dart';
 import '../../utils/map_recentering_mixin.dart';
@@ -23,6 +24,7 @@ import '../../utils/location_permission_utils.dart';
 import '../../utils/image_preparation.dart';
 import '../../utils/image_picker_utils.dart';
 import '../../utils/ui_yield.dart';
+import '../../utils/youtube_utils.dart';
 
 class EditSpotScreen extends StatefulWidget {
   final Spot spot;
@@ -477,38 +479,6 @@ class _EditSpotScreenState extends State<EditSpotScreen> with MapRecenteringMixi
     });
   }
 
-  // Extract YouTube ID from URL or return as-is if already an ID
-  String? _extractYoutubeId(String input) {
-    final trimmed = input.trim();
-    if (trimmed.isEmpty) return null;
-    // If it's already a likely ID, return as-is (11 chars typical)
-    if (RegExp(r'^[a-zA-Z0-9_-]{6,}$').hasMatch(trimmed) && !trimmed.contains('/')) {
-      return trimmed;
-    }
-    try {
-      final uri = Uri.parse(trimmed);
-      // youtu.be/<id>
-      if (uri.host.contains('youtu.be')) {
-        final seg = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : null;
-        if (seg != null && seg.isNotEmpty) return seg;
-      }
-      // youtube.com/watch?v=<id>
-      final vParam = uri.queryParameters['v'];
-      if (vParam != null && vParam.isNotEmpty) return vParam;
-      // youtube.com/embed/<id>
-      final embedIndex = uri.pathSegments.indexOf('embed');
-      if (embedIndex != -1 && embedIndex + 1 < uri.pathSegments.length) {
-        return uri.pathSegments[embedIndex + 1];
-      }
-      // youtube.com/shorts/<id>
-      final shortsIndex = uri.pathSegments.indexOf('shorts');
-      if (shortsIndex != -1 && shortsIndex + 1 < uri.pathSegments.length) {
-        return uri.pathSegments[shortsIndex + 1];
-      }
-    } catch (_) {}
-    return trimmed; // Fallback to raw value
-  }
-
   void _addYoutubeLink() {
     setState(() {
       _youtubeControllers.add(TextEditingController());
@@ -519,6 +489,13 @@ class _EditSpotScreenState extends State<EditSpotScreen> with MapRecenteringMixi
     setState(() {
       _youtubeControllers[index].dispose();
       _youtubeControllers.removeAt(index);
+    });
+  }
+
+  void _reorderYoutubeLink(int oldIndex, int newIndex) {
+    setState(() {
+      final controller = _youtubeControllers.removeAt(oldIndex);
+      _youtubeControllers.insert(newIndex, controller);
     });
   }
 
@@ -553,7 +530,7 @@ class _EditSpotScreenState extends State<EditSpotScreen> with MapRecenteringMixi
 
       // Extract YouTube IDs from controllers
       final youtubeIds = _youtubeControllers
-          .map((controller) => _extractYoutubeId(controller.text))
+          .map((controller) => extractYoutubeVideoId(controller.text))
           .whereType<String>()
           .where((id) => id.isNotEmpty)
           .toList();
@@ -865,68 +842,13 @@ class _EditSpotScreenState extends State<EditSpotScreen> with MapRecenteringMixi
                   ),
                   const SizedBox(height: 16),
 
-                  // YouTube Links Section
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                'YouTube Links',
-                                style: Theme.of(context).textTheme.titleMedium,
-                              ),
-                              IconButton(
-                                icon: const Icon(Icons.add),
-                                onPressed: _addYoutubeLink,
-                                tooltip: 'Add YouTube link',
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 8),
-                          const Text(
-                            'Enter YouTube video IDs or URLs (e.g., dQw4w9WgXcQ or https://www.youtube.com/watch?v=dQw4w9WgXcQ)',
-                            style: TextStyle(fontSize: 12, color: Colors.grey),
-                          ),
-                          const SizedBox(height: 16),
-                          if (_youtubeControllers.isEmpty)
-                            const Padding(
-                              padding: EdgeInsets.symmetric(vertical: 16.0),
-                              child: Text(
-                                'No YouTube links added. Click the + button to add one.',
-                                style: TextStyle(color: Colors.grey),
-                              ),
-                            )
-                          else
-                            ...List.generate(
-                              _youtubeControllers.length,
-                              (index) => Padding(
-                                padding: const EdgeInsets.only(bottom: 8.0),
-                                child: Row(
-                                  children: [
-                                    Expanded(
-                                      child: CustomTextField(
-                                        controller: _youtubeControllers[index],
-                                        labelText: 'YouTube Link ${index + 1}',
-                                        hintText: 'Enter YouTube video ID or URL',
-                                      ),
-                                    ),
-                                    IconButton(
-                                      icon: const Icon(Icons.remove_circle),
-                                      color: Colors.red,
-                                      onPressed: () => _removeYoutubeLink(index),
-                                      tooltip: 'Remove YouTube link',
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
+                  // YouTube links section
+                  SpotYoutubeSection(
+                    controllers: _youtubeControllers,
+                    onAdd: _addYoutubeLink,
+                    onRemove: _removeYoutubeLink,
+                    onReorder: _reorderYoutubeLink,
+                    onChanged: () => setState(() {}),
                   ),
                   const SizedBox(height: 16),
 

--- a/lib/services/spot_service.dart
+++ b/lib/services/spot_service.dart
@@ -15,6 +15,7 @@ import '../utils/spot_duplicate_merge.dart';
 import '../utils/spot_duplicate_review.dart';
 import '../utils/spots_added_by_user.dart';
 import '../utils/ui_yield.dart';
+import '../utils/youtube_utils.dart';
 import 'audit_log_service.dart';
 
 class SpotService extends ChangeNotifier {
@@ -270,13 +271,12 @@ class SpotService extends ChangeNotifier {
       _isLoading = true;
       notifyListeners();
 
-      // Get the old spot data for audit logging
       Spot? oldSpot;
-      if (userId != null && userName != null) {
+      if (spot.id != null) {
         oldSpot = await getSpotById(spot.id!);
       }
 
-      List<String>? imageUrls = List.from(spot.imageUrls ?? []);
+      List<String> imageUrls = List.from(spot.imageUrls ?? []);
 
       // Remove images from spot (but don't delete from storage - cleanup will handle that)
       if (imagesToDelete != null && imagesToDelete.isNotEmpty) {
@@ -294,6 +294,25 @@ class SpotService extends ChangeNotifier {
       if (newImageBytesList != null && newImageBytesList.isNotEmpty) {
         final uploadedUrls = await _uploadImagesBytes(newImageBytesList);
         imageUrls.addAll(uploadedUrls);
+      }
+
+      final newYoutubeIds = oldSpot == null
+          ? const <String>[]
+          : youtubeIdsNeedingThumbnails(
+              previousIds: oldSpot.youtubeVideoIds ?? const [],
+              nextIds: spot.youtubeVideoIds ?? const [],
+              existingImageUrls: imageUrls,
+            );
+      if (newYoutubeIds.isNotEmpty) {
+        final resolvedThumbnails = await _fetchYoutubeThumbnailUrls(
+          videoIds: newYoutubeIds,
+          spotName: spot.name,
+        );
+        imageUrls = appendYoutubeThumbnails(
+          imageUrls: imageUrls,
+          videoIds: newYoutubeIds,
+          resolvedUrls: resolvedThumbnails,
+        );
       }
 
       final updatedSpot = spot.copyWith(
@@ -732,6 +751,50 @@ class SpotService extends ChangeNotifier {
       imageUrls.add(imageUrl);
     }
     return imageUrls;
+  }
+
+  /// Downloads YouTube thumbnails via Cloud Function (same Storage path as import).
+  /// Returns videoId -> public URL for successful downloads; caller falls back
+  /// to YouTube CDN URLs for any IDs missing from the map.
+  Future<Map<String, String>> _fetchYoutubeThumbnailUrls({
+    required List<String> videoIds,
+    required String spotName,
+  }) async {
+    if (videoIds.isEmpty) return const {};
+    try {
+      final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
+      final callable = functions.httpsCallable(
+        'fetchYoutubeThumbnails',
+        options: HttpsCallableOptions(timeout: const Duration(minutes: 2)),
+      );
+      final result = await callable.call({
+        'videoIds': videoIds,
+        'spotName': spotName,
+      });
+      final rawData = result.data;
+      if (rawData is! Map) return const {};
+      final data = Map<String, dynamic>.from(rawData);
+      final rawThumbnails = data['thumbnails'];
+      if (rawThumbnails is! List) return const {};
+
+      final resolved = <String, String>{};
+      for (final item in rawThumbnails) {
+        if (item is! Map) continue;
+        final map = Map<String, dynamic>.from(item);
+        final id = map['videoId']?.toString();
+        final url = map['url']?.toString();
+        if (id != null &&
+            id.isNotEmpty &&
+            url != null &&
+            url.isNotEmpty) {
+          resolved[id] = url;
+        }
+      }
+      return resolved;
+    } catch (e) {
+      debugPrint('Error fetching YouTube thumbnails: $e');
+      return const {};
+    }
   }
 
   // Upload photos to /suggestions/ path (temporary storage, does NOT trigger resize extension)

--- a/lib/utils/youtube_utils.dart
+++ b/lib/utils/youtube_utils.dart
@@ -1,0 +1,113 @@
+/// YouTube video ID and thumbnail helpers (no Flutter imports — safe for VM tests).
+library;
+
+final _bareYoutubeIdPattern = RegExp(r'^[a-zA-Z0-9_-]{6,}$');
+
+/// Extracts a YouTube video ID from a raw ID or watch/embed/shorts/youtu.be URL.
+///
+/// Returns the trimmed input when it is non-empty but not recognized as a URL,
+/// matching existing spot parse behavior.
+String? extractYoutubeVideoId(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return null;
+  if (_bareYoutubeIdPattern.hasMatch(trimmed) && !trimmed.contains('/')) {
+    return trimmed;
+  }
+  try {
+    final uri = Uri.parse(trimmed);
+    if (uri.host.contains('youtu.be')) {
+      final seg = uri.pathSegments.isNotEmpty ? uri.pathSegments.last : null;
+      if (seg != null && seg.isNotEmpty) return seg;
+    }
+    final vParam = uri.queryParameters['v'];
+    if (vParam != null && vParam.isNotEmpty) return vParam;
+    final embedIndex = uri.pathSegments.indexOf('embed');
+    if (embedIndex != -1 && embedIndex + 1 < uri.pathSegments.length) {
+      return uri.pathSegments[embedIndex + 1];
+    }
+    final shortsIndex = uri.pathSegments.indexOf('shorts');
+    if (shortsIndex != -1 && shortsIndex + 1 < uri.pathSegments.length) {
+      return uri.pathSegments[shortsIndex + 1];
+    }
+  } catch (_) {}
+  return trimmed;
+}
+
+/// Parses a Firestore `youtubeVideoIds` value into a list of video IDs.
+List<String>? extractYoutubeVideoIdsFromValue(dynamic value) {
+  if (value == null) return null;
+  if (value is List) {
+    return value
+        .whereType<dynamic>()
+        .map((e) => e.toString())
+        .map(extractYoutubeVideoId)
+        .whereType<String>()
+        .toList();
+  }
+  if (value is String) {
+    final id = extractYoutubeVideoId(value);
+    return id == null ? null : <String>[id];
+  }
+  return null;
+}
+
+/// YouTube thumbnail URL for [videoId]. Import uses `maxresdefault`.
+String youtubeThumbnailUrl(
+  String videoId, {
+  String quality = 'maxresdefault',
+}) {
+  return 'https://img.youtube.com/vi/$videoId/$quality.jpg';
+}
+
+/// Smaller thumbnail used for edit-screen previews (always present for valid IDs).
+String youtubePreviewThumbnailUrl(String videoId) =>
+    youtubeThumbnailUrl(videoId, quality: 'hqdefault');
+
+/// True when [url] is a YouTube CDN thumbnail for [videoId].
+bool imageUrlIsYoutubeThumbnail(String url, String videoId) {
+  return url.contains('img.youtube.com/vi/$videoId/') ||
+      url.contains('i.ytimg.com/vi/$videoId/');
+}
+
+/// Newly added video IDs that do not already have a YouTube CDN thumbnail in photos.
+List<String> youtubeIdsNeedingThumbnails({
+  required List<String> previousIds,
+  required List<String> nextIds,
+  List<String> existingImageUrls = const [],
+}) {
+  final previous = previousIds.toSet();
+  final seen = <String>{};
+  final result = <String>[];
+  for (final rawId in nextIds) {
+    final id = rawId.trim();
+    if (id.isEmpty || previous.contains(id) || !seen.add(id)) continue;
+    final alreadyHasThumbnail = existingImageUrls.any(
+      (url) => imageUrlIsYoutubeThumbnail(url, id),
+    );
+    if (!alreadyHasThumbnail) {
+      result.add(id);
+    }
+  }
+  return result;
+}
+
+/// Appends thumbnail URLs for [videoIds], using [resolvedUrls] when present.
+List<String> appendYoutubeThumbnails({
+  required List<String> imageUrls,
+  required List<String> videoIds,
+  Map<String, String> resolvedUrls = const {},
+}) {
+  final result = List<String>.from(imageUrls);
+  for (final rawId in videoIds) {
+    final id = rawId.trim();
+    if (id.isEmpty) continue;
+    if (result.any((url) => imageUrlIsYoutubeThumbnail(url, id))) continue;
+    final resolved = resolvedUrls[id];
+    result.add(
+      (resolved != null && resolved.isNotEmpty)
+          ? resolved
+          : youtubeThumbnailUrl(id),
+    );
+  }
+  return result;
+}

--- a/lib/widgets/spot_form/youtube_section.dart
+++ b/lib/widgets/spot_form/youtube_section.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import '../../l10n/app_localizations.dart';
+import '../../utils/youtube_utils.dart';
+import '../custom_text_field.dart';
+
+/// Moderator edit card for YouTube video IDs/URLs, with drag-to-reorder.
+class SpotYoutubeSection extends StatelessWidget {
+  final List<TextEditingController> controllers;
+  final VoidCallback onAdd;
+  final void Function(int index) onRemove;
+  final void Function(int oldIndex, int newIndex) onReorder;
+  final VoidCallback? onChanged;
+
+  const SpotYoutubeSection({
+    super.key,
+    required this.controllers,
+    required this.onAdd,
+    required this.onRemove,
+    required this.onReorder,
+    this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  l10n.editSpotYoutubeSectionTitle,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add),
+                  onPressed: onAdd,
+                  tooltip: l10n.editSpotYoutubeAddTooltip,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.editSpotYoutubeHint,
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (controllers.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: Text(
+                  l10n.editSpotYoutubeEmpty,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              )
+            else
+              ReorderableListView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                buildDefaultDragHandles: false,
+                itemCount: controllers.length,
+                proxyDecorator: (child, index, animation) => child,
+                onReorder: (oldIndex, newIndex) {
+                  if (newIndex > oldIndex) {
+                    newIndex -= 1;
+                  }
+                  onReorder(oldIndex, newIndex);
+                },
+                itemBuilder: (context, index) {
+                  return _YoutubeLinkRow(
+                    key: ObjectKey(controllers[index]),
+                    index: index,
+                    controller: controllers[index],
+                    labelText: l10n.editSpotYoutubeLinkLabel(index + 1),
+                    hintText: l10n.editSpotYoutubeLinkHint,
+                    removeTooltip: l10n.editSpotYoutubeRemoveTooltip,
+                    reorderTooltip: l10n.editSpotYoutubeReorderTooltip,
+                    thumbnailSemanticLabel:
+                        l10n.editSpotYoutubeThumbnailSemanticLabel,
+                    onRemove: () => onRemove(index),
+                    onChanged: onChanged,
+                  );
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _YoutubeLinkRow extends StatelessWidget {
+  final int index;
+  final TextEditingController controller;
+  final String labelText;
+  final String hintText;
+  final String removeTooltip;
+  final String reorderTooltip;
+  final String thumbnailSemanticLabel;
+  final VoidCallback onRemove;
+  final VoidCallback? onChanged;
+
+  const _YoutubeLinkRow({
+    super.key,
+    required this.index,
+    required this.controller,
+    required this.labelText,
+    required this.hintText,
+    required this.removeTooltip,
+    required this.reorderTooltip,
+    required this.thumbnailSemanticLabel,
+    required this.onRemove,
+    this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final videoId = extractYoutubeVideoId(controller.text);
+    final hasPreview = videoId != null &&
+        videoId.isNotEmpty &&
+        !videoId.contains('/') &&
+        !videoId.contains(' ');
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8.0),
+      child: Row(
+        children: [
+          ReorderableDragStartListener(
+            index: index,
+            child: Semantics(
+              label: reorderTooltip,
+              button: true,
+              child: Tooltip(
+                message: reorderTooltip,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 12,
+                  ),
+                  margin: const EdgeInsets.only(right: 8),
+                  decoration: BoxDecoration(
+                    color: scheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(
+                    Icons.drag_handle,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Semantics(
+            label: thumbnailSemanticLabel,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: SizedBox(
+                width: 56,
+                height: 56,
+                child: hasPreview
+                    ? Image.network(
+                        youtubePreviewThumbnailUrl(videoId),
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) =>
+                            _ThumbnailPlaceholder(color: scheme.onSurfaceVariant),
+                      )
+                    : _ThumbnailPlaceholder(color: scheme.onSurfaceVariant),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: CustomTextField(
+              controller: controller,
+              labelText: labelText,
+              hintText: hintText,
+              onChanged: (_) => onChanged?.call(),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.remove_circle),
+            color: scheme.error,
+            onPressed: onRemove,
+            tooltip: removeTooltip,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThumbnailPlaceholder extends StatelessWidget {
+  final Color color;
+
+  const _ThumbnailPlaceholder({required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Icon(Icons.play_circle_outline, color: color),
+    );
+  }
+}

--- a/test/widgets/spot_youtube_section_test.dart
+++ b/test/widgets/spot_youtube_section_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/l10n/app_localizations.dart';
+import 'package:parkour_spot/widgets/spot_form/youtube_section.dart';
+
+Future<void> pumpYoutubeSection(
+  WidgetTester tester, {
+  required List<TextEditingController> controllers,
+  VoidCallback? onAdd,
+  void Function(int index)? onRemove,
+  void Function(int oldIndex, int newIndex)? onReorder,
+}) async {
+  tester.view.physicalSize = const Size(800, 1200);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: SpotYoutubeSection(
+            controllers: controllers,
+            onAdd: onAdd ?? () {},
+            onRemove: onRemove ?? (_) {},
+            onReorder: onReorder ?? (_, _) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('shows empty state and add button', (tester) async {
+    var addCount = 0;
+    await pumpYoutubeSection(
+      tester,
+      controllers: [],
+      onAdd: () => addCount++,
+    );
+
+    expect(find.text('YouTube links'), findsOneWidget);
+    expect(
+      find.text('No YouTube links added. Click the + button to add one.'),
+      findsOneWidget,
+    );
+    expect(find.byTooltip('Add YouTube link'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Add YouTube link'));
+    expect(addCount, 1);
+  });
+
+  testWidgets('shows reorder handles for multiple links', (tester) async {
+    final controllers = [
+      TextEditingController(text: 'aaa111bbb22'),
+      TextEditingController(text: 'ccc333ddd44'),
+    ];
+    addTearDown(() {
+      for (final controller in controllers) {
+        controller.dispose();
+      }
+    });
+
+    var reordered = false;
+    await pumpYoutubeSection(
+      tester,
+      controllers: controllers,
+      onReorder: (oldIndex, newIndex) {
+        reordered = true;
+        final moved = controllers.removeAt(oldIndex);
+        controllers.insert(newIndex, moved);
+      },
+    );
+
+    expect(find.text('YouTube link 1'), findsOneWidget);
+    expect(find.text('YouTube link 2'), findsOneWidget);
+    expect(find.byType(ReorderableDragStartListener), findsNWidgets(2));
+    expect(find.byIcon(Icons.drag_handle), findsNWidgets(2));
+    expect(find.byTooltip('Remove YouTube link'), findsNWidgets(2));
+    expect(reordered, isFalse);
+  });
+
+  testWidgets('remove button reports the row index', (tester) async {
+    final controllers = [
+      TextEditingController(text: 'aaa111bbb22'),
+      TextEditingController(text: 'ccc333ddd44'),
+    ];
+    addTearDown(() {
+      for (final controller in controllers) {
+        controller.dispose();
+      }
+    });
+
+    int? removedIndex;
+    await pumpYoutubeSection(
+      tester,
+      controllers: controllers,
+      onRemove: (index) => removedIndex = index,
+    );
+
+    await tester.tap(find.byTooltip('Remove YouTube link').last);
+    expect(removedIndex, 1);
+  });
+}

--- a/test/youtube_utils_test.dart
+++ b/test/youtube_utils_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/utils/youtube_utils.dart';
+
+void main() {
+  group('extractYoutubeVideoId', () {
+    test('returns null for empty input', () {
+      expect(extractYoutubeVideoId(''), isNull);
+      expect(extractYoutubeVideoId('   '), isNull);
+    });
+
+    test('returns bare IDs as-is', () {
+      expect(extractYoutubeVideoId('dQw4w9WgXcQ'), 'dQw4w9WgXcQ');
+    });
+
+    test('extracts from youtu.be URLs', () {
+      expect(
+        extractYoutubeVideoId('https://youtu.be/abc123xyz01'),
+        'abc123xyz01',
+      );
+    });
+
+    test('extracts from watch URLs', () {
+      expect(
+        extractYoutubeVideoId(
+          'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30',
+        ),
+        'dQw4w9WgXcQ',
+      );
+    });
+
+    test('extracts from embed and shorts URLs', () {
+      expect(
+        extractYoutubeVideoId('https://www.youtube.com/embed/abc123xyz01'),
+        'abc123xyz01',
+      );
+      expect(
+        extractYoutubeVideoId('https://www.youtube.com/shorts/abc123xyz01'),
+        'abc123xyz01',
+      );
+    });
+  });
+
+  group('youtubeIdsNeedingThumbnails', () {
+    test('returns only newly added IDs', () {
+      expect(
+        youtubeIdsNeedingThumbnails(
+          previousIds: const ['aaa'],
+          nextIds: const ['aaa', 'bbb'],
+        ),
+        ['bbb'],
+      );
+    });
+
+    test('skips IDs that already have a CDN thumbnail in photos', () {
+      expect(
+        youtubeIdsNeedingThumbnails(
+          previousIds: const [],
+          nextIds: const ['bbb'],
+          existingImageUrls: const [
+            'https://img.youtube.com/vi/bbb/maxresdefault.jpg',
+          ],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('preserves first-seen order and drops duplicates', () {
+      expect(
+        youtubeIdsNeedingThumbnails(
+          previousIds: const [],
+          nextIds: const ['bbb', 'ccc', 'bbb'],
+        ),
+        ['bbb', 'ccc'],
+      );
+    });
+  });
+
+  group('appendYoutubeThumbnails', () {
+    test('appends CDN URLs when no resolved Storage URLs are provided', () {
+      expect(
+        appendYoutubeThumbnails(
+          imageUrls: const ['https://example.com/photo.jpg'],
+          videoIds: const ['bbb'],
+        ),
+        [
+          'https://example.com/photo.jpg',
+          'https://img.youtube.com/vi/bbb/maxresdefault.jpg',
+        ],
+      );
+    });
+
+    test('prefers resolved Storage URLs', () {
+      expect(
+        appendYoutubeThumbnails(
+          imageUrls: const [],
+          videoIds: const ['bbb'],
+          resolvedUrls: const {
+            'bbb': 'https://storage.googleapis.com/bucket/spots/thumb.jpg',
+          },
+        ),
+        ['https://storage.googleapis.com/bucket/spots/thumb.jpg'],
+      );
+    });
+
+    test('does not duplicate an existing CDN thumbnail', () {
+      expect(
+        appendYoutubeThumbnails(
+          imageUrls: const [
+            'https://img.youtube.com/vi/bbb/maxresdefault.jpg',
+          ],
+          videoIds: const ['bbb'],
+        ),
+        ['https://img.youtube.com/vi/bbb/maxresdefault.jpg'],
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When importing a spot that has a YouTube video in its description, we already extract the thumbnail and add it to the spot photos. Moderator edit did not do that, and YouTube links on the edit screen could not be reordered.

## Changes
- When a moderator adds YouTube videos on edit and saves, newly added video IDs get a thumbnail added to `imageUrls` (Cloud Function `fetchYoutubeThumbnails` downloads/stores like import; falls back to the YouTube CDN `maxresdefault` URL).
- The edit screen YouTube list is drag-reorderable (order is stored in `youtubeVideoIds`).
- Each row shows a thumbnail preview so the videos are easier to tell apart while reordering.

## Testing
- Unit tests for YouTube ID parsing, which IDs need thumbnails, and appending thumbnail URLs.
- Widget tests for the YouTube edit section (empty state, reorder handles, remove).
- Cloud Functions helper tests and eslint.
- Emulator integration: called `fetchYoutubeThumbnails` as `moderator@parkour.spot` for `dQw4w9WgXcQ`; it stored a 1280×720 JPEG in Storage.

[YouTube thumbnail stored by fetchYoutubeThumbnails](https://cursor.com/agents/bc-d7737f5e-738f-46db-9be4-77367b9cec24/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyoutube_thumbnail_from_function.jpg)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7737f5e-738f-46db-9be4-77367b9cec24?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7737f5e-738f-46db-9be4-77367b9cec24&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

