### PR TITLE
Include active spot list spots on Explore map

### DIFF
--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -16,6 +16,7 @@ import '../../services/admin_events_service.dart';
 import '../../services/spot_service.dart';
 import '../../models/event_map_pin.dart';
 import '../../utils/explore_events_utils.dart';
+import '../../utils/explore_spots_utils.dart';
 import '../../widgets/event_card.dart';
 import '../../widgets/explore_bottom_sheet_header.dart';
 import '../../services/sync_source_service.dart';
@@ -1394,15 +1395,7 @@ class SearchScreenState extends State<SearchScreen>
     final extraSpots = fetched.whereType<Spot>().toList();
     if (extraSpots.isEmpty) return loadedSpots;
 
-    final seen = loadedIds;
-    final merged = List<Spot>.from(loadedSpots);
-    for (final spot in extraSpots) {
-      final id = spot.id;
-      if (id != null && seen.add(id)) {
-        merged.add(spot);
-      }
-    }
-    return merged;
+    return mergeSpotsById(loadedSpots, extraSpots);
   }
 
   bool get _isLoadingMapData =>

--- a/lib/screens/spots/search_screen.dart
+++ b/lib/screens/spots/search_screen.dart
@@ -437,6 +437,9 @@ class SearchScreenState extends State<SearchScreen>
           _highlightedSpotIds.clear();
           _markers = _rebuildMarkers();
         });
+        if (_mapController != null) {
+          _loadMapDataForCurrentView();
+        }
       }
     }
 
@@ -1342,7 +1345,9 @@ class SearchScreenState extends State<SearchScreen>
       final ranked = results[0] as Map<String, dynamic>;
       final eventsResult = results[1] as EventsInBoundsResult;
 
-      _loadedSpots = (ranked['spots'] as List<Spot>?) ?? <Spot>[];
+      _loadedSpots = await _mergeActiveSpotListSpots(
+        (ranked['spots'] as List<Spot>?) ?? <Spot>[],
+      );
       _totalSpotsInView = ranked['totalCount'] as int?;
       _bestShownCount = ranked['shownCount'] as int?;
 
@@ -1371,6 +1376,33 @@ class SearchScreenState extends State<SearchScreen>
       _visibleSpots = _loadedSpots;
       _markers = _rebuildMarkers();
     });
+  }
+
+  /// Ensures every spot from the active list is included alongside ranked map spots.
+  Future<List<Spot>> _mergeActiveSpotListSpots(List<Spot> loadedSpots) async {
+    if (_highlightedSpotIds.isEmpty || !mounted) return loadedSpots;
+
+    final loadedIds = loadedSpots.map((s) => s.id).whereType<String>().toSet();
+    final missingIds =
+        _highlightedSpotIds.where((id) => !loadedIds.contains(id)).toList();
+    if (missingIds.isEmpty) return loadedSpots;
+
+    final spotService = Provider.of<SpotService>(context, listen: false);
+    final fetched = await Future.wait(
+      missingIds.map(spotService.getSpotById),
+    );
+    final extraSpots = fetched.whereType<Spot>().toList();
+    if (extraSpots.isEmpty) return loadedSpots;
+
+    final seen = loadedIds;
+    final merged = List<Spot>.from(loadedSpots);
+    for (final spot in extraSpots) {
+      final id = spot.id;
+      if (id != null && seen.add(id)) {
+        merged.add(spot);
+      }
+    }
+    return merged;
   }
 
   bool get _isLoadingMapData =>
@@ -2315,6 +2347,18 @@ class SearchScreenState extends State<SearchScreen>
         // Rebuild markers to reflect highlighting
         _markers = _rebuildMarkers();
       });
+
+      if (_loadedSpots.isNotEmpty) {
+        final merged = await _mergeActiveSpotListSpots(_loadedSpots);
+        if (!mounted) return;
+        setState(() {
+          _loadedSpots = merged;
+          _visibleSpots = merged;
+          _markers = _rebuildMarkers();
+        });
+      } else if (_mapController != null) {
+        await _loadMapDataForCurrentView();
+      }
     } catch (e) {
       debugPrint('Error loading spot list: $e');
     }
@@ -2391,6 +2435,10 @@ class SearchScreenState extends State<SearchScreen>
     final searchState = _searchStateServiceRef;
     if (searchState != null) {
       searchState.setSelectedListId(null);
+    }
+
+    if (_mapController != null) {
+      _loadMapDataForCurrentView();
     }
 
     // Update URL query parameter, preserving existing params

--- a/lib/utils/explore_spots_utils.dart
+++ b/lib/utils/explore_spots_utils.dart
@@ -1,0 +1,14 @@
+import '../models/spot.dart';
+
+/// Returns [primary] plus any spots from [additional] whose IDs are not already present.
+List<Spot> mergeSpotsById(List<Spot> primary, List<Spot> additional) {
+  final seen = primary.map((s) => s.id).whereType<String>().toSet();
+  final merged = List<Spot>.from(primary);
+  for (final spot in additional) {
+    final id = spot.id;
+    if (id != null && seen.add(id)) {
+      merged.add(spot);
+    }
+  }
+  return merged;
+}

--- a/test/explore_spots_utils_test.dart
+++ b/test/explore_spots_utils_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parkour_spot/models/spot.dart';
+import 'package:parkour_spot/utils/explore_spots_utils.dart';
+
+Spot _spot(String id) =>
+    Spot(id: id, name: 'Spot $id', description: '', latitude: 0, longitude: 0);
+
+void main() {
+  group('mergeSpotsById', () {
+    test('returns primary unchanged when additional is empty', () {
+      final primary = [_spot('a'), _spot('b')];
+      expect(mergeSpotsById(primary, []), primary);
+    });
+
+    test('appends additional spots with new IDs', () {
+      final primary = [_spot('a')];
+      final additional = [_spot('b'), _spot('c')];
+      final merged = mergeSpotsById(primary, additional);
+      expect(merged.map((s) => s.id).toList(), ['a', 'b', 'c']);
+    });
+
+    test('skips additional spots already in primary', () {
+      final primary = [_spot('a'), _spot('b')];
+      final additional = [_spot('b'), _spot('c')];
+      final merged = mergeSpotsById(primary, additional);
+      expect(merged.map((s) => s.id).toList(), ['a', 'b', 'c']);
+    });
+
+    test('ignores additional spots without IDs', () {
+      final primary = [_spot('a')];
+      final additional = [
+        Spot(name: 'No id', description: '', latitude: 0, longitude: 0),
+      ];
+      final merged = mergeSpotsById(primary, additional);
+      expect(merged.map((s) => s.id).toList(), ['a']);
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a spot list is active on Explore, the map now loads the regular top 100 ranked spots for the current viewport **and** fetches any spots from the active list that are missing from that result. This prevents list spots from only appearing after zooming in.

## Changes

- After the ranked bounds query in `SearchScreen._loadMapDataForCurrentView`, merge in any active list spots not already loaded
- When a spot list is selected after map data is already loaded, merge list spots immediately
- When a spot list is cleared, reload map data so list-only pins are removed
- Added `mergeSpotsById` helper with unit tests

## Testing

- `flutter test test/explore_spots_utils_test.dart` — all pass
- `flutter analyze lib/screens/spots/search_screen.dart` — no new issues
- Full web manual testing was blocked by pre-existing web compile errors in this environment (`firebase_core_web` / `AuthorizationStatus.deniedPermanently`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49756d49-66d9-4240-b93f-5c96254d72c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49756d49-66d9-4240-b93f-5c96254d72c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

